### PR TITLE
Multi Input Support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
         version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}

--- a/configs/example_multi_input.yaml
+++ b/configs/example_multi_input.yaml
@@ -1,0 +1,100 @@
+loader:
+  name: CustomMultiInputLoader  # Yields "left", "right", "disparity", and "pointcloud" inputs
+
+use_rich_text: True
+
+model:
+  name: example_multi_input
+  nodes:
+    - name: FullBackbone
+      alias: full_backbone
+
+    - name: RGBDBackbone
+      alias: rgbd_backbone
+      input_sources:
+        - left
+        - right
+        - disparity
+
+    - name: PointcloudBackbone
+      alias: pointcloud_backbone
+      input_sources:
+        - pointcloud
+
+    - name: FusionNeck
+      alias: fusion_neck
+      inputs:
+        - rgbd_backbone
+        - pointcloud_backbone
+      input_sources:
+        - disparity
+
+    - name: FusionNeck2
+      alias: fusion_neck_2
+      inputs:
+        - rgbd_backbone
+        - pointcloud_backbone
+        - full_backbone
+    
+    - name: CustomSegHead1
+      alias: head_1
+      inputs:
+        - fusion_neck
+
+    - name: CustomSegHead2
+      alias: head_2
+      inputs:
+        - fusion_neck
+        - fusion_neck_2
+      input_sources:
+        - disparity
+
+  losses:
+    - name: BCEWithLogitsLoss
+      alias: loss_1
+      attached_to: head_1
+
+    - name: BCEWithLogitsLoss
+      alias: loss_2
+      attached_to: head_2
+
+  metrics:
+    - name: JaccardIndex
+      alias: jaccard_index_1
+      attached_to: head_1
+      is_main_metric: True
+      params:
+        task: binary
+
+    - name: JaccardIndex
+      alias: jaccard_index_2
+      attached_to: head_2
+      params:
+        task: binary
+
+trainer:
+  batch_size: 8
+  epochs: &epochs 3
+  num_workers: 4
+  validation_interval: 3
+  num_log_images: -1
+
+  callbacks:
+    - name: ExportOnTrainEnd
+  
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.01
+
+exporter:
+  onnx:
+    opset_version: 11
+
+# tracker:
+#   project_name: ace_reid_spot_segmentation
+#   save_directory: output
+#   is_tensorboard: True
+#   is_wandb: False
+#   wandb_entity: luxonis
+#   is_mlflow: False

--- a/configs/example_multi_input.yaml
+++ b/configs/example_multi_input.yaml
@@ -6,7 +6,7 @@ loader:
 
   # Name of the key in the batch that contains image-like data.
   # Needs to be set for visualizers and evaluators to work.
-  images_name: left
+  image_source: left
 
 use_rich_text: True
 

--- a/configs/example_multi_input.yaml
+++ b/configs/example_multi_input.yaml
@@ -1,5 +1,6 @@
 loader:
-  name: CustomMultiInputLoader  # Yields "left", "right", "disparity", and "pointcloud" inputs
+  name: CustomMultiInputLoader  # Yields "left", "right", "disparity", and "pointcloud" inputs. See implementation in `tests/integration/test_multi_input.py`.
+  images_name: left  # Name of the key in the batch that contains image-like data. Needs to be set for visualizers and evaluators to work.
 
 use_rich_text: True
 

--- a/luxonis_train/attached_modules/losses/adaptive_detection_loss.py
+++ b/luxonis_train/attached_modules/losses/adaptive_detection_loss.py
@@ -82,7 +82,7 @@ class AdaptiveDetectionLoss(BaseLoss[Tensor, Tensor, Tensor, Tensor, Tensor, Ten
         self.stride = self.node.stride
         self.grid_cell_size = self.node.grid_cell_size
         self.grid_cell_offset = self.node.grid_cell_offset
-        self.original_img_size = self.node.original_in_shape[2:]
+        self.original_img_size = self.node.original_in_shape[self.node.images_name][1:]
 
         self.n_warmup_epochs = n_warmup_epochs
         self.atts_assigner = ATSSAssigner(topk=9, n_classes=self.n_classes)

--- a/luxonis_train/attached_modules/losses/adaptive_detection_loss.py
+++ b/luxonis_train/attached_modules/losses/adaptive_detection_loss.py
@@ -82,7 +82,7 @@ class AdaptiveDetectionLoss(BaseLoss[Tensor, Tensor, Tensor, Tensor, Tensor, Ten
         self.stride = self.node.stride
         self.grid_cell_size = self.node.grid_cell_size
         self.grid_cell_offset = self.node.grid_cell_offset
-        self.original_img_size = self.node.original_in_shape[self.node.images_name][1:]
+        self.original_img_size = self.node.original_in_shape[1:]
 
         self.n_warmup_epochs = n_warmup_epochs
         self.atts_assigner = ATSSAssigner(topk=9, n_classes=self.n_classes)

--- a/luxonis_train/attached_modules/metrics/mean_average_precision.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision.py
@@ -41,7 +41,7 @@ class MeanAveragePrecision(BaseMetric):
         label = labels[self.task][0]
         output_nms = self.get_input_tensors(outputs)
 
-        image_size = self.node.original_in_shape[self.node.images_name][1:]
+        image_size = self.node.original_in_shape[1:]
 
         output_list: list[dict[str, Tensor]] = []
         label_list: list[dict[str, Tensor]] = []

--- a/luxonis_train/attached_modules/metrics/mean_average_precision.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision.py
@@ -41,7 +41,7 @@ class MeanAveragePrecision(BaseMetric):
         label = labels[LabelType.BOUNDINGBOX]
         output_nms = outputs["boxes"]
 
-        image_size = self.node.original_in_shape[2:]
+        image_size = self.node.original_in_shape[self.node.images_name][1:]
 
         output_list: list[dict[str, Tensor]] = []
         label_list: list[dict[str, Tensor]] = []

--- a/luxonis_train/attached_modules/metrics/mean_average_precision_keypoints.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision_keypoints.py
@@ -109,7 +109,7 @@ class MeanAveragePrecisionKeypoints(BaseMetric):
 
         output_list_kpt_map = []
         label_list_kpt_map = []
-        image_size = self.node.original_in_shape[2:]
+        image_size = self.node.original_in_shape[self.node.images_name][1:]
 
         output_kpts: list[Tensor] = outputs["keypoints"]
         output_bboxes: list[Tensor] = outputs["boxes"]

--- a/luxonis_train/attached_modules/metrics/mean_average_precision_keypoints.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision_keypoints.py
@@ -109,7 +109,7 @@ class MeanAveragePrecisionKeypoints(BaseMetric):
 
         output_list_kpt_map = []
         label_list_kpt_map = []
-        image_size = self.node.original_in_shape[self.node.images_name][1:]
+        image_size = self.node.original_in_shape[1:]
 
         output_kpts: list[Tensor] = outputs["keypoints"]
         output_bboxes: list[Tensor] = outputs["boundingbox"]

--- a/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
+++ b/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
@@ -79,7 +79,7 @@ class ObjectKeypointSimilarity(
 
         output_list_oks = []
         label_list_oks = []
-        image_size = self.node.original_in_shape[2:]
+        image_size = self.node.original_in_shape[self.node.images_name][1:]
 
         for i, pred_kpt in enumerate(outputs["keypoints"]):
             output_list_oks.append({"keypoints": pred_kpt})

--- a/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
+++ b/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
@@ -79,7 +79,7 @@ class ObjectKeypointSimilarity(
 
         output_list_oks = []
         label_list_oks = []
-        image_size = self.node.original_in_shape[self.node.images_name][1:]
+        image_size = self.node.original_in_shape[1:]
 
         for i, pred_kpt in enumerate(outputs["keypoints"]):
             output_list_oks.append({"keypoints": pred_kpt})

--- a/luxonis_train/attached_modules/visualizers/utils.py
+++ b/luxonis_train/attached_modules/visualizers/utils.py
@@ -220,7 +220,10 @@ def unnormalize(
     return out_img
 
 
-def get_unnormalized_images(cfg: Config, images: Tensor) -> Tensor:
+def get_unnormalized_images(cfg: Config, inputs: dict[str, Tensor]) -> Tensor:
+    # Get images from inputs according to config
+    images = inputs[cfg.loader.images_name]
+
     normalize_params = cfg.trainer.preprocessing.normalize.params
     mean = std = None
     if cfg.trainer.preprocessing.normalize.active:

--- a/luxonis_train/attached_modules/visualizers/utils.py
+++ b/luxonis_train/attached_modules/visualizers/utils.py
@@ -222,7 +222,7 @@ def unnormalize(
 
 def get_unnormalized_images(cfg: Config, inputs: dict[str, Tensor]) -> Tensor:
     # Get images from inputs according to config
-    images = inputs[cfg.loader.images_name]
+    images = inputs[cfg.loader.image_source]
 
     normalize_params = cfg.trainer.preprocessing.normalize.params
     mean = std = None

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -147,7 +147,7 @@ class Core:
                     if view == "train"
                     else self.cfg.loader.val_view
                 ),
-                images_name=self.cfg.loader.images_name,
+                image_source=self.cfg.loader.image_source,
                 **self.cfg.loader.params,
             )
             for view in ["train", "val", "test"]

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -146,6 +146,7 @@ class Core:
                     if view == "train"
                     else self.cfg.loader.val_view
                 ),
+                images_name=self.cfg.loader.images_name,
                 **self.cfg.loader.params,
             )
             for view in ["train", "val", "test"]

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -125,7 +125,7 @@ class LuxonisModel(pl.LightningModule):
 
         self.cfg = cfg
         self.original_in_shape = input_shape
-        self.images_name = cfg.loader.images_name
+        self.image_source = cfg.loader.image_source
         self.dataset_metadata = dataset_metadata or DatasetMetadata()
         self.frozen_nodes: list[tuple[nn.Module, int]] = []
         self.graph: dict[str, list[str]] = {}
@@ -269,7 +269,7 @@ class LuxonisModel(pl.LightningModule):
 
             node = Node(
                 input_shapes=node_input_shapes,
-                original_in_shape=self.original_in_shape[self.images_name],
+                original_in_shape=self.original_in_shape[self.image_source],
                 dataset_metadata=self.dataset_metadata,
                 **node_kwargs,
             )

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -33,7 +33,7 @@ from luxonis_train.nodes import BaseNode
 from luxonis_train.utils.config import AttachedModuleConfig, Config
 from luxonis_train.utils.general import (
     DatasetMetadata,
-    get_shape_packet,
+    to_shape_packet,
     traverse_graph,
 )
 from luxonis_train.utils.registry import CALLBACKS, OPTIMIZERS, SCHEDULERS, Registry
@@ -274,8 +274,7 @@ class LuxonisModel(pl.LightningModule):
                 # Add the input to the list of inputs
                 node_dummy_inputs.append(dummy_input)
 
-                # Add its shape to the list of input shapes
-                shape_packet = get_shape_packet(dummy_input)
+                shape_packet = to_shape_packet(dummy_input)
                 node_input_shapes.append(shape_packet)
 
             node = Node(

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -100,7 +100,7 @@ class LuxonisModel(pl.LightningModule):
         self,
         cfg: Config,
         save_dir: str,
-        input_shape: list[int] | Size,
+        input_shape: dict[str, Size],
         dataset_metadata: DatasetMetadata | None = None,
         **kwargs,
     ):
@@ -110,8 +110,9 @@ class LuxonisModel(pl.LightningModule):
         @param cfg: Config object.
         @type save_dir: str
         @param save_dir: Directory to save checkpoints.
-        @type input_shape: list[int] | L{Size}
-        @param input_shape: Shape of the input tensor.
+        @type input_shape: dict[str, Size]
+        @param input_shape: Dictionary of input shapes. Keys are input names, values are
+            shapes.
         @type dataset_metadata: L{DatasetMetadata} | None
         @param dataset_metadata: Dataset metadata.
         @type kwargs: Any
@@ -123,11 +124,12 @@ class LuxonisModel(pl.LightningModule):
         self._export: bool = False
 
         self.cfg = cfg
-        self.original_in_shape = Size(input_shape)
+        self.original_in_shape = input_shape
+        self.images_name = cfg.loader.images_name
         self.dataset_metadata = dataset_metadata or DatasetMetadata()
         self.frozen_nodes: list[tuple[nn.Module, int]] = []
         self.graph: dict[str, list[str]] = {}
-        self.input_shapes: dict[str, list[Size]] = {}
+        self.loader_input_shapes: dict[str, Size] = {}
         self.loss_weights: dict[str, float] = {}
         self.main_metric: str | None = None
         self.save_dir = save_dir
@@ -160,8 +162,33 @@ class LuxonisModel(pl.LightningModule):
                     unfreeze_after = int(node_cfg.freezing.unfreeze_after * epochs)
                 frozen_nodes.append((node_name, unfreeze_after))
             nodes[node_name] = (Node, node_cfg.params)
-            if not node_cfg.inputs:
-                self.input_shapes[node_name] = [Size(input_shape)]
+
+            # Handle inputs for this node
+
+            if not node_cfg.inputs and not node_cfg.input_sources:
+                # If no inputs (= preceding nodes) nor any input_sources (= loader outputs) are specified,
+                # assume the node is the starting node and takes all inputs from the loader.
+
+                self.loader_input_shapes[node_name] = {
+                    k: Size(v) for k, v in input_shape.items()
+                }
+            else:
+                # For each input_source, check if the loader provides the required output.
+                # If yes, add the shape to the input_shapes dict. If not, raise an error.
+                self.loader_input_shapes[node_name] = {}
+                for input_source in node_cfg.input_sources:
+                    if input_source not in input_shape:
+                        raise ValueError(
+                            f"Node {node_name} requires input source {input_source}, "
+                            "which is not provided by the loader."
+                        )
+
+                    self.loader_input_shapes[node_name][input_source] = Size(
+                        input_shape[input_source]
+                    )
+
+                # Inputs (= preceding nodes) are handled in the _initiate_nodes method.
+
             self.graph[node_name] = node_cfg.inputs
 
         self.nodes = self._initiate_nodes(nodes)
@@ -213,44 +240,64 @@ class LuxonisModel(pl.LightningModule):
         """
         initiated_nodes: dict[str, BaseNode] = {}
 
-        dummy_outputs: dict[str, Packet[Tensor]] = {
-            f"__{node_name}_input__": {
-                "features": [torch.zeros(2, *shape[1:]) for shape in shapes]
-            }
-            for node_name, shapes in self.input_shapes.items()
+        dummy_inputs: dict[str, Packet[Tensor]] = {
+            input_name: [torch.zeros(2, *shape)]
+            for node_name, shapes in self.loader_input_shapes.items()
+            for input_name, shape in shapes.items()
         }
 
         for node_name, (Node, node_kwargs), node_input_names, _ in traverse_graph(
             self.graph, nodes
         ):
-            node_input_shapes: list[Packet[Size]] = []
             node_dummy_inputs: list[Packet[Tensor]] = []
+            """List of dummy input packets for the node.
 
-            if not node_input_names:
-                node_input_names = [f"__{node_name}_input__"]
+            The first one is always from the loader.
+            """
+            node_input_shapes: list[Packet[Size]] = []
+            """Corresponding list of input shapes."""
 
+            # Add inputs from the loader (if the node has at least one input_source)
+            if len(self.loader_input_shapes[node_name]) > 0:
+                loader_packet = {}
+                for input_name in self.loader_input_shapes[node_name]:
+                    loader_packet[input_name] = dummy_inputs[input_name]
+
+                # Add the loader packet to the list of inputs
+                node_dummy_inputs.append(loader_packet)
+
+                # Add its shape to the list of input shapes
+                loader_shape_packet = get_shape_packet(loader_packet)
+                node_input_shapes.append(loader_shape_packet)
+
+            # Add inputs from preceding Nodes
             for node_input_name in node_input_names:
-                dummy_output = dummy_outputs[node_input_name]
-                shape_packet = get_shape_packet(dummy_output)
+                dummy_input = dummy_inputs[node_input_name]
+
+                # Add the input to the list of inputs
+                node_dummy_inputs.append(dummy_input)
+
+                # Add its shape to the list of input shapes
+                shape_packet = get_shape_packet(dummy_input)
                 node_input_shapes.append(shape_packet)
-                node_dummy_inputs.append(dummy_output)
 
-                node = Node(
-                    input_shapes=node_input_shapes,
-                    original_in_shape=self.original_in_shape,
-                    dataset_metadata=self.dataset_metadata,
-                    **node_kwargs,
-                )
-                node_outputs = node.run(node_dummy_inputs)
+            node = Node(
+                input_shapes=node_input_shapes,
+                original_in_shape=self.original_in_shape,
+                images_name=self.images_name,
+                dataset_metadata=self.dataset_metadata,
+                **node_kwargs,
+            )
+            node_outputs = node.run(node_dummy_inputs)
 
-                dummy_outputs[node_name] = node_outputs
-                initiated_nodes[node_name] = node
+            dummy_inputs[node_name] = node_outputs
+            initiated_nodes[node_name] = node
 
         return nn.ModuleDict(initiated_nodes)
 
     def forward(
         self,
-        inputs: Tensor,
+        inputs: dict[str, Tensor],
         task_labels: TaskLabels | None = None,
         images: Tensor | None = None,
         *,
@@ -280,27 +327,32 @@ class LuxonisModel(pl.LightningModule):
         @rtype: L{LuxonisOutput}
         @return: Output of the model.
         """
-        input_node_name = list(self.input_shapes.keys())[0]
-        input_dict = {input_node_name: [inputs]}
 
         losses: dict[
             str, dict[str, Tensor | tuple[Tensor, dict[str, Tensor]]]
         ] = defaultdict(dict)
         visualizations: dict[str, dict[str, Tensor]] = defaultdict(dict)
 
-        computed: dict[str, Packet[Tensor]] = {
-            f"__{node_name}_input__": {"features": input_tensors}
-            for node_name, input_tensors in input_dict.items()
-        }
+        packetized_inputs = {name: [inputs[name]] for name in inputs}
+
+        computed = {}
         for node_name, node, input_names, unprocessed in traverse_graph(
             self.graph, cast(dict[str, BaseNode], self.nodes)
         ):
-            # Special input for the first node. Will be changed when
-            # multiple inputs will be supported in `luxonis-ml.data`.
-            if not input_names:
-                input_names = [f"__{node_name}_input__"]
+            # Build node inputs from loader and preceding nodes
+            node_inputs = []
 
-            node_inputs = [computed[pred] for pred in input_names]
+            # Add inputs from the loader (if the node has at least one input_source)
+            if len(self.loader_input_shapes[node_name]) > 0:
+                loader_packet = {}
+                for input_name in self.loader_input_shapes[node_name]:
+                    loader_packet[input_name] = packetized_inputs[input_name]
+
+                # Add the loader packet to the list of inputs
+                node_inputs.append(loader_packet)
+
+            # Add inputs from preceding Nodes
+            node_inputs += [computed[pred] for pred in input_names]
             outputs = node.run(node_inputs)
             computed[node_name] = outputs
             labels = task_labels[self.node_tasks[node_name]] if task_labels else None
@@ -334,7 +386,10 @@ class LuxonisModel(pl.LightningModule):
                 if computed_name in self.outputs:
                     continue
                 for node_name in unprocessed:
-                    if computed_name in self.graph[node_name]:
+                    if (
+                        computed_name in self.graph[node_name]
+                        or computed_name in self.loader_input_shapes[node_name]
+                    ):
                         break
                 else:
                     del computed[computed_name]
@@ -393,18 +448,22 @@ class LuxonisModel(pl.LightningModule):
         """
 
         inputs = {
-            name: [torch.zeros(shape).to(self.device) for shape in shapes]
-            for name, shapes in self.input_shapes.items()
+            input_name: torch.zeros([1, *shape]).to(self.device)
+            for name, shapes in self.loader_input_shapes.items()
+            for input_name, shape in shapes.items()
         }
 
-        # TODO: multiple inputs
-        inp = list(inputs.values())[0][0]
+        inputs_deep_clone = {
+            k: torch.zeros(elem.shape).to(self.device) for k, elem in inputs.items()
+        }
+
+        inputs_for_onnx = {"inputs": inputs_deep_clone}
 
         for module in self.modules():
             if isinstance(module, BaseNode):
                 module.set_export_mode()
 
-        outputs = self.forward(inp.clone()).outputs
+        outputs = self.forward(inputs_deep_clone).outputs
         output_order = sorted(
             [
                 (node_name, output_name, i)
@@ -444,10 +503,13 @@ class LuxonisModel(pl.LightningModule):
             )
 
         self.forward = export_forward  # type: ignore
+
+        if "input_names" not in kwargs:
+            kwargs["input_names"] = list(inputs.keys())
         if "output_names" not in kwargs:
             kwargs["output_names"] = output_names
 
-        self.to_onnx(save_path, inp, **kwargs)
+        self.to_onnx(save_path, inputs_for_onnx, **kwargs)
 
         self.forward = old_forward  # type: ignore
 

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -280,8 +280,7 @@ class LuxonisModel(pl.LightningModule):
 
             node = Node(
                 input_shapes=node_input_shapes,
-                original_in_shape=self.original_in_shape,
-                images_name=self.images_name,
+                original_in_shape=self.original_in_shape[self.images_name],
                 dataset_metadata=self.dataset_metadata,
                 **node_kwargs,
             )

--- a/luxonis_train/models/luxonis_output.py
+++ b/luxonis_train/models/luxonis_output.py
@@ -3,7 +3,7 @@ from pprint import pformat
 
 from torch import Tensor
 
-from luxonis_train.utils.general import get_shape_packet
+from luxonis_train.utils.general import to_shape_packet
 from luxonis_train.utils.types import Packet
 
 
@@ -16,7 +16,7 @@ class LuxonisOutput:
 
     def __str__(self) -> str:
         outputs = {
-            node_name: get_shape_packet(packet)
+            node_name: to_shape_packet(packet)
             for node_name, packet in self.outputs.items()
         }
         viz = {

--- a/luxonis_train/nodes/base_node.py
+++ b/luxonis_train/nodes/base_node.py
@@ -86,7 +86,6 @@ class BaseNode(
         *,
         input_shapes: list[Packet[Size]] | None = None,
         original_in_shape: Size | None = None,
-        images_name: str = "features",
         dataset_metadata: DatasetMetadata | None = None,
         attach_index: AttachIndexType | None = None,
         in_protocols: list[type[BaseModel]] | None = None,
@@ -120,7 +119,6 @@ class BaseNode(
 
         self._input_shapes = input_shapes
         self._original_in_shape = original_in_shape
-        self._images_name = images_name
         if n_classes is not None:
             if dataset_metadata is not None:
                 raise ValueError("Cannot set both `dataset_metadata` and `n_classes`.")
@@ -135,14 +133,6 @@ class BaseNode(
             f"{self.__class__.__name__} is trying to access `{name}`, "
             "but it was not set during initialization. "
         )
-
-    @property
-    def images_name(self) -> str:
-        """Getter for the images name (name of the key from the loader which contains
-        images)."""
-        if self._images_name is None:
-            raise self._non_set_error("images_name")
-        return self._images_name
 
     @property
     def task(self) -> str:
@@ -216,13 +206,13 @@ class BaseNode(
         if self._in_sizes is not None:
             return self._in_sizes
 
-        features = self.input_shapes[0].get(self._images_name)
+        features = self.input_shapes[0].get("features")
         if features is None:
             raise IncompatibleException(
-                f"Images field '{self._images_name}' is missing in {self.__class__.__name__}. "
+                f"Feature field is missing in {self.__class__.__name__}. "
                 "The default implementation of `in_sizes` cannot be used."
             )
-        shapes = self.get_attached(self.input_shapes[0][self._images_name])
+        shapes = self.get_attached(self.input_shapes[0]["features"])
         if isinstance(shapes, list) and len(shapes) == 1:
             return shapes[0]
         return shapes

--- a/luxonis_train/nodes/bisenet_head.py
+++ b/luxonis_train/nodes/bisenet_head.py
@@ -32,7 +32,7 @@ class BiSeNetHead(BaseNode[Tensor, Tensor]):
         """
         super().__init__(task=LabelType.SEGMENTATION, **kwargs)
 
-        original_height = self.original_in_shape[self.images_name][1]
+        original_height = self.original_in_shape[1]
         upscale_factor = 2 ** infer_upscale_factor(self.in_height, original_height)
         out_channels = self.n_classes * upscale_factor * upscale_factor
 

--- a/luxonis_train/nodes/bisenet_head.py
+++ b/luxonis_train/nodes/bisenet_head.py
@@ -32,7 +32,7 @@ class BiSeNetHead(BaseNode[Tensor, Tensor]):
         """
         super().__init__(task_type=LabelType.SEGMENTATION, **kwargs)
 
-        original_height = self.original_in_shape[2]
+        original_height = self.original_in_shape[self.images_name][1]
         upscale_factor = 2 ** infer_upscale_factor(self.in_height, original_height)
         out_channels = self.n_classes * upscale_factor * upscale_factor
 

--- a/luxonis_train/nodes/efficient_bbox_head.py
+++ b/luxonis_train/nodes/efficient_bbox_head.py
@@ -126,7 +126,7 @@ class EfficientBBoxHead(
         """Returns correct stride for number of heads and attach index."""
         stride = torch.tensor(
             [
-                self.original_in_shape[self.images_name][1] / x[1]  # type: ignore
+                self.original_in_shape[1] / x[1]  # type: ignore
                 for x in self.in_sizes[: self.n_heads]
             ],
             dtype=torch.int,

--- a/luxonis_train/nodes/efficient_bbox_head.py
+++ b/luxonis_train/nodes/efficient_bbox_head.py
@@ -126,7 +126,7 @@ class EfficientBBoxHead(
         """Returns correct stride for number of heads and attach index."""
         stride = torch.tensor(
             [
-                self.original_in_shape[2] / x[2]  # type: ignore
+                self.original_in_shape[self.images_name][1] / x[1]  # type: ignore
                 for x in self.in_sizes[: self.n_heads]
             ],
             dtype=torch.int,

--- a/luxonis_train/nodes/implicit_keypoint_bbox_head.py
+++ b/luxonis_train/nodes/implicit_keypoint_bbox_head.py
@@ -218,7 +218,7 @@ class ImplicitKeypointBBoxHead(BaseNode):
         out_channel_list = channel_list[: self.num_heads]
         stride = torch.tensor(
             [
-                self.original_in_shape[self.images_name][1] / h
+                self.original_in_shape[1] / h
                 for h in cast(list[int], self.in_height)[: self.num_heads]
             ],
             dtype=torch.int,

--- a/luxonis_train/nodes/implicit_keypoint_bbox_head.py
+++ b/luxonis_train/nodes/implicit_keypoint_bbox_head.py
@@ -218,7 +218,7 @@ class ImplicitKeypointBBoxHead(BaseNode):
         out_channel_list = channel_list[: self.num_heads]
         stride = torch.tensor(
             [
-                self.original_in_shape[2] / h
+                self.original_in_shape[self.images_name][1] / h
                 for h in cast(list[int], self.in_height)[: self.num_heads]
             ],
             dtype=torch.int,

--- a/luxonis_train/nodes/segmentation_head.py
+++ b/luxonis_train/nodes/segmentation_head.py
@@ -4,7 +4,6 @@ Adapted from: U{https://github.com/pytorch/vision/blob/main/torchvision/models/s
 @license: U{BSD-3 <https://github.com/pytorch/vision/blob/main/LICENSE>}
 """
 
-
 import torch.nn as nn
 from torch import Tensor
 
@@ -29,7 +28,7 @@ class SegmentationHead(BaseNode[Tensor, Tensor]):
         """
         super().__init__(_task_type=LabelType.SEGMENTATION, **kwargs)
 
-        original_height = self.original_in_shape[self.images_name][1]
+        original_height = self.original_in_shape[1]
         num_up = infer_upscale_factor(self.in_height, original_height, strict=False)
 
         modules = []

--- a/luxonis_train/nodes/segmentation_head.py
+++ b/luxonis_train/nodes/segmentation_head.py
@@ -29,7 +29,7 @@ class SegmentationHead(BaseNode[Tensor, Tensor]):
         """
         super().__init__(task_type=LabelType.SEGMENTATION, **kwargs)
 
-        original_height = self.original_in_shape[2]
+        original_height = self.original_in_shape[self.images_name][1]
         num_up = infer_upscale_factor(self.in_height, original_height, strict=False)
 
         modules = []

--- a/luxonis_train/utils/boxutils.py
+++ b/luxonis_train/utils/boxutils.py
@@ -434,7 +434,7 @@ def anchors_from_dataset(
         inputs = inp
     assert inputs is not None, "No inputs found in data loader"
     _, _, h, w = inputs[
-        loader.dataset.images_name
+        loader.dataset.image_source  # type: ignore
     ].shape  # assuming all images are same size
     img_size = torch.tensor([w, h])
     wh = torch.vstack(widths) * img_size

--- a/luxonis_train/utils/boxutils.py
+++ b/luxonis_train/utils/boxutils.py
@@ -433,7 +433,9 @@ def anchors_from_dataset(
         widths.append(curr_wh)
         inputs = inp
     assert inputs is not None, "No inputs found in data loader"
-    _, _, h, w = inputs.shape  # assuming all images are same size
+    _, _, h, w = inputs[
+        loader.dataset.images_name
+    ].shape  # assuming all images are same size
     img_size = torch.tensor([w, h])
     wh = torch.vstack(widths) * img_size
 

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -38,7 +38,8 @@ class FreezingConfig(CustomBaseModel):
 class ModelNodeConfig(CustomBaseModel):
     name: str
     alias: str | None = None
-    inputs: list[str] = []
+    inputs: list[str] = []  # From preceding nodes
+    input_sources: list[str] = []  # From data loader
     params: dict[str, Any] = {}
     freezing: FreezingConfig = FreezingConfig()
     task_group: str = "default"
@@ -131,6 +132,7 @@ class TrackerConfig(CustomBaseModel):
 
 class LoaderConfig(CustomBaseModel):
     name: str = "LuxonisLoaderTorch"
+    images_name: str = "features"
     train_view: str = "train"
     val_view: str = "val"
     test_view: str = "test"
@@ -169,7 +171,8 @@ class PreprocessingConfig(CustomBaseModel):
         return self
 
     def get_active_augmentations(self) -> list[AugmentationConfig]:
-        """Returns list of augmentations that are active
+        """Returns list of augmentations that are active.
+
         @rtype: list[AugmentationConfig]
         @return: Filtered list of active augmentation configs
         """

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -133,7 +133,7 @@ class TrackerConfig(CustomBaseModel):
 
 class LoaderConfig(CustomBaseModel):
     name: str = "LuxonisLoaderTorch"
-    images_name: str = "image"
+    image_source: str = "image"
     train_view: str = "train"
     val_view: str = "val"
     test_view: str = "test"

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -133,7 +133,7 @@ class TrackerConfig(CustomBaseModel):
 
 class LoaderConfig(CustomBaseModel):
     name: str = "LuxonisLoaderTorch"
-    images_name: str = "features"
+    images_name: str = "image"
     train_view: str = "train"
     val_view: str = "val"
     test_view: str = "test"

--- a/luxonis_train/utils/general.py
+++ b/luxonis_train/utils/general.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from copy import deepcopy
 from typing import Generator, TypeVar
 
 from pydantic import BaseModel
@@ -210,7 +211,7 @@ def infer_upscale_factor(
         )
 
 
-def get_shape_packet(packet: Packet[Tensor]) -> Packet[Size]:
+def to_shape_packet(packet: Packet[Tensor]) -> Packet[Size]:
     shape_packet: Packet[Size] = {}
     for name, value in packet.items():
         shape_packet[name] = [x.shape for x in value]
@@ -281,6 +282,7 @@ def traverse_graph(
     )  # sort the set to allow reproducibility
     processed: set[str] = set()
 
+    graph = deepcopy(graph)
     while unprocessed_nodes:
         unprocessed_nodes_copy = unprocessed_nodes.copy()
         for node_name in unprocessed_nodes_copy:

--- a/luxonis_train/utils/loaders/base_loader.py
+++ b/luxonis_train/utils/loaders/base_loader.py
@@ -27,21 +27,21 @@ class BaseLoaderTorch(
         self,
         view: str,
         augmentations: Augmentations | None = None,
-        images_name: str | None = None,
+        image_source: str | None = None,
     ):
         self.view = view
         self.augmentations = augmentations
-        self._images_name = images_name
+        self._image_source = image_source
 
     @property
-    def images_name(self) -> str:
+    def image_source(self) -> str:
         """Name of the input image group.
 
-        Example: 'features'
+        Example: 'image'
         """
-        if self._images_name is None:
-            raise ValueError("images_name is not set")
-        return self._images_name
+        if self._image_source is None:
+            raise ValueError("image_source is not set")
+        return self._image_source
 
     @property
     @abstractmethod

--- a/luxonis_train/utils/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/utils/loaders/luxonis_loader_torch.py
@@ -43,9 +43,9 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         return len(self.base_loader)
 
     @property
-    def input_shape(self) -> Size:
-        img, _ = self[0]
-        return Size([1, *img.shape])
+    def input_shape(self) -> dict[str, Size]:
+        img = self[0][0][self._images_name]
+        return {self._images_name: img.shape}
 
     def __getitem__(self, idx: int) -> LuxonisLoaderTorchOutput:
         img, group_annotations = self.base_loader[idx]
@@ -57,7 +57,7 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
             for key in annotations:
                 annotations[key] = Tensor(annotations[key])  # type: ignore
 
-        return tensor_img, group_annotations
+        return {self._images_name: tensor_img}, group_annotations
 
     def get_classes(self) -> dict[LabelType, list[str]]:
         _, classes = self.dataset.get_classes()

--- a/luxonis_train/utils/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/utils/loaders/luxonis_loader_torch.py
@@ -43,8 +43,8 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
 
     @property
     def input_shape(self) -> dict[str, Size]:
-        img = self[0][0][self.images_name]
-        return {self.images_name: img.shape}
+        img = self[0][0][self.image_source]
+        return {self.image_source: img.shape}
 
     def __getitem__(self, idx: int) -> LuxonisLoaderTorchOutput:
         img, labels = self.base_loader[idx]
@@ -55,7 +55,7 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         for task, (array, label_type) in labels.items():
             tensor_labels[task] = (Tensor(array), label_type)
 
-        return {self.images_name: tensor_img}, tensor_labels
+        return {self.image_source: tensor_img}, tensor_labels
 
     def get_classes(self) -> dict[str, list[str]]:
         _, classes = self.dataset.get_classes()

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">76%</text>
-        <text x="80" y="14">76%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
+        <text x="80" y="14">77%</text>
     </g>
 </svg>

--- a/tests/integration/test_multi_input.py
+++ b/tests/integration/test_multi_input.py
@@ -1,0 +1,195 @@
+import os
+import shutil
+from typing import Annotated
+
+import pytest
+import torch
+from pydantic import Field
+from torch import Tensor
+from torch.nn.parameter import Parameter
+
+from luxonis_train.core import Trainer
+from luxonis_train.nodes import BaseNode
+from luxonis_train.utils.loaders import BaseLoaderTorch
+from luxonis_train.utils.registry import LOADERS
+from luxonis_train.utils.types import BaseProtocol, FeaturesProtocol, LabelType
+
+LOADERS.register_module()
+
+
+class CustomMultiInputLoader(BaseLoaderTorch):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def input_shape(self):
+        return {
+            "left": torch.Size([3, 224, 224]),
+            "right": torch.Size([3, 224, 224]),
+            "disparity": torch.Size([1, 224, 224]),
+            "pointcloud": torch.Size([1000, 3]),
+        }
+
+    @property
+    def images_name(self):
+        return "left"
+
+    def __getitem__(self, idx):
+        # Fake data
+        left = torch.rand(3, 224, 224, dtype=torch.float32)
+        right = torch.rand(3, 224, 224, dtype=torch.float32)
+        disparity = torch.rand(1, 224, 224, dtype=torch.float32)
+        pointcloud = torch.rand(1000, 3, dtype=torch.float32)
+        inputs = {
+            "left": left,
+            "right": right,
+            "disparity": disparity,
+            "pointcloud": pointcloud,
+        }
+
+        # Fake labels
+        segmap = torch.zeros(1, 224, 224, dtype=torch.float32)
+        labels = {
+            "default": {
+                LabelType.SEGMENTATION: segmap,
+            }
+        }
+
+        return inputs, labels
+
+    def __len__(self):
+        return 10
+
+    def get_classes(self) -> dict[LabelType, list[str]]:
+        return {LabelType.SEGMENTATION: ["square"]}
+
+
+class FullCustomMultiInputProtocol(BaseProtocol):
+    left: Annotated[list[Tensor], Field(min_length=1)]
+    right: Annotated[list[Tensor], Field(min_length=1)]
+    disparity: Annotated[list[Tensor], Field(min_length=1)]
+    pointcloud: Annotated[list[Tensor], Field(min_length=1)]
+
+
+class RGBDCustomMultiInputProtocol(BaseProtocol):
+    left: Annotated[list[Tensor], Field(min_length=1)]
+    right: Annotated[list[Tensor], Field(min_length=1)]
+    disparity: Annotated[list[Tensor], Field(min_length=1)]
+
+
+class PointcloudCustomMultiInputProtocol(BaseProtocol):
+    pointcloud: Annotated[list[Tensor], Field(min_length=1)]
+
+
+class DisparityCustomMultiInputProtocol(BaseProtocol):
+    disparity: Annotated[list[Tensor], Field(min_length=1)]
+
+
+class MultiInputTestBaseNode(BaseNode):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.scalar = Parameter(torch.tensor(1.0), requires_grad=True)
+
+    def forward(self, inputs):
+        return [self.scalar * inp for inp in inputs]
+
+    def unwrap(self, inputs: list[dict[str, list[Tensor]]]):
+        return [item for inp in inputs for key in inp for item in inp[key]]
+
+
+class FullBackbone(MultiInputTestBaseNode):
+    def __init__(self, **kwargs):
+        in_protocols = [FullCustomMultiInputProtocol]
+        super().__init__(**kwargs)
+        self.in_protocols = in_protocols
+
+
+class RGBDBackbone(MultiInputTestBaseNode):
+    def __init__(self, **kwargs):
+        in_protocols = [RGBDCustomMultiInputProtocol]
+        super().__init__(**kwargs)
+        self.in_protocols = in_protocols
+
+
+class PointcloudBackbone(MultiInputTestBaseNode):
+    def __init__(self, **kwargs):
+        in_protocols = [PointcloudCustomMultiInputProtocol]
+        super().__init__(**kwargs)
+        self.in_protocols = in_protocols
+
+
+class FusionNeck(MultiInputTestBaseNode):
+    def __init__(self, **kwargs):
+        in_protocols = [
+            DisparityCustomMultiInputProtocol,
+            FeaturesProtocol,
+            FeaturesProtocol,
+        ]
+        super().__init__(**kwargs)
+        self.in_protocols = in_protocols
+
+
+class FusionNeck2(MultiInputTestBaseNode):
+    def __init__(self, **kwargs):
+        in_protocols = [FeaturesProtocol, FeaturesProtocol, FeaturesProtocol]
+        super().__init__(**kwargs)
+        self.in_protocols = in_protocols
+
+
+class CustomSegHead1(MultiInputTestBaseNode):
+    def __init__(self, **kwargs):
+        in_protocols = [FeaturesProtocol]
+        super().__init__(**kwargs)
+        self.in_protocols = in_protocols
+
+    def wrap(self, outputs: list[Tensor]):
+        return {"segmentation": outputs}
+
+
+class CustomSegHead2(MultiInputTestBaseNode):
+    def __init__(self, **kwargs):
+        in_protocols = [
+            DisparityCustomMultiInputProtocol,
+            FeaturesProtocol,
+            FeaturesProtocol,
+        ]
+        super().__init__(**kwargs)
+        self.in_protocols = in_protocols
+
+    def wrap(self, outputs: list[Tensor]):
+        return {"segmentation": outputs}
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_output():
+    shutil.rmtree("output", ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "config_file", [path for path in os.listdir("configs") if "multi_input" in path]
+)
+def test_sanity(config_file):
+    # opts = [
+    #     "trainer.epochs",
+    #     "3",
+    #     "trainer.validation_interval",
+    #     "3",
+    # ]
+
+    Trainer(f"configs/{config_file}").train()
+
+    # TODO add export and eval tests
+    # opts += ["model.weights", str(list(Path("output").rglob("*.ckpt"))[0])]
+    # opts += ["exporter.onnx.opset_version", "11"]
+
+    # result = subprocess.run(
+    #     ["luxonis_train", "export", "--config", f"configs/{config_file}", *opts],
+    # )
+
+    # assert result.returncode == 0
+
+    # result = subprocess.run(
+    #     ["luxonis_train", "eval", "--config", f"configs/{config_file}", *opts],
+    # )
+
+    # assert result.returncode == 0

--- a/tests/unittests/test_utils/test_loaders/test_base_loader.py
+++ b/tests/unittests/test_utils/test_loaders/test_base_loader.py
@@ -7,34 +7,65 @@ from luxonis_train.utils.loaders import (
 from luxonis_train.utils.types import LabelType
 
 
-def test_collate_fn():
+@pytest.mark.parametrize(
+    "input_names_and_shapes",
+    [
+        [("features", torch.Size([3, 224, 224]))],
+        [
+            ("features", torch.Size([3, 224, 224])),
+            ("segmentation", torch.Size([1, 224, 224])),
+        ],
+        [
+            ("features", torch.Size([3, 224, 224])),
+            ("segmentation", torch.Size([1, 224, 224])),
+            ("disparity", torch.Size([1, 224, 224])),
+        ],
+        [
+            ("features", torch.Size([3, 224, 224])),
+            ("pointcloud", torch.Size([1000, 3])),
+        ],
+        [
+            ("features", torch.Size([3, 224, 224])),
+            ("pointcloud", torch.Size([1000, 3])),
+            ("foobar", torch.Size([2, 3, 4, 5, 6])),
+        ],
+    ],
+)
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_collate_fn(input_names_and_shapes, batch_size):
     # Mock batch data
-    batch = [
-        (
-            torch.rand(3, 224, 224, dtype=torch.float32),
-            {"default": {LabelType.CLASSIFICATION: torch.tensor([1, 0])}},
-        ),
-        (
-            torch.rand(3, 224, 224, dtype=torch.float32),
-            {"default": {LabelType.CLASSIFICATION: torch.tensor([0, 1])}},
-        ),
-    ]
+
+    def build_batch_element():
+        inputs = {}
+        for name, shape in input_names_and_shapes:
+            inputs[name] = torch.rand(shape, dtype=torch.float32)
+
+        labels = {
+            "default": {
+                LabelType.CLASSIFICATION: torch.randint(0, 2, (2,), dtype=torch.int64),
+            }
+        }
+
+        return inputs, labels
+
+    batch = [build_batch_element() for _ in range(batch_size)]
 
     # Call collate_fn
-    imgs, annotations = collate_fn(batch)
+    inputs, annotations = collate_fn(batch)
 
     # Check images tensor
-    assert imgs.shape == (2, 3, 224, 224)
-    assert imgs.dtype == torch.float32
+    assert inputs["features"].shape == (batch_size, 3, 224, 224)
+    assert inputs["features"].dtype == torch.float32
 
     # Check annotations
     assert "default" in annotations
     annotations = annotations["default"]
     assert LabelType.CLASSIFICATION in annotations
-    assert annotations[LabelType.CLASSIFICATION].shape == (2, 2)
+    assert annotations[LabelType.CLASSIFICATION].shape == (batch_size, 2)
     assert annotations[LabelType.CLASSIFICATION].dtype == torch.int64
 
-    # TODO: test also segmentation, boundingbox and keypoint
+
+# TODO: test also segmentation, boundingbox and keypoint
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Motivation
The goal is to support multi-input models and loaders in luxonis-train. 

# Examples
## Multi-input loader

The loader simulates an input consisting of stereo images (left and right), disparity maps, and point clouds. It also identifies "left" as the primary image type, which can be used in visualizers.
```python
class CustomMultiInputLoader(BaseLoaderTorch):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

    @property
    def input_shape(self) -> dict[str, Size]:
        return {
            "left": torch.Size([3, 224, 224]),
            "right": torch.Size([3, 224, 224]),
            "disparity": torch.Size([1, 224, 224]),
            "pointcloud": torch.Size([1000, 3]),
        }

    @property
    def image_source(self) -> str:
        return "left"

    def __getitem__(self, idx):
        # Fake data
        left = torch.rand(3, 224, 224, dtype=torch.float32)
        right = torch.rand(3, 224, 224, dtype=torch.float32)
        disparity = torch.rand(1, 224, 224, dtype=torch.float32)
        pointcloud = torch.rand(1000, 3, dtype=torch.float32)
        inputs = {
            "left": left,
            "right": right,
            "disparity": disparity,
            "pointcloud": pointcloud,
        }

        # Fake labels
        segmap = torch.zeros(1, 224, 224, dtype=torch.float32)
        labels = {
            "segmentation": (segmap, LabelType.SEGMENTATION)
        }

        return inputs, labels

    def __len__(self):
        return 10

    def get_classes(self) -> dict[LabelType, list[str]]:
        return {LabelType.SEGMENTATION: ["square"]}
```
## Multi-input model

This model includes nodes such as FullBackbone, RGBDBackbone (processing left, right, and disparity inputs), and PointcloudBackbone (processing pointcloud inputs). It also features FusionNeck and FusionNeck2 for combining outputs from these backbones, and CustomSegHead1 and CustomSegHead2 which also make use of the different fusion necks and inputs. The model showcases our capability to handle intricate data fusion, multi-modal processing, and serving loader data to any node in the graph.
```yaml
model:
  name: example_multi_input
  nodes:
    - name: FullBackbone
      alias: full_backbone  # By default loads all loader sub-elements since no inputs nor input_sources are provided

    - name: RGBDBackbone
      alias: rgbd_backbone
      input_sources:
        - left
        - right
        - disparity

    - name: PointcloudBackbone
      alias: pointcloud_backbone
      input_sources:
        - pointcloud

    - name: FusionNeck
      alias: fusion_neck
      inputs:
        - rgbd_backbone
        - pointcloud_backbone
      input_sources:
        - disparity

    - name: FusionNeck2
      alias: fusion_neck_2
      inputs:
        - rgbd_backbone
        - pointcloud_backbone
        - full_backbone
    
    - name: CustomSegHead1
      alias: head_1
      inputs:
        - fusion_neck

    - name: CustomSegHead2
      alias: head_2
      inputs:
        - fusion_neck
        - fusion_neck_2
      input_sources:
        - disparity
```
# Test changes
[Updated collate_fn test ](https://github.com/luxonis/luxonis-train/pull/36/commits/6809f98e4f1b39b865175d2efed2c2cee87b44ea)due to how inputs were changed from `Tensor`s to `dict[str, Tensor]`.

# Breaking changes
Changed the type of `original_in_shape` of `LuxonisModel` from `Size` to `dict[str, Size]` (multiple inputs), so any custom models making use of this will stop working. To resolve this, users can make use of the new structure [like this](https://github.com/luxonis/luxonis-train/commit/0e1ceffb5ea35bfc9a201da063d1b322e894bc78). 
