### PR TITLE
Resnet variants

### DIFF
--- a/configs/resnet_model.yaml
+++ b/configs/resnet_model.yaml
@@ -1,0 +1,121 @@
+
+model:
+  name: resnet18_classification
+  nodes:
+    - name: ResNet18
+      download_weights: True
+
+    - name: ClassificationHead
+      inputs:
+        - ResNet18
+    
+    - name: SegmentationHead
+      inputs:
+        - ResNet18
+
+  losses:
+    - name: CrossEntropyLoss
+      attached_to: ClassificationHead
+
+  metrics:
+    - name: Accuracy
+      is_main_metric: true
+      attached_to: ClassificationHead
+
+tracker:
+  project_name: coco_test
+  save_directory: output
+  is_tensorboard: True
+  is_wandb: False
+  wandb_entity: luxonis
+  is_mlflow: False
+
+dataset:
+  name: coco_test
+  train_view: train
+  val_view: val
+  test_view: test
+
+trainer:
+  accelerator: auto
+  devices: auto
+  strategy: auto
+
+  num_sanity_val_steps: 1
+  profiler: null
+  verbose: True
+  batch_size: 4
+  accumulate_grad_batches: 1
+  epochs: &epochs 1
+  num_workers: 8
+  train_metrics_interval: -1
+  validation_interval: 1
+  num_log_images: 8
+  skip_last_batch: True
+  main_head_index: 0
+  log_sub_losses: True
+  save_top_k: 3
+
+  preprocessing:
+    train_image_size: [&height 256, &width 320]
+    keep_aspect_ratio: False
+    train_rgb: True
+    normalize:
+      active: True
+    augmentations:
+      - name: Defocus
+        params:
+          p: 0.1
+      - name: Sharpen
+        params:
+          p: 0.1
+      - name: Flip
+      - name: RandomRotate90
+      - name: Mosaic4
+        params:
+          out_width: *width
+          out_height: *height
+
+  callbacks:
+    - name: LearningRateMonitor
+      params:
+        logging_interval: step
+    - name: MetadataLogger
+      params:
+        hyperparams: ["trainer.epochs", trainer.batch_size]
+    - name: EarlyStopping
+      params:
+        patience: 3
+        monitor: val/loss
+        mode: min
+        verbose: true
+    - name: DeviceStatsMonitor
+    - name: ExportOnTrainEnd
+    - name: TestOnTrainEnd
+
+  optimizer:
+    name: SGD
+    params:
+      lr: 0.02
+      momentum: 0.937
+      nesterov: True
+      weight_decay: 0.0005
+
+  scheduler:
+    name: CosineAnnealingLR
+    params:
+      T_max: *epochs
+      eta_min: 0
+
+exporter:
+  onnx:
+    opset_version: 11
+  blobconverter:
+    active: True
+    shaves: 8
+
+tuner:
+  params:
+    trainer.optimizer.name_categorical: ["Adam", "SGD"]
+    trainer.optimizer.params.lr_float: [0.0001, 0.001]
+    trainer.batch_size_int: [4, 16, 4]

--- a/configs/resnet_model.yaml
+++ b/configs/resnet_model.yaml
@@ -9,7 +9,7 @@ model:
     - name: ClassificationHead
       inputs:
         - ResNet
-    
+
   losses:
     - name: CrossEntropyLoss
       attached_to: ClassificationHead
@@ -19,8 +19,17 @@ model:
       is_main_metric: true
       attached_to: ClassificationHead
 
+  visualizers:
+    - name: ClassificationVisualizer
+      attached_to: ClassificationHead
+      params:
+        font_scale: 0.5
+        color: [255, 0, 0]
+        thickness: 2
+        include_plot: True
+
 dataset:
-  name: coco_test
+  name: cifar10_test
 
 trainer:
   batch_size: 4

--- a/configs/resnet_model.yaml
+++ b/configs/resnet_model.yaml
@@ -1,17 +1,18 @@
 
 model:
-  name: resnet18_classification
+  name: resnet50_classification
   nodes:
-    - name: ResNet18
+    - name: ResNet
+      variant: "50"
       download_weights: True
 
     - name: ClassificationHead
       inputs:
-        - ResNet18
+        - ResNet
     
     - name: SegmentationHead
       inputs:
-        - ResNet18
+        - ResNet
 
   losses:
     - name: CrossEntropyLoss

--- a/configs/resnet_model.yaml
+++ b/configs/resnet_model.yaml
@@ -10,10 +10,6 @@ model:
       inputs:
         - ResNet
     
-    - name: SegmentationHead
-      inputs:
-        - ResNet
-
   losses:
     - name: CrossEntropyLoss
       attached_to: ClassificationHead
@@ -23,74 +19,23 @@ model:
       is_main_metric: true
       attached_to: ClassificationHead
 
-tracker:
-  project_name: coco_test
-  save_directory: output
-  is_tensorboard: True
-  is_wandb: False
-  wandb_entity: luxonis
-  is_mlflow: False
-
 dataset:
   name: coco_test
-  train_view: train
-  val_view: val
-  test_view: test
 
 trainer:
-  accelerator: auto
-  devices: auto
-  strategy: auto
-
-  num_sanity_val_steps: 1
-  profiler: null
-  verbose: True
   batch_size: 4
-  accumulate_grad_batches: 1
-  epochs: &epochs 1
-  num_workers: 8
-  train_metrics_interval: -1
-  validation_interval: 1
+  epochs: &epochs 200
+  num_workers: 4
+  validation_interval: 10
   num_log_images: 8
-  skip_last_batch: True
-  main_head_index: 0
-  log_sub_losses: True
-  save_top_k: 3
 
   preprocessing:
-    train_image_size: [&height 256, &width 320]
+    train_image_size: [&height 224, &width 224]
     keep_aspect_ratio: False
-    train_rgb: True
     normalize:
       active: True
-    augmentations:
-      - name: Defocus
-        params:
-          p: 0.1
-      - name: Sharpen
-        params:
-          p: 0.1
-      - name: Flip
-      - name: RandomRotate90
-      - name: Mosaic4
-        params:
-          out_width: *width
-          out_height: *height
 
   callbacks:
-    - name: LearningRateMonitor
-      params:
-        logging_interval: step
-    - name: MetadataLogger
-      params:
-        hyperparams: ["trainer.epochs", trainer.batch_size]
-    - name: EarlyStopping
-      params:
-        patience: 3
-        monitor: val/loss
-        mode: min
-        verbose: true
-    - name: DeviceStatsMonitor
     - name: ExportOnTrainEnd
     - name: TestOnTrainEnd
 
@@ -98,25 +43,6 @@ trainer:
     name: SGD
     params:
       lr: 0.02
-      momentum: 0.937
-      nesterov: True
-      weight_decay: 0.0005
 
   scheduler:
-    name: CosineAnnealingLR
-    params:
-      T_max: *epochs
-      eta_min: 0
-
-exporter:
-  onnx:
-    opset_version: 11
-  blobconverter:
-    active: True
-    shaves: 8
-
-tuner:
-  params:
-    trainer.optimizer.name_categorical: ["Adam", "SGD"]
-    trainer.optimizer.params.lr_float: [0.0001, 0.001]
-    trainer.batch_size_int: [4, 16, 4]
+    name: ConstantLR

--- a/luxonis_train/nodes/README.md
+++ b/luxonis_train/nodes/README.md
@@ -5,7 +5,7 @@ arbitrarily as long as the two nodes are compatible with each other.
 
 ## Table Of Contents
 
-- [ResNet18](#resnet18)
+- [ResNet](#resnet)
 - [MicroNet](#micronet)
 - [RepVGG](#repvgg)
 - [EfficientRep](#efficientrep)
@@ -30,15 +30,16 @@ Every node takes these parameters:
 
 Additional parameters for specific nodes are listed below.
 
-## ResNet18
+## ResNet
 
-Adapted from [here](https://pytorch.org/vision/main/models/generated/torchvision.models.resnet18.html).
+Adapted from [here](https://pytorch.org/vision/main/models/resnet.html).
 
 **Params**
 
-| Key              | Type | Default value | Description                            |
-| ---------------- | ---- | ------------- | -------------------------------------- |
-| download_weights | bool | False         | If True download weights from imagenet |
+| Key              | Type                                      | Default value | Description                            |
+| ---------------- | ----------------------------------------- | ------------- | -------------------------------------- |
+| variant          | Literal\["18", "34", "50", "101", "152"\] | "18"          | Variant of the network.                |
+| download_weights | bool                                      | False         | If True download weights from imagenet |
 
 ## MicroNet
 

--- a/luxonis_train/nodes/__init__.py
+++ b/luxonis_train/nodes/__init__.py
@@ -10,7 +10,7 @@ from .mobilenetv2 import MobileNetV2
 from .mobileone import MobileOne
 from .reppan_neck import RepPANNeck
 from .repvgg import RepVGG
-from .resnet18 import ResNet18
+from .resnet import ResNet
 from .rexnetv1 import ReXNetV1_lite
 from .segmentation_head import SegmentationHead
 
@@ -28,6 +28,6 @@ __all__ = [
     "ReXNetV1_lite",
     "RepPANNeck",
     "RepVGG",
-    "ResNet18",
+    "ResNet",
     "SegmentationHead",
 ]

--- a/luxonis_train/nodes/resnet.py
+++ b/luxonis_train/nodes/resnet.py
@@ -1,7 +1,6 @@
-"""ResNet18 backbone.
+"""ResNet backbone.
 
-Source: U{https://pytorch.org/vision/main/models/generated/
-torchvision.models.resnet18.html}
+Source: U{https://pytorch.org/vision/main/models/resnet.html}
 @license: U{PyTorch<https://github.com/pytorch/pytorch/blob/master/LICENSE>}
 """
 from typing import Literal

--- a/luxonis_train/nodes/resnet.py
+++ b/luxonis_train/nodes/resnet.py
@@ -4,7 +4,7 @@ Source: U{https://pytorch.org/vision/main/models/generated/
 torchvision.models.resnet18.html}
 @license: U{PyTorch<https://github.com/pytorch/pytorch/blob/master/LICENSE>}
 """
-
+from typing import Literal
 
 import torchvision
 from torch import Tensor
@@ -12,19 +12,22 @@ from torch import Tensor
 from .base_node import BaseNode
 
 
-class ResNet18(BaseNode[Tensor, list[Tensor]]):
+class ResNet(BaseNode[Tensor, list[Tensor]]):
     attach_index: int = -1
 
     def __init__(
         self,
+        variant: Literal["18", "34", "50", "101", "152"] = "18",
         channels_list: list[int] | None = None,
         download_weights: bool = False,
         **kwargs,
     ):
-        """Implementation of the ResNet18 backbone.
+        """Implementation of the ResNetX backbone.
 
         TODO: add more info
 
+        @type variant: Literal["18", "34", "50", "101", "152"]
+        @param variant: ResNet variant. Defaults to "18".
         @type channels_list: list[int] | None
         @param channels_list: List of channels to return.
             If unset, defaults to [64, 128, 256, 512].
@@ -35,7 +38,12 @@ class ResNet18(BaseNode[Tensor, list[Tensor]]):
         """
         super().__init__(**kwargs)
 
-        self.backbone = torchvision.models.resnet18(
+        if variant not in RESNET_VARIANTS:
+            raise ValueError(
+                f"ResNet model variant should be in {list(RESNET_VARIANTS.keys())}"
+            )
+
+        self.backbone = RESNET_VARIANTS[variant](
             weights="DEFAULT" if download_weights else None
         )
         self.channels_list = channels_list or [64, 128, 256, 512]
@@ -57,3 +65,12 @@ class ResNet18(BaseNode[Tensor, list[Tensor]]):
         outs.append(x)
 
         return outs
+
+
+RESNET_VARIANTS = {
+    "18": torchvision.models.resnet18,
+    "34": torchvision.models.resnet34,
+    "50": torchvision.models.resnet50,
+    "101": torchvision.models.resnet101,
+    "152": torchvision.models.resnet152,
+}

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">78%</text>
-        <text x="80" y="14">78%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">79%</text>
+        <text x="80" y="14">79%</text>
     </g>
 </svg>


### PR DESCRIPTION
Added support for ResNet 18, 34, 50, 101, 152 backbones.
Using _torchvision_ library from **pytorch** ([source](https://pytorch.org/vision/main/models/resnet.html)).