### PR TITLE
Uploading logs to MLFlow

### DIFF
--- a/luxonis_train/callbacks/export_on_train_end.py
+++ b/luxonis_train/callbacks/export_on_train_end.py
@@ -58,7 +58,7 @@ class ExportOnTrainEnd(pl.Callback):
                 new_upload_url = f"mlflow://{tracker.project_id}/{tracker.run_id}"
                 cfg.exporter.upload_url = new_upload_url
             else:
-                logger.warning(
+                logger.error(
                     "`upload_to_mlflow` is set to True, "
                     "but there is no MLFlow active run, skipping."
                 )

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -79,9 +79,10 @@ class Core:
         self.run_save_dir = os.path.join(
             self.cfg.tracker.save_directory, self.tracker.run_name
         )
+        self.log_file = osp.join(self.run_save_dir, "luxonis_train.log")
+
         # NOTE: to add the file handler (we only get the save dir now,
         # but we want to use the logger before)
-        self.log_file = osp.join(self.run_save_dir, "luxonis_train.log")
         reset_logging()
         setup_logging(
             use_rich=self.cfg.use_rich_text,

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -81,10 +81,11 @@ class Core:
         )
         # NOTE: to add the file handler (we only get the save dir now,
         # but we want to use the logger before)
+        self.log_file = osp.join(self.run_save_dir, "luxonis_train.log")
         reset_logging()
         setup_logging(
             use_rich=self.cfg.use_rich_text,
-            file=osp.join(self.run_save_dir, "luxonis_train.log"),
+            file=self.log_file,
         )
 
         # NOTE: overriding logger in pl so it uses our logger to log device info

--- a/luxonis_train/core/trainer.py
+++ b/luxonis_train/core/trainer.py
@@ -42,13 +42,14 @@ class Trainer(Core):
 
     def _upload_logs(self) -> None:
         if self.cfg.tracker.is_mlflow:
+            logger.info("Uploading logs to MLFlow.")
             self.fs = LuxonisFileSystem(
                 "mlflow://",
                 allow_active_mlflow_run=True,
                 allow_local=False,
             )
             self.fs.put_file(
-                local_path="luxonis_train.log",
+                local_path=self.log_file,
                 remote_path="luxonis_train.log",
                 mlflow_instance=self.tracker.experiment.get("mlflow", None),
             )

--- a/luxonis_train/core/trainer.py
+++ b/luxonis_train/core/trainer.py
@@ -43,12 +43,12 @@ class Trainer(Core):
     def _upload_logs(self) -> None:
         if self.cfg.tracker.is_mlflow:
             logger.info("Uploading logs to MLFlow.")
-            self.fs = LuxonisFileSystem(
+            fs = LuxonisFileSystem(
                 "mlflow://",
                 allow_active_mlflow_run=True,
                 allow_local=False,
             )
-            self.fs.put_file(
+            fs.put_file(
                 local_path=self.log_file,
                 remote_path="luxonis_train.log",
                 mlflow_instance=self.tracker.experiment.get("mlflow", None),

--- a/luxonis_train/core/trainer.py
+++ b/luxonis_train/core/trainer.py
@@ -57,6 +57,8 @@ class Trainer(Core):
     def _traner_fit(self, *args, **kwargs):
         try:
             self.pl_trainer.fit(*args, **kwargs)
+        except Exception:
+            logger.exception("Encountered exception during training.")
         finally:
             self._upload_logs()
 

--- a/luxonis_train/core/trainer.py
+++ b/luxonis_train/core/trainer.py
@@ -67,6 +67,7 @@ class Trainer(Core):
                     self.fs.put_file(
                         local_path="luxonis_train.log",
                         remote_path="luxonis_train.log",
+                        mlflow_instance=self.tracker.experiment.get("mlflow", None),
                     )
 
         else:

--- a/luxonis_train/core/trainer.py
+++ b/luxonis_train/core/trainer.py
@@ -54,7 +54,7 @@ class Trainer(Core):
                 mlflow_instance=self.tracker.experiment.get("mlflow", None),
             )
 
-    def _traner_fit(self, *args, **kwargs):
+    def _trainer_fit(self, *args, **kwargs):
         try:
             self.pl_trainer.fit(*args, **kwargs)
         except Exception:
@@ -71,7 +71,7 @@ class Trainer(Core):
         if not new_thread:
             logger.info(f"Checkpoints will be saved in: {self.get_save_dir()}")
             logger.info("Starting training...")
-            self._traner_fit(
+            self._trainer_fit(
                 self.lightning_module,
                 self.pytorch_loader_train,
                 self.pytorch_loader_val,
@@ -87,7 +87,7 @@ class Trainer(Core):
             threading.excepthook = thread_exception_hook
 
             self.thread = threading.Thread(
-                target=self._traner_fit,
+                target=self._trainer_fit,
                 args=(
                     self.lightning_module,
                     self.pytorch_loader_train,

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -682,11 +682,8 @@ class LuxonisModel(pl.LightningModule):
         if path is None:
             return
 
-        try:
-            checkpoint = torch.load(path, map_location=self.device)
-        except Exception:
-            logger.error(f"Could not load checkpoint from '{path}'.")
-            return
+        checkpoint = torch.load(path, map_location=self.device)
+
         if "state_dict" not in checkpoint:
             raise ValueError("Checkpoint does not contain state_dict.")
         state_dict = {}

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -681,7 +681,12 @@ class LuxonisModel(pl.LightningModule):
         """
         if path is None:
             return
-        checkpoint = torch.load(path, map_location=self.device)
+
+        try:
+            checkpoint = torch.load(path, map_location=self.device)
+        except Exception:
+            logger.error(f"Could not load checkpoint from '{path}'.")
+            return
         if "state_dict" not in checkpoint:
             raise ValueError("Checkpoint does not contain state_dict.")
         state_dict = {}


### PR DESCRIPTION
# Uploading logs to `MLFlow`

- Added functionality to upload logs to `MLFlow` at the end of the training.
- Replaced exception with error log in `ExportOnTrainEnd` callback if no checkpoint was created