### PR TITLE
Added active param to augmentations

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -137,7 +137,9 @@ def inspect(
 
     augmentations = (TrainAugmentations if view == "train" else ValAugmentations)(
         image_size=image_size,
-        augmentations=[i.model_dump() for i in cfg.trainer.preprocessing.augmentations],
+        augmentations=[
+            i.model_dump() for i in cfg.trainer.preprocessing.get_active_augmentations()
+        ],
         train_rgb=cfg.trainer.preprocessing.train_rgb,
         keep_aspect_ratio=cfg.trainer.preprocessing.keep_aspect_ratio,
     )

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -102,7 +102,8 @@ class Core:
         self.train_augmentations = TrainAugmentations(
             image_size=self.cfg.trainer.preprocessing.train_image_size,
             augmentations=[
-                i.model_dump() for i in self.cfg.trainer.preprocessing.augmentations
+                i.model_dump()
+                for i in self.cfg.trainer.preprocessing.get_active_augmentations()
             ],
             train_rgb=self.cfg.trainer.preprocessing.train_rgb,
             keep_aspect_ratio=self.cfg.trainer.preprocessing.keep_aspect_ratio,
@@ -110,7 +111,8 @@ class Core:
         self.val_augmentations = ValAugmentations(
             image_size=self.cfg.trainer.preprocessing.train_image_size,
             augmentations=[
-                i.model_dump() for i in self.cfg.trainer.preprocessing.augmentations
+                i.model_dump()
+                for i in self.cfg.trainer.preprocessing.get_active_augmentations()
             ],
             train_rgb=self.cfg.trainer.preprocessing.train_rgb,
             keep_aspect_ratio=self.cfg.trainer.preprocessing.keep_aspect_ratio,
@@ -134,12 +136,16 @@ class Core:
 
         self.loaders = {
             view: LOADERS.get(self.cfg.loader.name)(
-                augmentations=self.train_augmentations
-                if view == "train"
-                else self.val_augmentations,
-                view=self.cfg.loader.train_view
-                if view == "train"
-                else self.cfg.loader.val_view,
+                augmentations=(
+                    self.train_augmentations
+                    if view == "train"
+                    else self.val_augmentations
+                ),
+                view=(
+                    self.cfg.loader.train_view
+                    if view == "train"
+                    else self.cfg.loader.val_view
+                ),
                 **self.cfg.loader.params,
             )
             for view in ["train", "val", "test"]
@@ -163,9 +169,9 @@ class Core:
                 num_workers=self.cfg.trainer.num_workers,
                 collate_fn=collate_fn,
                 shuffle=view == "train",
-                drop_last=self.cfg.trainer.skip_last_batch
-                if view == "train"
-                else False,
+                drop_last=(
+                    self.cfg.trainer.skip_last_batch if view == "train" else False
+                ),
                 sampler=sampler if view == "train" else None,
             )
             for view in ["train", "val", "test"]

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -147,6 +147,7 @@ class NormalizeAugmentationConfig(CustomBaseModel):
 
 class AugmentationConfig(CustomBaseModel):
     name: str
+    active: bool = True
     params: dict[str, Any] = {}
 
 
@@ -166,6 +167,13 @@ class PreprocessingConfig(CustomBaseModel):
                 AugmentationConfig(name="Normalize", params=self.normalize.params)
             )
         return self
+
+    def get_active_augmentations(self) -> list[AugmentationConfig]:
+        """Returns list of augmentations that are active
+        @rtype: list[AugmentationConfig]
+        @return: Filtered list of active augmentation configs
+        """
+        return [aug for aug in self.augmentations if aug.active]
 
 
 class CallbackConfig(CustomBaseModel):


### PR DESCRIPTION
- Added `active` parameter for each augmentation
- [Augmentation](https://github.com/luxonis/luxonis-ml/blob/06dedb7bb0e7caaee1663e815925456a51c46595/luxonis_ml/data/augmentations/utils.py#L16) gets only currently active augmentations
- This makes it possible for `Tuner` to turn on/off specific augmentation per trial. Example part of config:
```yaml
trainer:
  ...
  preprocessing:
    ...
     augmentations:
       - name: Defocus
         params:
           p: 0.1
tuner:
  params:
    trainer.preprocessing.augmentations.0.active_categorical: [True, False]
```