### PR TITLE
Generate NN archive from training configs

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -207,6 +207,7 @@ def archive(config: ConfigType = None, opts: OptsType = None, executable: Path =
 
     Archiver(str(config), opts).archive(executable)
 
+
 def version_callback(value: bool):
     if value:
         typer.echo(f"LuxonisTrain Version: {version(__package__)}")

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -201,7 +201,13 @@ def inspect(
 
 
 @app.command()
-def archive(config: ConfigType = None, opts: OptsType = None, executable: Path = None):
+def archive(
+    executable: Annotated[
+        Optional[Path], typer.Option(help="Path to the model file.", show_default=False)
+    ],
+    config: ConfigType = None,
+    opts: OptsType = None,
+):
     """Generate NN archive."""
     from luxonis_train.core import Archiver
 

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -200,6 +200,13 @@ def inspect(
                     exit()
 
 
+@app.command()
+def archive(config: ConfigType = None, opts: OptsType = None, executable: Path = None):
+    """Generate NN archive."""
+    from luxonis_train.core import Archiver
+
+    Archiver(str(config), opts).archive(executable)
+
 def version_callback(value: bool):
     if value:
         typer.echo(f"LuxonisTrain Version: {version(__package__)}")

--- a/luxonis_train/callbacks/__init__.py
+++ b/luxonis_train/callbacks/__init__.py
@@ -8,6 +8,7 @@ from lightning.pytorch.callbacks import (
 
 from luxonis_train.utils.registry import CALLBACKS
 
+from .archive_on_train_end import ArchiveOnTrainEnd
 from .export_on_train_end import ExportOnTrainEnd
 from .luxonis_progress_bar import LuxonisProgressBar
 from .metadata_logger import MetadataLogger
@@ -23,6 +24,7 @@ CALLBACKS.register_module(module=DeviceStatsMonitor)
 
 
 __all__ = [
+    "ArchiveOnTrainEnd",
     "ExportOnTrainEnd",
     "LuxonisProgressBar",
     "MetadataLogger",

--- a/luxonis_train/callbacks/archive_on_train_end.py
+++ b/luxonis_train/callbacks/archive_on_train_end.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 from pathlib import Path
 from typing import cast
 
@@ -13,7 +13,8 @@ from luxonis_train.utils.tracker import LuxonisTrackerPL
 @CALLBACKS.register_module()
 class ArchiveOnTrainEnd(pl.Callback):
     def __init__(self, upload_to_mlflow: bool = False):
-        """Callback that performs archiving of onnx or exported model at the end of training/export. TODO: description
+        """Callback that performs archiving of onnx or exported model at the end of
+        training/export. TODO: description.
 
         @type upload_to_mlflow: bool
         @param upload_to_mlflow: If set to True, overrides the upload url in Archiver
@@ -59,15 +60,13 @@ class ArchiveOnTrainEnd(pl.Callback):
                     "`upload_to_mlflow` is set to True, "
                     "but there is  no MLFlow active run, skipping."
                 )
-        
+
         onnx_path = str(Path(best_model_path).parent.with_suffix(".onnx"))
         if not os.path.exists(onnx_path):
-            raise FileNotFoundError("Model executable not found. Make sure to run exporter callback before archiver callback")
-            # TODO: if onnx model non-existent, should export be ran?
-            #from luxonis_train.core.exporter import Exporter
-            #exporter = Exporter(cfg=cfg)
-            #exporter.export(onnx_path=onnx_path)
+            raise FileNotFoundError(
+                "Model executable not found. Make sure to run exporter callback before archiver callback"
+            )
 
         archiver = Archiver(cfg=cfg)
-        
+
         archiver.archive(onnx_path)

--- a/luxonis_train/callbacks/archive_on_train_end.py
+++ b/luxonis_train/callbacks/archive_on_train_end.py
@@ -1,0 +1,73 @@
+import os
+import logging
+from pathlib import Path
+from typing import cast
+
+import lightning.pytorch as pl
+
+from luxonis_train.utils.config import Config
+from luxonis_train.utils.registry import CALLBACKS
+from luxonis_train.utils.tracker import LuxonisTrackerPL
+
+
+@CALLBACKS.register_module()
+class ArchiveOnTrainEnd(pl.Callback):
+    def __init__(self, upload_to_mlflow: bool = False):
+        """Callback that performs archiving of onnx or exported model at the end of training/export. TODO: description
+
+        @type upload_to_mlflow: bool
+        @param upload_to_mlflow: If set to True, overrides the upload url in Archiver
+            with currently active MLFlow run (if present).
+        """
+        super().__init__()
+        self.upload_to_mlflow = upload_to_mlflow
+
+    def on_train_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Archives the model on train end.
+
+        @type trainer: L{pl.Trainer}
+        @param trainer: Pytorch Lightning trainer.
+        @type pl_module: L{pl.LightningModule}
+        @param pl_module: Pytorch Lightning module.
+        @raises RuntimeError: If no best model path is found.
+        """
+        from luxonis_train.core.archiver import Archiver
+
+        model_checkpoint_callbacks = [
+            c
+            for c in trainer.callbacks  # type: ignore
+            if isinstance(c, pl.callbacks.ModelCheckpoint)  # type: ignore
+        ]
+
+        # NOTE: assume that first checkpoint callback is based on val loss
+        best_model_path = model_checkpoint_callbacks[0].best_model_path
+        if not best_model_path:
+            raise RuntimeError(
+                "No best model path found. "
+                "Please make sure that ModelCheckpoint callback is present "
+                "and at least one validation epoch has been performed."
+            )
+        cfg: Config = pl_module.cfg
+        cfg.model.weights = best_model_path
+        if self.upload_to_mlflow:
+            if cfg.tracker.is_mlflow:
+                tracker = cast(LuxonisTrackerPL, trainer.logger)
+                new_upload_url = f"mlflow://{tracker.project_id}/{tracker.run_id}"
+                cfg.archiver.upload_url = new_upload_url
+            else:
+                logging.getLogger(__name__).warning(
+                    "`upload_to_mlflow` is set to True, "
+                    "but there is  no MLFlow active run, skipping."
+                )
+        
+        onnx_path = str(Path(best_model_path).parent.with_suffix(".onnx"))
+        if not os.path.exists(onnx_path):
+            raise FileNotFoundError("Model executable not found. Make sure to run exporter callback before archiver callback")
+            # TODO: if onnx model non-existent, should export be ran?
+            #from luxonis_train.core.exporter import Exporter
+            #exporter = Exporter(cfg=cfg)
+            #exporter.export(onnx_path=onnx_path)
+
+        archiver = Archiver(cfg=cfg)
+        
+        archiver.archive(onnx_path)

--- a/luxonis_train/core/__init__.py
+++ b/luxonis_train/core/__init__.py
@@ -1,7 +1,7 @@
+from .archiver import Archiver
 from .exporter import Exporter
 from .inferer import Inferer
 from .trainer import Trainer
 from .tuner import Tuner
-from .archiver import Archiver
 
 __all__ = ["Exporter", "Trainer", "Tuner", "Inferer", "Archiver"]

--- a/luxonis_train/core/__init__.py
+++ b/luxonis_train/core/__init__.py
@@ -2,5 +2,6 @@ from .exporter import Exporter
 from .inferer import Inferer
 from .trainer import Trainer
 from .tuner import Tuner
+from .archiver import Archiver
 
-__all__ = ["Exporter", "Trainer", "Tuner", "Inferer"]
+__all__ = ["Exporter", "Trainer", "Tuner", "Inferer", "Archiver"]

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -1,0 +1,365 @@
+import os
+from logging import getLogger
+from pathlib import Path
+from typing import Any, List, Dict
+import onnx
+
+from luxonis_train.utils.config import Config
+from luxonis_train.models import LuxonisModel
+from luxonis_train.nodes.enums.head_categorization import ImplementedHeads
+
+from luxonis_ml.utils import LuxonisFileSystem
+
+from luxonis_ml.nn_archive.archive_generator import ArchiveGenerator
+from luxonis_ml.nn_archive.config import CONFIG_VERSION
+
+from .core import Core
+
+logger = getLogger(__name__)
+
+
+class Archiver(Core):
+    """Main API which is used to construct the NN archive file out of a trainig config and model executables."""
+
+    def __init__(
+        self,
+        cfg: str | dict[str, Any] | Config,
+        opts: list[str] | tuple[str, ...] | dict[str, Any] | None = None,
+    ):
+        """Constructs a new Archiver instance.
+
+        @type cfg: str | dict[str, Any] | Config
+        @param cfg: Path to config file or config dict used to setup training.
+
+        @type opts: list[str] | tuple[str, ...] | dict[str, Any] | None
+        @param opts: Argument dict provided through command line,
+            used for config overriding.
+
+        @type executable: str
+        @param executable: Path to model executable file.
+        """
+
+        super().__init__(cfg, opts)
+
+        self.lightning_module = LuxonisModel(
+            cfg=self.cfg,
+            dataset_metadata=self.dataset_metadata,
+            save_dir=self.run_save_dir,
+            input_shape=self.loader_train.input_shape,
+        )
+
+        self.model_name = self.cfg.model.name
+        
+        self.archive_name = self.cfg.archiver.archive_name
+        archive_save_directory = Path(self.cfg.archiver.archive_save_directory)
+        if not archive_save_directory.exists():
+            logger.info(f"Creating archive directory {archive_save_directory}")
+            archive_save_directory.mkdir(parents=True, exist_ok=True)
+        self.archive_save_directory = str(archive_save_directory)
+
+        self.inputs = []
+        self.outputs = []
+        self.heads = []
+
+    def archive(self, executable_path: str):
+        """Runs archiving.
+
+        @type executable_path: str
+        @param executable_path: Path to model executable file (e.g. ONNX model).
+        """
+
+        executable_fname = os.path.split(executable_path)[1]
+        _, executable_suffix = os.path.splitext(executable_fname)
+        self.archive_name += f"_{executable_suffix[1:]}"
+
+        preprocessing = {  # TODO: keep preprocessing same for each input?
+            "mean": self.cfg.trainer.preprocessing.normalize.params["mean"],
+            "scale": self.cfg.trainer.preprocessing.normalize.params["std"],
+            "reverse_channels": self.cfg.trainer.preprocessing.train_rgb,
+            "interleaved_to_planar": False,  # TODO: make it modifiable?
+        }
+
+        inputs_dict = self._get_inputs(executable_path)
+        for input_name in inputs_dict:
+            self._add_input(
+                name=input_name,
+                dtype=inputs_dict[input_name]["dtype"],
+                shape=inputs_dict[input_name]["shape"],
+                preprocessing=preprocessing,
+            )
+
+        outputs_dict = self._get_outputs(executable_path)
+        for output_name in outputs_dict:
+            self._add_output(name=output_name, dtype=outputs_dict[output_name]["dtype"])
+
+        heads_dict = self._get_heads()
+        for head_name in heads_dict:
+            outputs_list = [
+                output_name for output_name in outputs_dict if True
+            ]  # TODO: currently we list all output names. Is this correct?
+            self._add_head(
+                outputs_list=outputs_list,
+                head_metadata=heads_dict[head_name]["head_metadata"],
+            )
+
+        model = {
+            "metadata": {
+                "name": self.model_name,
+                "path": executable_fname,
+            },
+            "inputs": self.inputs,
+            "outputs": self.outputs,
+            "heads": self.heads,
+        }
+
+        cfg_dict = {
+            "config_version": CONFIG_VERSION.__args__[0],
+            "model": model,
+        }
+
+        self.archive_path = ArchiveGenerator(
+            archive_name=self.archive_name,
+            save_path=self.archive_save_directory,
+            cfg_dict=cfg_dict,
+            executables_paths=[executable_path],  # TODO: what if more executables?
+        ).make_archive()
+
+        #self.archive_path = os.path.join(
+        #    self.archive_save_directory, f"{self.archive_name}.tar.gz"
+        #)  # TODO: instead of making it manually, modify ArchiveGenerator.make_archive() to return it!
+
+        if self.cfg.archiver.upload_url is not None:
+            self._upload()
+
+        return self.archive_path  # TODO: is this necessary?
+
+    def _get_inputs(self, executable_path: str):
+        """Get inputs of a model executable.
+
+        @type executable_path: str
+        @param executable_path: Path to model executable file.
+        """
+
+        _, executable_suffix = os.path.splitext(executable_path)
+        if executable_suffix == ".onnx":
+            return self._get_onnx_inputs(executable_path)
+        else:
+            raise NotImplementedError(
+                f"Missing input reading function for {executable_suffix} models."
+            )
+
+    def _get_onnx_inputs(self, executable_path: str):
+        """Get inputs of an ONNX model executable.
+
+        @type executable_path: str
+        @param executable_path: Path to model executable file.
+        """
+
+        inputs_dict = {}
+        model = onnx.load(executable_path)
+        for input in model.graph.input:
+            tensor_type = input.type.tensor_type
+            dtype_idx = tensor_type.elem_type
+            dtype = str(onnx.helper.tensor_dtype_to_np_dtype(dtype_idx))
+            shape = []
+            for d in tensor_type.shape.dim:
+                if d.HasField("dim_value"):
+                    shape.append(d.dim_value)
+                else:
+                    raise ValueError("Unsupported input dimension identifier type")
+            inputs_dict[input.name] = {"dtype": dtype, "shape": shape}
+        return inputs_dict
+
+    def _add_input(
+        self,
+        name: str,
+        dtype: str,
+        shape: list,
+        preprocessing: dict,
+        input_type: str = "image",
+    ) -> None:
+        """Add input to self.inputs.
+
+        @type name: str
+        @param name: Name of the input layer.
+
+        @type dtype: str
+        @param dtype: Data type of the input data (e.g., 'float32').
+
+        @type shape: list
+        @param shape: Shape of the input data as a list of integers (e.g. [H,W], [H,W,C], [BS,H,W,C], ...).
+
+        @type preprocessing: dict
+        @param preprocessing: Preprocessing steps applied to the input data.
+
+        @type input_type: str
+        @param input_type: Type of input data (e.g., 'image').
+        """
+
+        self.inputs.append(
+            {
+                "name": name,  # name of the input layer
+                "dtype": dtype,
+                "input_type": input_type,
+                "shape": shape,  # Shape of the input data as a list of integers (e.g. [H,W], [H,W,C], [BS,H,W,C], ...).
+                "preprocessing": preprocessing,  # Preprocessing steps applied to the input data.
+            }
+        )
+
+    def _get_outputs(self, executable_path):
+        """Get outputs of a model executable.
+
+        @type executable_path: str
+        @param executable_path: Path to model executable file.
+        """
+
+        _, executable_suffix = os.path.splitext(executable_path)
+        if executable_suffix == ".onnx":
+            return self._get_onnx_outputs(executable_path)
+        else:
+            raise NotImplementedError(
+                f"Missing input reading function for {executable_suffix} models."
+            )
+
+    def _get_onnx_outputs(self, executable_path):
+        """Get outputs of an ONNX model executable.
+
+        @type executable_path: str
+        @param executable_path: Path to model executable file.
+        """
+
+        outputs_dict = {}
+        model = onnx.load(executable_path)
+        for output in model.graph.output:
+            tensor_type = output.type.tensor_type
+            dtype_idx = tensor_type.elem_type
+            dtype = str(onnx.helper.tensor_dtype_to_np_dtype(dtype_idx))
+            outputs_dict[output.name] = {"dtype": dtype}
+        return outputs_dict
+
+    def _add_output(self, name: str, dtype: str) -> None:
+        """Add output to self.outputs
+
+        @type name: str
+        @param name: Name of the output layer.
+
+        @type dtype: str
+        @param dtype: Data type of the output data (e.g., 'float32').
+        """
+
+        self.outputs.append({"name": name, "dtype": dtype})
+
+    def _get_classes(self, head_family):
+        if head_family.startswith("Classification"):
+            return self.dataset_metadata._classes["class"]
+        elif head_family.startswith("Object"):
+            return self.dataset_metadata._classes["boxes"]
+        elif head_family.startswith("Segmentation"):
+            return self.dataset_metadata._classes["segmentation"]
+        elif head_family.startswith("Keypoint"):
+            return self.dataset_metadata._classes["keypoints"]
+        else:
+            raise ValueError(
+                f"No classes found for the specified head family ({head_family})"
+            )
+
+    def _get_head_specific_metadata(self, head_name, head_alias) -> dict:
+        """Get head-specific metadata.
+
+        @type head_name: str
+        @param head_name: TODO: ...
+        @type head_alias: str
+        @param head_alias: TODO: ...
+        """
+
+        head_specific_metadata = {}
+        if head_name == "ClassificationHead":
+            # TODO
+            # is_softmax: bool
+            raise NotImplementedError
+        elif head_name == "EfficientBBoxHead":
+            head_specific_metadata["subtype"] = "yolov6"
+            head_node = self.lightning_module._modules["nodes"][head_alias]
+            head_specific_metadata["iou_threshold"] = head_node.iou_thres
+            head_specific_metadata["conf_threshold"] = head_node.conf_thres
+            head_specific_metadata["max_det"] = head_node.max_det
+            # head_specific_metadata["n_keypoints"] # TODO
+            # head_specific_metadata["n_prototypes"] # TODO
+            # head_specific_metadata["prototype_output_name"] # TODO
+        elif head_name == "ObjectDetectionSSD":
+            # TODO:
+            # anchors: list
+            raise NotImplementedError
+        elif head_name == "SegmentationHead":
+            # TODO:
+            # is_softmax: bool
+            raise NotImplementedError
+        elif head_name == "BiSeNetHead":
+            # TODO:
+            # is_softmax: bool
+            raise NotImplementedError
+        elif head_name == "ImplicitKeypointBBoxHead":
+            raise NotImplementedError
+        else:
+            raise ValueError("Unknown head name")
+        return head_specific_metadata
+
+    def _get_heads(self):
+        """Get model heads."""
+        heads_dict = {}
+
+        for node in self.cfg.model.nodes:
+            node_name = node.name
+            node_alias = node.alias
+            # node_inputs = node.inputs
+            if node_alias in self.lightning_module.outputs:
+                if node_name in ImplementedHeads.__members__:
+                    head_family = getattr(ImplementedHeads, node_name).value
+                    classes = self._get_classes(head_family)
+                    head_metadata = {
+                        "family": head_family,
+                        "classes": classes,
+                        "n_classes": len(classes),
+                    }
+                    head_metadata.update(
+                        self._get_head_specific_metadata(node_name, node_alias)
+                    )
+                    heads_dict[node_name] = {"head_metadata": head_metadata}
+        return heads_dict
+
+    def _add_head(self, head_metadata: dict, outputs_list: list) -> str:
+        """Add head to self.heads.
+
+        @type outputs: list
+        @param outputs: A list of output names.
+        @type metadata: dict
+        @param metadata: Parameters required by head to run postprocessing.
+        """
+
+        self.heads.append(
+            {
+                "outputs": outputs_list,
+                "metadata": head_metadata,
+            }
+        )
+
+    def _upload(self):
+        """Uploads the archive file to specified s3 bucket.
+
+        @type archive_path: str
+        @param archive_path: Path to archive file.
+        @raises ValueError: If upload url was not specified in config file.
+        """
+
+        if self.cfg.archiver.upload_url is None:
+            raise ValueError("Upload url must be specified in config file.")
+
+        fs = LuxonisFileSystem(self.cfg.archiver.upload_url, allow_local=False)
+        logger.info(f"Started Archive upload to {fs.full_path}...")
+
+        fs.put_file(  # transfer the data from the temporary file to a remote file system
+            local_path=self.archive_path,
+            remote_path=self.archive_name,
+        )
+
+        logger.info("Files upload finished")

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -115,6 +115,8 @@ class Archiver(Core):
             executables_paths=[executable_path],  # TODO: what if more executables?
         ).make_archive()
 
+        logger.info(f"archive saved to {self.archive_path}")
+
         if self.cfg.archiver.upload_url is not None:
             self._upload()
 

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -259,7 +259,7 @@ class Archiver(Core):
 
         parameters = {}
         if head_name == "ClassificationHead":
-            parameters["is_softmax"] = self._is_softmax(executable_path)  # TODO: test
+            parameters["is_softmax"] = self._is_softmax(executable_path)
         elif head_name == "EfficientBBoxHead":
             parameters["subtype"] = "yolov6"
             head_node = self.lightning_module._modules["nodes"][head_alias]
@@ -269,10 +269,8 @@ class Archiver(Core):
             # head_outputs["n_keypoints"] # TODO: implement
             # head_outputs["n_prototypes"] # TODO: implement
             # head_outputs["prototype_output_name"] # TODO: implement
-        elif head_name == "SegmentationHead":
-            parameters["is_softmax"] = self._is_softmax(executable_path)  # TODO: test
-        elif head_name == "BiSeNetHead":
-            parameters["is_softmax"] = self._is_softmax(executable_path)  # TODO: test
+        elif head_name in ["SegmentationHead", "BiSeNetHead"]:
+            parameters["is_softmax"] = self._is_softmax(executable_path)
         elif head_name == "ImplicitKeypointBBoxHead":
             pass
         else:
@@ -316,17 +314,13 @@ class Archiver(Core):
 
         head_outputs = {}
         if head_name == "ClassificationHead":
-            head_outputs["predictions"] = self.outputs[0]["name"]  # TODO: test
+            head_outputs["predictions"] = self.outputs[0]["name"]
         elif head_name == "EfficientBBoxHead":
-            head_outputs["yolo_outputs"] = [
-                output_dict["name"] for output_dict in self.outputs
-            ]  # TODO: test
-        elif head_name == "SegmentationHead":
-            raise NotImplementedError  # TODO: predictions
-        elif head_name == "BiSeNetHead":
-            raise NotImplementedError
+            head_outputs["yolo_outputs"] = [output["name"] for output in self.outputs]
+        elif head_name in ["SegmentationHead", "BiSeNetHead"]:
+            head_outputs["predictions"] = self.outputs[0]["name"]
         elif head_name == "ImplicitKeypointBBoxHead":
-            head_outputs["predictions"] = self.outputs[0]["name"]  # TODO: test
+            head_outputs["predictions"] = self.outputs[0]["name"]
         else:
             raise ValueError("Unknown head name")
         return head_outputs

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -277,7 +277,7 @@ class Archiver(Core):
         elif head_name == "BiSeNetHead":
             parameters["is_softmax"] = self._is_softmax(executable_path)  # TODO: test
         elif head_name == "ImplicitKeypointBBoxHead":
-            raise NotImplementedError
+            pass
         else:
             raise ValueError("Unknown head name")
         return parameters
@@ -331,7 +331,7 @@ class Archiver(Core):
         elif head_name == "BiSeNetHead":
             raise NotImplementedError
         elif head_name == "ImplicitKeypointBBoxHead":
-            raise NotImplementedError
+            head_outputs["predictions"] = self.outputs[0]["name"]  # TODO: test
         else:
             raise ValueError("Unknown head name")
         return head_outputs

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -269,9 +269,6 @@ class Archiver(Core):
             # head_outputs["n_keypoints"] # TODO: implement
             # head_outputs["n_prototypes"] # TODO: implement
             # head_outputs["prototype_output_name"] # TODO: implement
-        elif head_name == "ObjectDetectionSSD":
-            raise NotImplementedError
-            # head_outputs["anchors"] # TODO: implement
         elif head_name == "SegmentationHead":
             parameters["is_softmax"] = self._is_softmax(executable_path)  # TODO: test
         elif head_name == "BiSeNetHead":
@@ -324,8 +321,6 @@ class Archiver(Core):
             head_outputs["yolo_outputs"] = [
                 output_dict["name"] for output_dict in self.outputs
             ]  # TODO: test
-        elif head_name == "ObjectDetectionSSD":
-            raise NotImplementedError  # TODO: boxes, scores
         elif head_name == "SegmentationHead":
             raise NotImplementedError  # TODO: predictions
         elif head_name == "BiSeNetHead":

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -266,13 +266,10 @@ class Archiver(Core):
             parameters["iou_threshold"] = head_node.iou_thres
             parameters["conf_threshold"] = head_node.conf_thres
             parameters["max_det"] = head_node.max_det
-            # head_outputs["n_keypoints"] # TODO: implement
-            # head_outputs["n_prototypes"] # TODO: implement
-            # head_outputs["prototype_output_name"] # TODO: implement
         elif head_name in ["SegmentationHead", "BiSeNetHead"]:
             parameters["is_softmax"] = self._is_softmax(executable_path)
         elif head_name == "ImplicitKeypointBBoxHead":
-            pass
+            parameters["n_keypoints"] = self.dataset_metadata._n_keypoints
         else:
             raise ValueError("Unknown head name")
         return parameters

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -6,6 +6,7 @@ from typing import Any
 import onnx
 from luxonis_ml.nn_archive.archive_generator import ArchiveGenerator
 from luxonis_ml.nn_archive.config import CONFIG_VERSION
+from luxonis_ml.nn_archive.config_building_blocks import ObjectDetectionSubtypeYOLO
 from luxonis_ml.utils import LuxonisFileSystem
 
 from luxonis_train.models import LuxonisModel
@@ -261,7 +262,7 @@ class Archiver(Core):
         if head_name == "ClassificationHead":
             parameters["is_softmax"] = self._is_softmax(executable_path)
         elif head_name == "EfficientBBoxHead":
-            parameters["subtype"] = "yolov6"
+            parameters["subtype"] = ObjectDetectionSubtypeYOLO.YOLOv6.value
             head_node = self.lightning_module._modules["nodes"][head_alias]
             parameters["iou_threshold"] = head_node.iou_thres
             parameters["conf_threshold"] = head_node.conf_thres
@@ -269,7 +270,14 @@ class Archiver(Core):
         elif head_name in ["SegmentationHead", "BiSeNetHead"]:
             parameters["is_softmax"] = self._is_softmax(executable_path)
         elif head_name == "ImplicitKeypointBBoxHead":
-            parameters["n_keypoints"] = self.dataset_metadata._n_keypoints
+            parameters["subtype"] = ObjectDetectionSubtypeYOLO.YOLOv7.value
+            head_node = self.lightning_module._modules["nodes"][head_alias]
+            parameters["iou_threshold"] = head_node.iou_thres
+            parameters["conf_threshold"] = head_node.conf_thres
+            parameters["max_det"] = head_node.max_det
+            parameters["n_keypoints"] = head_node.n_keypoints
+            parameters["anchors"] = head_node.anchors.tolist()
+
         else:
             raise ValueError("Unknown head name")
         return parameters

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -234,3 +234,7 @@ class Core:
         @return: Path to best checkpoint with respect to best validation metric
         """
         return self.pl_trainer.checkpoint_callbacks[1].best_model_path  # type: ignore
+
+    def reset_logging(self) -> None:
+        """Close file handlers to release the log file."""
+        reset_logging()

--- a/luxonis_train/nodes/efficient_bbox_head.py
+++ b/luxonis_train/nodes/efficient_bbox_head.py
@@ -30,6 +30,7 @@ class EfficientBBoxHead(
         n_heads: Literal[2, 3, 4] = 3,
         conf_thres: float = 0.25,
         iou_thres: float = 0.45,
+        max_det: int = 300,
         **kwargs,
     ):
         """Head for object detection.
@@ -52,6 +53,8 @@ class EfficientBBoxHead(
 
         self.conf_thres = conf_thres
         self.iou_thres = iou_thres
+
+        self.max_det = max_det
 
         self.stride = self._fit_stride_to_num_heads()
         self.grid_cell_offset = 0.5

--- a/luxonis_train/nodes/efficient_bbox_head.py
+++ b/luxonis_train/nodes/efficient_bbox_head.py
@@ -46,6 +46,9 @@ class EfficientBBoxHead(
 
         @type iou_thres: float
         @param iou_thres: Threshold for IoU. Defaults to C{0.45}.
+
+        @type max_det: int
+        @param max_det: Maximum number of detections retained after NMS. Defaults to C{300}.
         """
         super().__init__(task_type=LabelType.BOUNDINGBOX, **kwargs)
 
@@ -53,7 +56,6 @@ class EfficientBBoxHead(
 
         self.conf_thres = conf_thres
         self.iou_thres = iou_thres
-
         self.max_det = max_det
 
         self.stride = self._fit_stride_to_num_heads()
@@ -166,5 +168,6 @@ class EfficientBBoxHead(
             conf_thres=self.conf_thres,
             iou_thres=self.iou_thres,
             bbox_format="xyxy",
+            max_det=self.max_det,
             predicts_objectness=False,
         )

--- a/luxonis_train/nodes/enums/head_categorization.py
+++ b/luxonis_train/nodes/enums/head_categorization.py
@@ -5,9 +5,7 @@ class ImplementedHeads(Enum):
     """Task categorization for the implemented heads."""
 
     ClassificationHead = "Classification"
-    EfficientBBoxHead = (
-        "ObjectDetectionYOLO"  # TODO ObjectDetectionYOLO/ObjectDetectionSSD?
-    )
-    ImplicitKeypointBBoxHead = "KeypointDetection"
+    EfficientBBoxHead = "ObjectDetectionYOLO"
+    ImplicitKeypointBBoxHead = "KeypointDetectionYOLO"
     SegmentationHead = "Segmentation"
-    BiSeNetHead = "Segmentation"  # TODO: SemanticSegmentation?
+    BiSeNetHead = "Segmentation"

--- a/luxonis_train/nodes/enums/head_categorization.py
+++ b/luxonis_train/nodes/enums/head_categorization.py
@@ -9,3 +9,13 @@ class ImplementedHeads(Enum):
     ImplicitKeypointBBoxHead = "KeypointDetectionYOLO"
     SegmentationHead = "Segmentation"
     BiSeNetHead = "Segmentation"
+
+
+class ImplementedHeadsIsSoxtmaxed(Enum):
+    """Softmaxed output categorization for the implemented heads."""
+
+    ClassificationHead = False
+    EfficientBBoxHead = None
+    ImplicitKeypointBBoxHead = None
+    SegmentationHead = False
+    BiSeNetHead = False

--- a/luxonis_train/nodes/enums/head_categorization.py
+++ b/luxonis_train/nodes/enums/head_categorization.py
@@ -1,12 +1,13 @@
 from enum import Enum
 
+
 class ImplementedHeads(Enum):
-    """ Task categorization for the implemented heads. """
+    """Task categorization for the implemented heads."""
 
     ClassificationHead = "Classification"
-    EfficientBBoxHead = "ObjectDetectionYOLO" # TODO ObjectDetectionYOLO/ObjectDetectionSSD?
+    EfficientBBoxHead = (
+        "ObjectDetectionYOLO"  # TODO ObjectDetectionYOLO/ObjectDetectionSSD?
+    )
     ImplicitKeypointBBoxHead = "KeypointDetection"
     SegmentationHead = "Segmentation"
-    BiSeNetHead = "Segmentation" # TODO: SemanticSegmentation?
-
-    
+    BiSeNetHead = "Segmentation"  # TODO: SemanticSegmentation?

--- a/luxonis_train/nodes/enums/head_categorization.py
+++ b/luxonis_train/nodes/enums/head_categorization.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+class ImplementedHeads(Enum):
+    """ Task categorization for the implemented heads. """
+
+    ClassificationHead = "Classification"
+    EfficientBBoxHead = "ObjectDetectionYOLO" # TODO ObjectDetectionYOLO/ObjectDetectionSSD?
+    ImplicitKeypointBBoxHead = "KeypointDetection"
+    SegmentationHead = "Segmentation"
+    BiSeNetHead = "Segmentation" # TODO: SemanticSegmentation?
+
+    

--- a/luxonis_train/nodes/implicit_keypoint_bbox_head.py
+++ b/luxonis_train/nodes/implicit_keypoint_bbox_head.py
@@ -30,6 +30,7 @@ class ImplicitKeypointBBoxHead(BaseNode):
         init_coco_biases: bool = True,
         conf_thres: float = 0.25,
         iou_thres: float = 0.45,
+        max_det: int = 300,
         **kwargs,
     ):
         """Head for object and keypoint detection.
@@ -53,6 +54,8 @@ class ImplicitKeypointBBoxHead(BaseNode):
         @param conf_thres: Threshold for confidence. Defaults to C{0.25}.
         @type iou_thres: float
         @param iou_thres: Threshold for IoU. Defaults to C{0.45}.
+        @type max_det: int
+        @param max_det: Maximum number of detections retained after NMS. Defaults to C{300}.
         """
         super().__init__(task_type=LabelType.KEYPOINT, **kwargs)
 
@@ -63,6 +66,7 @@ class ImplicitKeypointBBoxHead(BaseNode):
 
         self.conf_thres = conf_thres
         self.iou_thres = iou_thres
+        self.max_det = max_det
 
         n_keypoints = n_keypoints or self.dataset_metadata._n_keypoints
 
@@ -164,6 +168,7 @@ class ImplicitKeypointBBoxHead(BaseNode):
             conf_thres=self.conf_thres,
             iou_thres=self.iou_thres,
             bbox_format="cxcywh",
+            max_det=self.max_det,
         )
 
         return {

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -269,6 +269,12 @@ class ExportConfig(CustomBaseModel):
         return self
 
 
+class ArchiveConfig(BaseModel):
+    archive_name: str = "nn_archive"
+    archive_save_directory: str = "output_archive"
+    upload_url: str | None = None
+
+
 class StorageConfig(CustomBaseModel):
     active: bool = True
     storage_type: Literal["local", "remote"] = "local"
@@ -292,6 +298,7 @@ class Config(LuxonisConfig):
     tracker: TrackerConfig = TrackerConfig()
     trainer: TrainerConfig = TrainerConfig()
     exporter: ExportConfig = ExportConfig()
+    archiver: ArchiveConfig = ArchiveConfig()
     tuner: TunerConfig | None = None
     ENVIRON: Environ = Field(Environ(), exclude=True)
 

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">80%</text>
-        <text x="80" y="14">80%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">79%</text>
+        <text x="80" y="14">79%</text>
     </g>
 </svg>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ luxonis-ml[all]@git+https://github.com/luxonis/luxonis-ml.git@dev
 onnx>=1.12.0
 onnxruntime>=1.13.1
 onnxsim>=0.4.10
-opencv-python>=4.7.0.68
 optuna>=3.2.0
 psycopg2-binary>=2.9.1
 pycocotools>=2.0.7
@@ -14,3 +13,4 @@ s3fs>=2023.0.0
 tensorboard>=2.10.1
 torchvision>=0.16.0
 typer>=0.9.0
+mlflow>=2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ luxonis-ml@git+https://github.com/luxonis/luxonis-ml.git@dev
 onnx>=1.12.0
 onnxruntime>=1.13.1
 onnxsim>=0.4.10
+opencv-python>=4.7.0.68
 optuna>=3.2.0
 psycopg2-binary>=2.9.1
 pycocotools>=2.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 blobconverter>=1.4.2
 lightning>=2.0.0
-luxonis-ml[all]>=0.0.1
+#luxonis-ml[all]>=0.0.1
+luxonis-ml@git+https://github.com/luxonis/luxonis-ml.git@dev
 onnx>=1.12.0
 onnxruntime>=1.13.1
 onnxsim>=0.4.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 blobconverter>=1.4.2
 lightning>=2.0.0
 #luxonis-ml[all]>=0.0.1
-luxonis-ml@git+https://github.com/luxonis/luxonis-ml.git@dev
+luxonis-ml[all]@git+https://github.com/luxonis/luxonis-ml.git@dev
 onnx>=1.12.0
 onnxruntime>=1.13.1
 onnxsim>=0.4.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ onnx>=1.12.0
 onnxruntime>=1.13.1
 onnxsim>=0.4.10
 optuna>=3.2.0
+optuna_integration>=3.6.0
 psycopg2-binary>=2.9.1
 pycocotools>=2.0.7
 rich>=13.0.0

--- a/tests/unittests/test_core/test_archiver.py
+++ b/tests/unittests/test_core/test_archiver.py
@@ -1,0 +1,114 @@
+import pytest
+import torch
+import torchvision
+import os
+import tarfile
+import onnx
+import json
+import yaml
+
+import luxonis_train
+from luxonis_train.core import Archiver
+
+
+class TestArchiver:
+
+    @classmethod
+    def setup_class(cls):
+        """Create and load all files required for testing."""
+
+        luxonis_train_parent_dir = os.path.dirname(
+            os.path.dirname(luxonis_train.__file__)
+        )
+        tmp_test_path = os.path.join(
+            luxonis_train_parent_dir,
+            "tests",
+            "unittests",
+            "test_core",
+        )
+
+        # make config
+        config_dict = {
+            "model": {"name": "dummy", "predefined_model": {"name": "DetectionModel"}},
+            "dataset": {
+                "name": "dummyldf"
+            },  # TODO: set LDF name automatically - choose one random LDF or make a random LDF!
+        }
+        cls.config_path = os.path.join(tmp_test_path, "tmp_config.yaml")
+        with open(cls.config_path, "w") as yaml_file:
+            yaml_str = yaml.dump(config_dict)
+            yaml_file.write(yaml_str)
+
+        # make model
+        model = torchvision.models.squeezenet1_0(pretrained=False)
+        cls.model_path = "tmp_squeezenet1_0.onnx"
+        n, c, h, w = 1, 3, 224, 224
+        input_shape = torch.randn(n, c, h, w)
+        cls.input_names = ["TestInput"]
+        cls.output_names = ["TestOutput"]
+
+        torch.onnx.export(
+            model,
+            input_shape,
+            cls.model_path,
+            verbose=False,
+            input_names=cls.input_names,
+            output_names=cls.output_names,
+        )
+
+        # make archive
+        cls.archive_path = Archiver(cls.config_path).archive(cls.model_path)
+
+        # load archive files into memory
+        with tarfile.open(cls.archive_path, mode="r") as tar:
+            cls.archive_fnames = tar.getnames()  # List all the contents of the tar file
+            for fname in cls.archive_fnames:
+                if fname.endswith(".json"):
+                    json_file = tar.extractfile(fname)
+                    cls.json_dict = json.load(json_file)
+                elif fname.endswith(".onnx"):
+                    onnx_file = tar.extractfile(fname)
+                    cls.onnx_model = onnx.load(onnx_file)
+
+    @classmethod
+    def teardown_class(cls):
+        """Remove all created files."""
+        os.remove(cls.archive_path)
+        os.remove(cls.config_path)
+        os.remove(cls.model_path)
+
+    def test_archive_suffix(self):
+        """Test if nn_archive was created."""
+        assert self.archive_path.endswith("tar.gz")
+
+    def test_archive_contents(self):
+        """Test if nn_archive consists of exactly one JSON and one ONNX file."""
+        assert (
+            len(self.archive_fnames) == 2
+            and any([fname.endswith(".json") for fname in self.archive_fnames])
+            and any([fname.endswith(".onnx") for fname in self.archive_fnames])
+        )
+
+    def test_onnx(self):
+        """Test if archived ONNX model is valid."""
+        try:
+            onnx.checker.check_model(self.onnx_model, full_check=True)
+        except onnx.checker.ValidationError as e:
+            print("The model is invalid: %s" % e)
+            assert False
+        else:
+            assert True
+
+    def test_config_inputs(self):
+        """Test if archived config inputs are valid."""
+        config_input_names = []
+        for input in self.json_dict["model"]["inputs"]:
+            config_input_names.append(input["name"])
+        assert set(self.input_names) == set(config_input_names)
+
+    def test_config_outputs(self):
+        """Test if archived config outputs are valid."""
+        config_output_names = []
+        for input in self.json_dict["model"]["outputs"]:
+            config_output_names.append(input["name"])
+        assert set(self.output_names) == set(config_output_names)

--- a/tests/unittests/test_core/test_archiver.py
+++ b/tests/unittests/test_core/test_archiver.py
@@ -6,15 +6,17 @@ import shutil
 import tarfile
 
 import cv2
+import lightning.pytorch as pl
 import numpy as np
 import onnx
-import torch
-import torchvision
 import yaml
 from luxonis_ml.data import LuxonisDataset
 
 import luxonis_train
 from luxonis_train.core import Archiver
+from luxonis_train.core.exporter import Exporter
+from luxonis_train.core.trainer import Trainer
+from luxonis_train.utils.config import Config
 
 
 class TestArchiver:
@@ -26,11 +28,9 @@ class TestArchiver:
             os.path.dirname(luxonis_train.__file__)
         )
         cls.tmp_path = os.path.join(
-            luxonis_train_parent_dir,
-            "tests",
-            "unittests",
-            "test_core",
+            luxonis_train_parent_dir, "tests", "unittests", "test_core", "tmp"
         )
+        os.mkdir(cls.tmp_path)
 
         # make LDF
         os.mkdir(os.path.join(cls.tmp_path, "images"))
@@ -39,7 +39,7 @@ class TestArchiver:
 
         def classification_dataset_generator():
             for i in range(10):
-                img = np.random.randint(0, 256, (50, 50, 3), dtype=np.uint8)
+                img = np.random.randint(0, 256, (10, 10, 3), dtype=np.uint8)
                 img_file_path = os.path.join(cls.tmp_path, "images", f"img{i}.png")
                 cv2.imwrite(img_file_path, img)
                 yield {
@@ -64,36 +64,37 @@ class TestArchiver:
                 "predefined_model": {"name": "ClassificationModel"},
             },
             "dataset": {"name": cls.ldf_name},
-            "archiver": {
-                "archive_name": "tmp_nn_archive",
-                "archive_save_directory": cls.tmp_path,
-            },
+            "tracker": {"save_directory": cls.tmp_path},
         }
-        cls.config_path = os.path.join(cls.tmp_path, "tmp_config.yaml")
+        cls.config_path = os.path.join(cls.tmp_path, "config.yaml")
         with open(cls.config_path, "w") as yaml_file:
             yaml_str = yaml.dump(config_dict)
             yaml_file.write(yaml_str)
+        cfg = Config.get_config(config_dict)
 
-        # make model
-        model = torchvision.models.mobilenet_v2(pretrained=False)
-        cls.model_path = os.path.join(cls.tmp_path, "tmp_mobilenet_v2.onnx")
+        # train model
+        cfg.trainer.epochs = 1
+        cfg.trainer.validation_interval = 1
+        cfg.trainer.batch_size = 4
+        trainer = Trainer(cfg=cfg)
+        trainer.train()
+        callbacks = [
+            c
+            for c in trainer.pl_trainer.callbacks
+            if isinstance(c, pl.callbacks.ModelCheckpoint)
+        ]
+        model_checkpoint_path = callbacks[0].best_model_path
+        model_ckpt = os.path.join(trainer.run_save_dir, model_checkpoint_path)
 
-        n, c, h, w = 1, 3, 224, 224
-        input_shape = torch.randn(n, c, h, w)
-        cls.input_names = ["TestInput"]
-        cls.output_names = ["TestOutput"]
-
-        torch.onnx.export(
-            model,
-            input_shape,
-            cls.model_path,
-            verbose=False,
-            input_names=cls.input_names,
-            output_names=cls.output_names,
-        )
+        # export model to ONNX
+        cfg.model.weights = model_ckpt
+        exporter = Exporter(cfg=cfg)
+        cls.onnx_model_path = os.path.join(cls.tmp_path, "model.onnx")
+        exporter.export(onnx_path=cls.onnx_model_path)
 
         # make archive
-        cls.archive_path = Archiver(cls.config_path).archive(cls.model_path)
+        cfg.archiver.archive_save_directory = cls.tmp_path
+        cls.archive_path = Archiver(cls.config_path).archive(cls.onnx_model_path)
 
         # load archive files into memory
         with tarfile.open(cls.archive_path, mode="r") as tar:
@@ -110,11 +111,8 @@ class TestArchiver:
     @classmethod
     def teardown_class(cls):
         """Remove all created files."""
-        os.remove(cls.archive_path)
-        os.remove(cls.config_path)
-        os.remove(cls.model_path)
         LuxonisDataset(cls.ldf_name).delete_dataset()
-        shutil.rmtree(os.path.join(cls.tmp_path, "images"))
+        shutil.rmtree(cls.tmp_path)
 
     def test_archive_creation(self):
         """Test if nn_archive was created."""
@@ -126,12 +124,11 @@ class TestArchiver:
         assert self.archive_path.endswith("tar.xz")
 
     def test_archive_contents(self):
-        """Test if nn_archive consists of exactly one JSON file named config.json and
-        one ONNX file."""
+        """Test if nn_archive consists of config.json and model.onnx."""
         assert (
             len(self.archive_fnames) == 2
             and any([fname == "config.json" for fname in self.archive_fnames])
-            and any([fname.endswith(".onnx") for fname in self.archive_fnames])
+            and any([fname == "model.onnx" for fname in self.archive_fnames])
         )
 
     def test_onnx(self):
@@ -143,11 +140,15 @@ class TestArchiver:
         config_input_names = []
         for input in self.json_dict["model"]["inputs"]:
             config_input_names.append(input["name"])
-        assert set(self.input_names) == set(config_input_names)
+        assert set([input.name for input in self.onnx_model.graph.input]) == set(
+            config_input_names
+        )
 
     def test_config_outputs(self):
         """Test if archived config outputs are valid."""
         config_output_names = []
         for input in self.json_dict["model"]["outputs"]:
             config_output_names.append(input["name"])
-        assert set(self.output_names) == set(config_output_names)
+        assert set([output.name for output in self.onnx_model.graph.output]) == set(
+            config_output_names
+        )

--- a/tests/unittests/test_core/test_archiver.py
+++ b/tests/unittests/test_core/test_archiver.py
@@ -4,6 +4,7 @@ import os
 import random
 import shutil
 import tarfile
+import time
 
 import cv2
 import lightning.pytorch as pl
@@ -112,6 +113,7 @@ class TestArchiver:
     def teardown_class(cls):
         """Remove all created files."""
         LuxonisDataset(cls.ldf_name).delete_dataset()
+        time.sleep(1)  # wait for all files to be released by other processes
         shutil.rmtree(cls.tmp_path)
 
     def test_archive_creation(self):


### PR DESCRIPTION
This PR introduces a new generator class (`luxonis_train.core.Archiver`) enabling automatic generation of NN archives from training configs. This functionality is exposed both through a command-line interface (CLI) and callbacks (with uploading the NN archive to MLFlow). Furthermore, basic test coverage is included to ensure correctness of generation.

The added features are functional but there are still a few open issues so any insights or suggestions regarding the current implementation would be greatly appreciated!

Open issues:
- (**model formats**): Currently, the generator is only able to archive for ONNX model format. Do we want to support it for other formats also (e.g. BLOB, DLC, XML/BIN… )? If so, how to approach models with multiple executables (e.g. the [path parameter](https://github.com/luxonis/luxonis-ml/blob/dev/luxonis_ml/nn_archive/config_building_blocks/base_models/metadata.py) in NN archive `Metadata` class requires a single path to the model executable so I'm not sure what to do in case of multiple)?
- (**is_softmax** parameter, e.g. in `HeadClassification` [class](https://github.com/luxonis/luxonis-ml/blob/10f9a4323c3ac52e946ef4ba5f49f1701ea0b2a7/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py#L80)): Currently, decision if output is already softmaxed is based on iterating ONNX nodes and checking if there is a node named softmax. However, I'm not sure how bulletproof is that and if it is implementable for other model formats. Is there some other way to determine this parameter (OR should maybe even be hard-coded for specific architectures)?
- (**head_outputs** [classes](https://github.com/luxonis/luxonis-ml/blob/dev/luxonis_ml/nn_archive/config_building_blocks/base_models/head_outputs.py)): I’m wondering how to determine which outputs belong to specific head output parameters (cc @conorsim). For example:
  - `yolo_outputs` parameter in `EfficientBBoxHead`. Is it sensible to expect that all outputs of the model always belong here? If not, how to determine the outputs to be listed?
  - `predictions` parameter in `ClassificationHead`. Is it sensible to expect that models with `ClassificationHead` will always only have one output? If not, how to determine which of the outputs is the right one?
  - `boxes` and `scores` parameters in `ObjectDetectionSSD`. How to determine which output belongs to which parameter for an arbitrary SSD network?
- (**tests**): I’ve implemented setup class method that makes a dummy LDF, config, and ONNX model, and runs the archivation. Next, the tests are run to inspect basic characteristics of the constructed archive file. In the end, teardown class method deletes all the constructed files. Is this approach OK or is there some better way to tackle this?