### PR TITLE
Support for LuxonisML - Annotation Refactor

### DIFF
--- a/configs/resnet_multitask_model.yaml
+++ b/configs/resnet_multitask_model.yaml
@@ -1,0 +1,110 @@
+
+model:
+  name: resnet50_classification
+  nodes:
+    - name: ResNet
+      params:
+        variant: "50"
+        download_weights: True
+
+    - name: ClassificationHead
+      alias: ClassificationHead_1
+      task: classification_1
+      inputs:
+        - ResNet
+
+    - name: ClassificationHead
+      alias: ClassificationHead_2
+      task: classification_2
+      inputs:
+        - ResNet
+
+    - name: ClassificationHead
+      alias: ClassificationHead_3
+      task: classification_3
+      inputs:
+        - ResNet
+
+  losses:
+    - name: CrossEntropyLoss
+      alias: CrossEntropyLoss_1
+      attached_to: ClassificationHead_1
+
+    - name: CrossEntropyLoss
+      alias: CrossEntropyLoss_2
+      attached_to: ClassificationHead_2
+
+    - name: CrossEntropyLoss
+      alias: CrossEntropyLoss_3
+      attached_to: ClassificationHead_3
+
+  metrics:
+    - name: Accuracy
+      is_main_metric: true
+      alias: Accuracy_1
+      attached_to: ClassificationHead_1
+
+    - name: Accuracy
+      alias: Accuracy_2
+      attached_to: ClassificationHead_2
+
+    - name: Accuracy
+      alias: Accuracy_3
+      attached_to: ClassificationHead_3
+
+  visualizers:
+    - name: ClassificationVisualizer
+      alias: ClassificationVisualizer_1
+      attached_to: ClassificationHead_1
+      params:
+        font_scale: 0.5
+        color: [255, 0, 0]
+        thickness: 2
+        include_plot: True
+
+    - name: ClassificationVisualizer
+      alias: ClassificationVisualizer_2
+      attached_to: ClassificationHead_2
+      params:
+        font_scale: 0.5
+        color: [255, 0, 0]
+        thickness: 2
+        include_plot: True
+
+    - name: ClassificationVisualizer
+      alias: ClassificationVisualizer_3
+      attached_to: ClassificationHead_3
+      params:
+        font_scale: 0.5
+        color: [255, 0, 0]
+        thickness: 2
+        include_plot: True
+
+loader:
+  params:
+    dataset_name: cifar10_task_test
+
+trainer:
+  batch_size: 4
+  epochs: &epochs 200
+  num_workers: 4
+  validation_interval: 10
+  num_log_images: 8
+
+  preprocessing:
+    train_image_size: [&height 224, &width 224]
+    keep_aspect_ratio: False
+    normalize:
+      active: True
+
+  callbacks:
+    - name: ExportOnTrainEnd
+    - name: TestOnTrainEnd
+
+  optimizer:
+    name: SGD
+    params:
+      lr: 0.02
+
+  scheduler:
+    name: ConstantLR

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -110,10 +110,7 @@ def inspect(
 ):
     """Inspect dataset."""
     from lightning.pytorch import seed_everything
-    from luxonis_ml.data import (
-        TrainAugmentations,
-        ValAugmentations,
-    )
+    from luxonis_ml.data import Augmentations
 
     from luxonis_train.attached_modules.visualizers.utils import (
         draw_bounding_box_labels,
@@ -139,13 +136,14 @@ def inspect(
 
     image_size = cfg.trainer.preprocessing.train_image_size
 
-    augmentations = (TrainAugmentations if view == "train" else ValAugmentations)(
+    augmentations = Augmentations(
         image_size=image_size,
         augmentations=[
             i.model_dump() for i in cfg.trainer.preprocessing.get_active_augmentations()
         ],
         train_rgb=cfg.trainer.preprocessing.train_rgb,
         keep_aspect_ratio=cfg.trainer.preprocessing.keep_aspect_ratio,
+        only_normalize=view != "train",
     )
 
     loader = LOADERS.get(cfg.loader.name)(
@@ -178,7 +176,7 @@ def inspect(
                             colors="yellow",
                             width=1,
                         )
-                    elif label_type == LabelType.KEYPOINT:
+                    elif label_type == LabelType.KEYPOINTS:
                         img = draw_keypoint_labels(
                             img, labels[labels[:, 0] == i][:, 1:], colors="red"
                         )

--- a/luxonis_train/attached_modules/base_attached_module.py
+++ b/luxonis_train/attached_modules/base_attached_module.py
@@ -74,6 +74,22 @@ class BaseAttachedModule(
             )
         return self._node
 
+    @property
+    def task(self) -> str:
+        """Task of the node that this module is attached to.
+
+        @rtype: str
+        """
+        if self.required_labels and len(self.required_labels) == 1:
+            return self.required_labels[0].value
+        task = self.node.task
+        if task is None:
+            raise RuntimeError(
+                "Attempt to access `task` reference, but the node does not have a task. ",
+                f"You have to specify the task in the configuration for node {self.node.__class__.__name__}.",
+            )
+        return task
+
     def prepare(self, inputs: Packet[Tensor], labels: Labels) -> tuple[Unpack[Ts]]:
         """Prepares node outputs for the forward pass of the module.
 
@@ -102,20 +118,13 @@ class BaseAttachedModule(
                 "This module requires multiple labels, the default `prepare` "
                 "implementation does not support this."
             )
-        if not self.required_labels:
-            if "boxes" in inputs and LabelType.BOUNDINGBOX in labels:
-                return inputs["boxes"], labels[LabelType.BOUNDINGBOX]  # type: ignore
-            if "classes" in inputs and LabelType.CLASSIFICATION in labels:
-                return inputs["classes"][0], labels[LabelType.CLASSIFICATION]  # type: ignore
-            if "keypoints" in inputs and LabelType.KEYPOINT in labels:
-                return inputs["keypoints"], labels[LabelType.KEYPOINT]  # type: ignore
-            if "segmentation" in inputs and LabelType.SEGMENTATION in labels:
-                return inputs["segmentation"][0], labels[LabelType.SEGMENTATION]  # type: ignore
-            raise IncompatibleException(
-                f"No matching labels and outputs found for {self.__class__.__name__}"
-            )
-        label_type = self.required_labels[0]
-        return inputs[label_type.value], labels[label_type]  # type: ignore
+        x = inputs[self.task]
+        label, label_type = labels[self.task]
+        if label_type in [LabelType.CLASSIFICATION, LabelType.SEGMENTATION]:
+            if isinstance(x, list) and len(x) == 1:
+                x = x[0]
+
+        return x, label  # type: ignore
 
     def validate(self, inputs: Packet[Tensor], labels: Labels) -> None:
         """Validates that the inputs and labels are compatible with the module.
@@ -126,11 +135,10 @@ class BaseAttachedModule(
         @param labels: Labels from the dataset. @raises L{IncompatibleException}: If the
             inputs are not compatible with the module.
         """
-        for label in self.required_labels:
-            if label not in labels:
-                raise IncompatibleException.from_missing_label(
-                    label, list(labels.keys()), self.__class__.__name__
-                )
+        if self.node.task is not None and self.node.task not in labels:
+            raise IncompatibleException.from_missing_task(
+                self.node.task, list(labels.keys()), self.__class__.__name__
+            )
 
         if self.protocol is not None:
             try:

--- a/luxonis_train/attached_modules/losses/adaptive_detection_loss.py
+++ b/luxonis_train/attached_modules/losses/adaptive_detection_loss.py
@@ -104,7 +104,7 @@ class AdaptiveDetectionLoss(BaseLoss[Tensor, Tensor, Tensor, Tensor, Tensor, Ten
         batch_size = pred_scores.shape[0]
         device = pred_scores.device
 
-        target = labels[LabelType.BOUNDINGBOX].to(device)
+        target = labels[self.task][0].to(device)
         gt_bboxes_scale = torch.tensor(
             [
                 self.original_img_size[1],

--- a/luxonis_train/attached_modules/losses/implicit_keypoint_bbox_loss.py
+++ b/luxonis_train/attached_modules/losses/implicit_keypoint_bbox_loss.py
@@ -89,7 +89,7 @@ class ImplicitKeypointBBoxLoss(BaseLoss[list[Tensor], KeypointTargetType]):
         """
 
         super().__init__(
-            required_labels=[LabelType.BOUNDINGBOX, LabelType.KEYPOINT],
+            required_labels=[LabelType.BOUNDINGBOX, LabelType.KEYPOINTS],
             **kwargs,
         )
 
@@ -165,8 +165,8 @@ class ImplicitKeypointBBoxLoss(BaseLoss[list[Tensor], KeypointTargetType]):
         """
         predictions = outputs["features"]
 
-        kpts = labels[LabelType.KEYPOINT]
-        boxes = labels[LabelType.BOUNDINGBOX]
+        kpts = labels["keypoints"][0]
+        boxes = labels["boundingbox"][0]
 
         nkpts = (kpts.shape[1] - 2) // 3
         targets = torch.zeros((len(boxes), nkpts * 2 + self.box_offset + 1))

--- a/luxonis_train/attached_modules/losses/keypoint_loss.py
+++ b/luxonis_train/attached_modules/losses/keypoint_loss.py
@@ -29,7 +29,7 @@ class KeypointLoss(BaseLoss[Tensor, Tensor]):
         **kwargs,
     ):
         super().__init__(
-            protocol=Protocol, required_labels=[LabelType.KEYPOINT], **kwargs
+            protocol=Protocol, required_labels=[LabelType.KEYPOINTS], **kwargs
         )
         self.b_cross_entropy = BCEWithLogitsLoss(
             pos_weight=torch.tensor([bce_power]), **kwargs
@@ -38,7 +38,7 @@ class KeypointLoss(BaseLoss[Tensor, Tensor]):
         self.visibility_weight = visibility_weight
 
     def prepare(self, inputs: Packet[Tensor], labels: Labels) -> tuple[Tensor, Tensor]:
-        return torch.cat(inputs["keypoints"], dim=0), labels[LabelType.KEYPOINT]
+        return torch.cat(inputs["keypoints"], dim=0), labels[LabelType.KEYPOINTS]
 
     def forward(
         self, prediction: Tensor, target: Tensor

--- a/luxonis_train/attached_modules/metrics/common.py
+++ b/luxonis_train/attached_modules/metrics/common.py
@@ -27,9 +27,9 @@ class TorchMetricWrapper(BaseMetric):
                 f"assuming {task}."
             )
             kwargs["task"] = task
-        self.task = task
+        self._task = task
 
-        if self.task == "multiclass":
+        if self._task == "multiclass":
             if "num_classes" not in kwargs:
                 if self.node is None:
                     raise ValueError(
@@ -37,7 +37,7 @@ class TorchMetricWrapper(BaseMetric):
                         "multiclass torchmetrics."
                     )
                 kwargs["num_classes"] = self.node.n_classes
-        elif self.task == "multilabel":
+        elif self._task == "multilabel":
             if "num_labels" not in kwargs:
                 if self.node is None:
                     raise ValueError(
@@ -49,7 +49,7 @@ class TorchMetricWrapper(BaseMetric):
         self.metric = self.Metric(**kwargs)
 
     def update(self, preds, target, *args, **kwargs) -> None:
-        if self.task in ["multiclass"]:
+        if self._task in ["multiclass"]:
             target = target.argmax(dim=1)
         self.metric.update(preds, target, *args, **kwargs)
 

--- a/luxonis_train/attached_modules/metrics/mean_average_precision.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision.py
@@ -38,8 +38,8 @@ class MeanAveragePrecision(BaseMetric):
     def prepare(
         self, outputs: Packet[Tensor], labels: Labels
     ) -> tuple[list[dict[str, Tensor]], list[dict[str, Tensor]]]:
-        label = labels[LabelType.BOUNDINGBOX]
-        output_nms = outputs["boxes"]
+        label = labels[self.task][0]
+        output_nms = outputs["boundingbox"]
 
         image_size = self.node.original_in_shape[2:]
 

--- a/luxonis_train/attached_modules/metrics/mean_average_precision.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision.py
@@ -39,7 +39,7 @@ class MeanAveragePrecision(BaseMetric):
         self, outputs: Packet[Tensor], labels: Labels
     ) -> tuple[list[dict[str, Tensor]], list[dict[str, Tensor]]]:
         label = labels[self.task][0]
-        output_nms = outputs["boundingbox"]
+        output_nms = outputs[self.node.task]
 
         image_size = self.node.original_in_shape[2:]
 

--- a/luxonis_train/attached_modules/metrics/mean_average_precision.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision.py
@@ -39,7 +39,7 @@ class MeanAveragePrecision(BaseMetric):
         self, outputs: Packet[Tensor], labels: Labels
     ) -> tuple[list[dict[str, Tensor]], list[dict[str, Tensor]]]:
         label = labels[self.task][0]
-        output_nms = outputs[self.node.task]
+        output_nms = self.get_input_tensors(outputs)
 
         image_size = self.node.original_in_shape[2:]
 

--- a/luxonis_train/attached_modules/metrics/mean_average_precision_keypoints.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision_keypoints.py
@@ -68,7 +68,7 @@ class MeanAveragePrecisionKeypoints(BaseMetric):
         """
         super().__init__(
             protocol=Protocol,
-            required_labels=[LabelType.BOUNDINGBOX, LabelType.KEYPOINT],
+            required_labels=[LabelType.BOUNDINGBOX, LabelType.KEYPOINTS],
             **kwargs,
         )
 
@@ -97,8 +97,8 @@ class MeanAveragePrecisionKeypoints(BaseMetric):
         self.add_state("groundtruth_keypoints", default=[], dist_reduce_fx=None)
 
     def prepare(self, outputs: Packet[Tensor], labels: Labels):
-        kpts = labels[LabelType.KEYPOINT]
-        boxes = labels[LabelType.BOUNDINGBOX]
+        kpts = labels["keypoints"][0]
+        boxes = labels["boundingbox"][0]
         nkpts = (kpts.shape[1] - 2) // 3
         label = torch.zeros((len(boxes), nkpts * 3 + 6))
         label[:, :2] = boxes[:, :2]
@@ -112,7 +112,7 @@ class MeanAveragePrecisionKeypoints(BaseMetric):
         image_size = self.node.original_in_shape[2:]
 
         output_kpts: list[Tensor] = outputs["keypoints"]
-        output_bboxes: list[Tensor] = outputs["boxes"]
+        output_bboxes: list[Tensor] = outputs["boundingbox"]
         for i in range(len(output_kpts)):
             output_list_kpt_map.append(
                 {

--- a/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
+++ b/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
@@ -46,7 +46,7 @@ class ObjectKeypointSimilarity(
         **kwargs,
     ) -> None:
         super().__init__(
-            required_labels=[LabelType.KEYPOINT], protocol=KeypointProtocol, **kwargs
+            required_labels=[LabelType.KEYPOINTS], protocol=KeypointProtocol, **kwargs
         )
 
         if n_keypoints is None and self.node is None:
@@ -67,8 +67,8 @@ class ObjectKeypointSimilarity(
     def prepare(
         self, outputs: Packet[Tensor], labels: Labels
     ) -> tuple[list[dict[str, Tensor]], list[dict[str, Tensor]]]:
-        kpts_labels = labels[LabelType.KEYPOINT]
-        bbox_labels = labels[LabelType.BOUNDINGBOX]
+        kpts_labels = labels["keypoints"][0]
+        bbox_labels = labels["boundingbox"][0]
         num_keypoints = (kpts_labels.shape[1] - 2) // 3
         label = torch.zeros((len(bbox_labels), num_keypoints * 3 + 6))
         label[:, :2] = bbox_labels[:, :2]

--- a/luxonis_train/attached_modules/visualizers/keypoint_visualizer.py
+++ b/luxonis_train/attached_modules/visualizers/keypoint_visualizer.py
@@ -4,9 +4,7 @@ import torch
 from torch import Tensor
 
 from luxonis_train.utils.types import (
-    Labels,
     LabelType,
-    Packet,
 )
 
 from .base_visualizer import BaseVisualizer
@@ -42,16 +40,16 @@ class KeypointVisualizer(BaseVisualizer[list[Tensor], Tensor]):
         @param nonvisible_color: Color of nonvisible keypoints. If C{None}, nonvisible
             keypoints are not drawn. Defaults to C{None}.
         """
-        super().__init__(required_labels=[LabelType.KEYPOINT], **kwargs)
+        super().__init__(required_labels=[LabelType.KEYPOINTS], **kwargs)
         self.visibility_threshold = visibility_threshold
         self.connectivity = connectivity
         self.visible_color = visible_color
         self.nonvisible_color = nonvisible_color
 
-    def prepare(
-        self, output: Packet[Tensor], label: Labels
-    ) -> tuple[list[Tensor], Tensor]:
-        return output["keypoints"], label[LabelType.KEYPOINT]
+    # def prepare(
+    #     self, output: Packet[Tensor], label: Labels
+    # ) -> tuple[list[Tensor], Tensor]:
+    #     return output[self.task], label[self.task][0]
 
     @staticmethod
     def draw_predictions(

--- a/luxonis_train/attached_modules/visualizers/keypoint_visualizer.py
+++ b/luxonis_train/attached_modules/visualizers/keypoint_visualizer.py
@@ -46,11 +46,6 @@ class KeypointVisualizer(BaseVisualizer[list[Tensor], Tensor]):
         self.visible_color = visible_color
         self.nonvisible_color = nonvisible_color
 
-    # def prepare(
-    #     self, output: Packet[Tensor], label: Labels
-    # ) -> tuple[list[Tensor], Tensor]:
-    #     return output[self.task], label[self.task][0]
-
     @staticmethod
     def draw_predictions(
         canvas: Tensor,

--- a/luxonis_train/attached_modules/visualizers/segmentation_visualizer.py
+++ b/luxonis_train/attached_modules/visualizers/segmentation_visualizer.py
@@ -45,7 +45,7 @@ class SegmentationVisualizer(BaseVisualizer[Tensor, Tensor]):
         self.alpha = alpha
 
     def prepare(self, output: Packet[Tensor], label: Labels) -> tuple[Tensor, Tensor]:
-        return output["segmentation"][0], label[self.task][0]
+        return output[self.node.task][0], label[self.task][0]
 
     @staticmethod
     def draw_predictions(

--- a/luxonis_train/attached_modules/visualizers/segmentation_visualizer.py
+++ b/luxonis_train/attached_modules/visualizers/segmentation_visualizer.py
@@ -45,7 +45,7 @@ class SegmentationVisualizer(BaseVisualizer[Tensor, Tensor]):
         self.alpha = alpha
 
     def prepare(self, output: Packet[Tensor], label: Labels) -> tuple[Tensor, Tensor]:
-        return output["segmentation"][0], label[LabelType.SEGMENTATION]
+        return output["segmentation"][0], label[self.task][0]
 
     @staticmethod
     def draw_predictions(

--- a/luxonis_train/core/archiver.py
+++ b/luxonis_train/core/archiver.py
@@ -243,7 +243,7 @@ class Archiver(Core):
         if head_family.startswith("Classification"):
             return self.dataset_metadata._classes["class"]
         elif head_family.startswith("Object"):
-            return self.dataset_metadata._classes["boxes"]
+            return self.dataset_metadata._classes["boundingbox"]
         elif head_family.startswith("Segmentation"):
             return self.dataset_metadata._classes["segmentation"]
         elif head_family.startswith("Keypoint"):

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -9,7 +9,7 @@ import rich.traceback
 import torch
 import torch.utils.data as torch_data
 from lightning.pytorch.utilities import rank_zero_only  # type: ignore
-from luxonis_ml.data import TrainAugmentations, ValAugmentations
+from luxonis_ml.data import Augmentations
 from luxonis_ml.utils import reset_logging, setup_logging
 
 from luxonis_train.callbacks import LuxonisProgressBar
@@ -99,7 +99,7 @@ class Core:
             pl.seed_everything(self.cfg.trainer.seed, workers=True)
             deterministic = True
 
-        self.train_augmentations = TrainAugmentations(
+        self.train_augmentations = Augmentations(
             image_size=self.cfg.trainer.preprocessing.train_image_size,
             augmentations=[
                 i.model_dump()
@@ -108,7 +108,7 @@ class Core:
             train_rgb=self.cfg.trainer.preprocessing.train_rgb,
             keep_aspect_ratio=self.cfg.trainer.preprocessing.keep_aspect_ratio,
         )
-        self.val_augmentations = ValAugmentations(
+        self.val_augmentations = Augmentations(
             image_size=self.cfg.trainer.preprocessing.train_image_size,
             augmentations=[
                 i.model_dump()
@@ -116,6 +116,7 @@ class Core:
             ],
             train_rgb=self.cfg.trainer.preprocessing.train_rgb,
             keep_aspect_ratio=self.cfg.trainer.preprocessing.keep_aspect_ratio,
+            only_normalize=True,
         )
 
         self.pl_trainer = pl.Trainer(
@@ -152,7 +153,7 @@ class Core:
         }
         sampler = None
         if self.cfg.trainer.use_weighted_sampler:
-            classes_count = self.dataset.get_classes()[1]
+            classes_count = self.loaders["train"].get_classes()[1]
             if len(classes_count) == 0:
                 logger.warning(
                     "WeightedRandomSampler only available for classification tasks. Using default sampler instead."
@@ -183,15 +184,15 @@ class Core:
 
         self.cfg.save_data(os.path.join(self.run_save_dir, "config.yaml"))
 
-    def set_train_augmentations(self, aug: TrainAugmentations) -> None:
+    def set_train_augmentations(self, aug: Augmentations) -> None:
         """Sets augmentations used for training dataset."""
         self.train_augmentations = aug
 
-    def set_val_augmentations(self, aug: ValAugmentations) -> None:
+    def set_val_augmentations(self, aug: Augmentations) -> None:
         """Sets augmentations used for validation dataset."""
         self.val_augmentations = aug
 
-    def set_test_augmentations(self, aug: ValAugmentations) -> None:
+    def set_test_augmentations(self, aug: Augmentations) -> None:
         """Sets augmentations used for test dataset."""
         self.test_augmentations = aug
 

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -38,7 +38,7 @@ from luxonis_train.utils.general import (
 )
 from luxonis_train.utils.registry import CALLBACKS, OPTIMIZERS, SCHEDULERS, Registry
 from luxonis_train.utils.tracker import LuxonisTrackerPL
-from luxonis_train.utils.types import Kwargs, Labels, Packet, TaskLabels
+from luxonis_train.utils.types import Kwargs, Labels, Packet
 
 from .luxonis_output import LuxonisOutput
 
@@ -143,13 +143,10 @@ class LuxonisModel(pl.LightningModule):
         frozen_nodes: list[tuple[str, int]] = []
         nodes: dict[str, tuple[type[BaseNode], Kwargs]] = {}
 
-        self.node_tasks: dict[str, str] = {}
-
         for node_cfg in self.cfg.model.nodes:
             node_name = node_cfg.name
             Node = BaseNode.REGISTRY.get(node_name)
             node_name = node_cfg.alias or node_name
-            self.node_tasks[node_name] = node_cfg.task_group
             if node_cfg.freezing.active:
                 epochs = self.cfg.trainer.epochs
                 if node_cfg.freezing.unfreeze_after is None:
@@ -159,7 +156,7 @@ class LuxonisModel(pl.LightningModule):
                 else:
                     unfreeze_after = int(node_cfg.freezing.unfreeze_after * epochs)
                 frozen_nodes.append((node_name, unfreeze_after))
-            nodes[node_name] = (Node, node_cfg.params)
+            nodes[node_name] = (Node, {**node_cfg.params, "task": node_cfg.task})
             if not node_cfg.inputs:
                 self.input_shapes[node_name] = [Size(input_shape)]
             self.graph[node_name] = node_cfg.inputs
@@ -251,7 +248,7 @@ class LuxonisModel(pl.LightningModule):
     def forward(
         self,
         inputs: Tensor,
-        task_labels: TaskLabels | None = None,
+        labels: Labels | None = None,
         images: Tensor | None = None,
         *,
         compute_loss: bool = True,
@@ -303,7 +300,6 @@ class LuxonisModel(pl.LightningModule):
             node_inputs = [computed[pred] for pred in input_names]
             outputs = node.run(node_inputs)
             computed[node_name] = outputs
-            labels = task_labels[self.node_tasks[node_name]] if task_labels else None
 
             if compute_loss and node_name in self.losses and labels is not None:
                 for loss_name, loss in self.losses[node_name].items():
@@ -500,7 +496,7 @@ class LuxonisModel(pl.LightningModule):
         training_step_output["loss"] = final_loss.detach().cpu()
         return final_loss, training_step_output
 
-    def training_step(self, train_batch: tuple[Tensor, TaskLabels]) -> Tensor:
+    def training_step(self, train_batch: tuple[Tensor, Labels]) -> Tensor:
         """Performs one step of training with provided batch."""
         outputs = self.forward(*train_batch)
         assert outputs.losses, "Losses are empty, check if you have defined any loss"

--- a/luxonis_train/nodes/base_node.py
+++ b/luxonis_train/nodes/base_node.py
@@ -91,7 +91,8 @@ class BaseNode(
         in_protocols: list[type[BaseModel]] | None = None,
         n_classes: int | None = None,
         in_sizes: Size | list[Size] | None = None,
-        task_type: LabelType | None = None,
+        task: str | None = None,
+        _task_type: LabelType | None = None,
     ):
         super().__init__()
 
@@ -111,7 +112,10 @@ class BaseNode(
             self.attach_index = attach_index
 
         self.in_protocols = in_protocols or [FeaturesProtocol]
-        self.task_type = task_type
+        self._task_type = _task_type
+        if task is None and self._task_type is not None:
+            task = self._task_type.value
+        self._task = task
 
         self._input_shapes = input_shapes
         self._original_in_shape = original_in_shape
@@ -131,14 +135,21 @@ class BaseNode(
         )
 
     @property
+    def task(self) -> str:
+        """Getter for the task."""
+        if self._task is None:
+            raise self._non_set_error("task")
+        return self._task
+
+    @property
     def n_classes(self) -> int:
         """Getter for the number of classes."""
-        return self.dataset_metadata.n_classes(self.task_type)
+        return self.dataset_metadata.n_classes(self.task)
 
     @property
     def class_names(self) -> list[str]:
         """Getter for the class names."""
-        return self.dataset_metadata.class_names(self.task_type)
+        return self.dataset_metadata.class_names(self.task)
 
     @property
     def input_shapes(self) -> list[Packet[Size]]:
@@ -312,7 +323,7 @@ class BaseNode(
                 raise IncompatibleException(
                     "Default `wrap` expects a single tensor or a list of tensors."
                 )
-        return {"features": outputs}
+        return {self._task or "features": outputs}
 
     def run(self, inputs: list[Packet[Tensor]]) -> Packet[Tensor]:
         """Combines the forward pass with the wrapping and unwrapping of the inputs.

--- a/luxonis_train/nodes/bisenet_head.py
+++ b/luxonis_train/nodes/bisenet_head.py
@@ -41,7 +41,7 @@ class BiSeNetHead(BaseNode[Tensor, Tensor]):
         self.upscale = nn.PixelShuffle(upscale_factor)
 
     def wrap(self, output: Tensor) -> Packet[Tensor]:
-        return {"segmentation": [output]}
+        return {self.task: [output]}
 
     def forward(self, inputs: Tensor) -> Tensor:
         x = self.conv_3x3(inputs)

--- a/luxonis_train/nodes/bisenet_head.py
+++ b/luxonis_train/nodes/bisenet_head.py
@@ -41,7 +41,7 @@ class BiSeNetHead(BaseNode[Tensor, Tensor]):
         self.upscale = nn.PixelShuffle(upscale_factor)
 
     def wrap(self, output: Tensor) -> Packet[Tensor]:
-        return {self.task: [output]}
+        return {"segmentation": [output]}
 
     def forward(self, inputs: Tensor) -> Tensor:
         x = self.conv_3x3(inputs)

--- a/luxonis_train/nodes/bisenet_head.py
+++ b/luxonis_train/nodes/bisenet_head.py
@@ -30,7 +30,7 @@ class BiSeNetHead(BaseNode[Tensor, Tensor]):
         @param intermediate_channels: How many intermediate channels to use.
             Defaults to C{64}.
         """
-        super().__init__(task_type=LabelType.SEGMENTATION, **kwargs)
+        super().__init__(task=LabelType.SEGMENTATION, **kwargs)
 
         original_height = self.original_in_shape[2]
         upscale_factor = 2 ** infer_upscale_factor(self.in_height, original_height)

--- a/luxonis_train/nodes/classification_head.py
+++ b/luxonis_train/nodes/classification_head.py
@@ -34,4 +34,4 @@ class ClassificationHead(BaseNode[Tensor, Tensor]):
         return self.head(inputs)
 
     def wrap(self, output: Tensor) -> Packet[Tensor]:
-        return {self.task: [output]}
+        return {"classification": [output]}

--- a/luxonis_train/nodes/classification_head.py
+++ b/luxonis_train/nodes/classification_head.py
@@ -19,7 +19,9 @@ class ClassificationHead(BaseNode[Tensor, Tensor]):
         @param dropout_rate: Dropout rate before last layer, range C{[0, 1]}. Defaults
             to C{0.2}.
         """
-        super().__init__(task_type=LabelType.CLASSIFICATION, **kwargs)
+        super().__init__(
+            _task_type=kwargs.pop("_task_type", LabelType.CLASSIFICATION), **kwargs
+        )
 
         self.head = nn.Sequential(
             nn.AdaptiveAvgPool2d(1),
@@ -32,4 +34,4 @@ class ClassificationHead(BaseNode[Tensor, Tensor]):
         return self.head(inputs)
 
     def wrap(self, output: Tensor) -> Packet[Tensor]:
-        return {"classes": [output]}
+        return {self.task: [output]}

--- a/luxonis_train/nodes/efficient_bbox_head.py
+++ b/luxonis_train/nodes/efficient_bbox_head.py
@@ -50,7 +50,7 @@ class EfficientBBoxHead(
         @type max_det: int
         @param max_det: Maximum number of detections retained after NMS. Defaults to C{300}.
         """
-        super().__init__(task_type=LabelType.BOUNDINGBOX, **kwargs)
+        super().__init__(_task_type=LabelType.BOUNDINGBOX, **kwargs)
 
         self.n_heads = n_heads
 
@@ -97,7 +97,7 @@ class EfficientBBoxHead(
                 conf, _ = out_cls.max(1, keepdim=True)
                 out = torch.cat([out_reg, conf, out_cls], dim=1)
                 outputs.append(out)
-            return {"boxes": outputs}
+            return {"boundingbox": outputs}
 
         cls_tensor = torch.cat(
             [cls_score_list[i].flatten(2) for i in range(len(cls_score_list))], dim=2
@@ -116,7 +116,7 @@ class EfficientBBoxHead(
         else:
             boxes = self._process_to_bbox((features, cls_tensor, reg_tensor))
             return {
-                "boxes": boxes,
+                "boundingbox": boxes,
                 "features": features,
                 "class_scores": [cls_tensor],
                 "distributions": [reg_tensor],

--- a/luxonis_train/nodes/implicit_keypoint_bbox_head.py
+++ b/luxonis_train/nodes/implicit_keypoint_bbox_head.py
@@ -57,7 +57,7 @@ class ImplicitKeypointBBoxHead(BaseNode):
         @type max_det: int
         @param max_det: Maximum number of detections retained after NMS. Defaults to C{300}.
         """
-        super().__init__(task_type=LabelType.KEYPOINT, **kwargs)
+        super().__init__(_task_type=LabelType.KEYPOINTS, **kwargs)
 
         if anchors is None:
             logger.info("No anchors provided, generating them automatically.")
@@ -172,7 +172,7 @@ class ImplicitKeypointBBoxHead(BaseNode):
         )
 
         return {
-            "boxes": [detection[:, :6] for detection in nms],
+            "boundingbox": [detection[:, :6] for detection in nms],
             "keypoints": [
                 detection[:, 6:].reshape(-1, self.n_keypoints, 3) for detection in nms
             ],

--- a/luxonis_train/nodes/segmentation_head.py
+++ b/luxonis_train/nodes/segmentation_head.py
@@ -46,7 +46,7 @@ class SegmentationHead(BaseNode[Tensor, Tensor]):
         )
 
     def wrap(self, output: Tensor) -> Packet[Tensor]:
-        return {self.task: [output]}
+        return {"segmentation": [output]}
 
     def forward(self, inputs: Tensor) -> Tensor:
         return self.head(inputs)

--- a/luxonis_train/nodes/segmentation_head.py
+++ b/luxonis_train/nodes/segmentation_head.py
@@ -27,7 +27,7 @@ class SegmentationHead(BaseNode[Tensor, Tensor]):
         @type kwargs: Any
         @param kwargs: Additional arguments to pass to L{BaseNode}.
         """
-        super().__init__(task_type=LabelType.SEGMENTATION, **kwargs)
+        super().__init__(_task_type=LabelType.SEGMENTATION, **kwargs)
 
         original_height = self.original_in_shape[2]
         num_up = infer_upscale_factor(self.in_height, original_height, strict=False)

--- a/luxonis_train/nodes/segmentation_head.py
+++ b/luxonis_train/nodes/segmentation_head.py
@@ -46,7 +46,7 @@ class SegmentationHead(BaseNode[Tensor, Tensor]):
         )
 
     def wrap(self, output: Tensor) -> Packet[Tensor]:
-        return {"segmentation": [output]}
+        return {self.task: [output]}
 
     def forward(self, inputs: Tensor) -> Tensor:
         return self.head(inputs)

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -41,7 +41,7 @@ class ModelNodeConfig(CustomBaseModel):
     inputs: list[str] = []
     params: dict[str, Any] = {}
     freezing: FreezingConfig = FreezingConfig()
-    task_group: str = "default"
+    task: str | None = None
 
 
 class PredefinedModelConfig(CustomBaseModel):

--- a/luxonis_train/utils/general.py
+++ b/luxonis_train/utils/general.py
@@ -71,11 +71,11 @@ class DatasetMetadata:
             )
         return self._classes
 
-    def n_classes(self, label_type: LabelType | None) -> int:
-        """Gets the number of classes for the specified label type.
+    def n_classes(self, task: str | None) -> int:
+        """Gets the number of classes for the specified task.
 
-        @type label_type: L{LabelType} | None
-        @param label_type: Label type to get the number of classes for.
+        @type task: str | None
+        @param task: Task to get the number of classes for.
         @rtype: int
         @return: Number of classes for the specified label type.
         @raises ValueError: If the dataset loader was not provided during
@@ -83,12 +83,10 @@ class DatasetMetadata:
         @raises ValueError: If the dataset contains different number of classes for
             different label types.
         """
-        if label_type is not None:
-            if label_type not in self.classes:
-                raise ValueError(
-                    f"Task type {label_type.name} is not present in the dataset."
-                )
-            return len(self.classes[label_type])
+        if task is not None:
+            if task not in self.classes:
+                raise ValueError(f"Task '{task}' is not present in the dataset.")
+            return len(self.classes[task])
         n_classes = len(list(self.classes.values())[0])
         for classes in self.classes.values():
             if len(classes) != n_classes:
@@ -97,11 +95,11 @@ class DatasetMetadata:
                 )
         return n_classes
 
-    def class_names(self, label_type: LabelType | None) -> list[str]:
-        """Gets the class names for the specified label type.
+    def class_names(self, task: str | None) -> list[str]:
+        """Gets the class names for the specified task.
 
-        @type label_type: L{LabelType} | None
-        @param label_type: Label type to get the class names for.
+        @type task: str | None
+        @param task: Task to get the class names for.
         @rtype: list[str]
         @return: List of class names for the specified label type.
         @raises ValueError: If the dataset loader was not provided during
@@ -109,12 +107,10 @@ class DatasetMetadata:
         @raises ValueError: If the dataset contains different class names for different
             label types.
         """
-        if label_type is not None:
-            if label_type not in self.classes:
-                raise ValueError(
-                    f"Task type {label_type.name} is not present in the dataset."
-                )
-            return self.classes[label_type]
+        if task is not None:
+            if task not in self.classes:
+                raise ValueError(f"Task type {task} is not present in the dataset.")
+            return self.classes[task]
         class_names = list(self.classes.values())[0]
         for classes in self.classes.values():
             if classes != class_names:
@@ -170,9 +166,10 @@ class DatasetMetadata:
 
         if skeletons is not None:
             if len(skeletons) == 1:
-                name = list(skeletons.keys())[0]
-                keypoint_names = skeletons[name]["labels"]
-                connectivity = skeletons[name]["edges"]
+                task_name = next(iter(skeletons))
+                class_name = next(iter(skeletons[task_name]))
+                keypoint_names = skeletons[task_name][class_name]["labels"]
+                connectivity = skeletons[task_name][class_name]["edges"]
 
             elif len(skeletons) > 1:
                 raise NotImplementedError(

--- a/luxonis_train/utils/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/utils/loaders/luxonis_loader_torch.py
@@ -4,7 +4,6 @@ import numpy as np
 from luxonis_ml.data import (
     BucketStorage,
     BucketType,
-    LabelType,
     LuxonisDataset,
     LuxonisLoader,
 )
@@ -48,20 +47,18 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         return Size([1, *img.shape])
 
     def __getitem__(self, idx: int) -> LuxonisLoaderTorchOutput:
-        img, group_annotations = self.base_loader[idx]
+        img, labels = self.base_loader[idx]
 
         img = np.transpose(img, (2, 0, 1))  # HWC to CHW
         tensor_img = Tensor(img)
-        for task in group_annotations:
-            annotations = group_annotations[task]
-            for key in annotations:
-                annotations[key] = Tensor(annotations[key])  # type: ignore
+        for task, (array, label_type) in labels.items():
+            labels[task] = (Tensor(array), label_type)  # type: ignore
 
-        return tensor_img, group_annotations
+        return tensor_img, labels
 
-    def get_classes(self) -> dict[LabelType, list[str]]:
+    def get_classes(self) -> dict[str, list[str]]:
         _, classes = self.dataset.get_classes()
-        return {LabelType(task): classes[task] for task in classes}
+        return {task: classes[task] for task in classes}
 
     def get_skeletons(self) -> dict[str, dict] | None:
         return self.dataset.get_skeletons()

--- a/luxonis_train/utils/types.py
+++ b/luxonis_train/utils/types.py
@@ -1,13 +1,12 @@
 from typing import Annotated, Any, Literal, TypeVar
 
-from luxonis_ml.enums import LabelType
+from luxonis_ml.data import LabelType
 from pydantic import BaseModel, Field, ValidationError
 from torch import Size, Tensor
 
 Kwargs = dict[str, Any]
-OutputTypes = Literal["boxes", "class", "keypoints", "segmentation", "features"]
-Labels = dict[LabelType, Tensor]
-TaskLabels = dict[str, Labels]
+OutputTypes = Literal["boundingbox", "class", "keypoints", "segmentation", "features"]
+Labels = dict[str, tuple[Tensor, LabelType]]
 
 AttachIndexType = Literal["all"] | int | tuple[int, int] | tuple[int, int, int]
 """AttachIndexType is used to specify to which output of the prevoius node does the
@@ -36,12 +35,10 @@ class IncompatibleException(Exception):
         )
 
     @classmethod
-    def from_missing_label(
-        cls, label: LabelType, present_labels: list[LabelType], class_name: str
-    ):
+    def from_missing_task(cls, task: str, present_tasks: list[str], class_name: str):
         return cls(
-            f"{class_name} requires {label} label, but it was not found in "
-            f"the label dictionary. Available labels: {present_labels}."
+            f"{class_name} requires {task} label, but it was not found in "
+            f"the label dictionary. Available labels: {present_tasks}."
         )
 
 
@@ -59,7 +56,7 @@ class KeypointProtocol(BaseProtocol):
 
 
 class BBoxProtocol(BaseProtocol):
-    boxes: Annotated[list[Tensor], Field(min_length=1)]
+    boundingbox: Annotated[list[Tensor], Field(min_length=1)]
 
 
 class FeaturesProtocol(BaseProtocol):

--- a/luxonis_train/utils/types.py
+++ b/luxonis_train/utils/types.py
@@ -46,6 +46,15 @@ class BaseProtocol(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
+    @classmethod
+    def get_task(cls) -> str:
+        if len(cls.__annotations__) == 1:
+            return list(cls.__annotations__)[0]
+        raise ValueError(
+            "Protocol must have exactly one field for automatic task inference. "
+            "Implement custom `prepare` method in your attached module."
+        )
+
 
 class SegmentationProtocol(BaseProtocol):
     segmentation: Annotated[list[Tensor], Field(min_length=1)]

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">76%</text>
-        <text x="80" y="14">76%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
+        <text x="80" y="14">77%</text>
     </g>
 </svg>

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,15 +1,11 @@
-import glob
-import json
 import os
-import zipfile
 from pathlib import Path
 
-import cv2
 import gdown
-import numpy as np
 import pytest
 import torchvision
 from luxonis_ml.data import LuxonisDataset
+from luxonis_ml.data.parsers import LuxonisParser
 from luxonis_ml.utils import environ
 
 Path(environ.LUXONISML_BASE_PATH).mkdir(exist_ok=True)
@@ -24,7 +20,7 @@ def create_dataset(name: str) -> LuxonisDataset:
 
 @pytest.fixture(scope="session", autouse=True)
 def create_coco_dataset():
-    dataset = create_dataset("coco_test")
+    dataset_name = "coco_test"
     url = "https://drive.google.com/uc?id=1XlvFK7aRmt8op6-hHkWVKIJQeDtOwoRT"
     output_folder = "../data/"
     output_zip = os.path.join(output_folder, "COCO_people_subset.zip")
@@ -37,96 +33,12 @@ def create_coco_dataset():
     ):
         gdown.download(url, output_zip, quiet=False)
 
-        with zipfile.ZipFile(output_zip, "r") as zip_ref:
-            zip_ref.extractall(output_folder)
-
-    def COCO_people_subset_generator():
-        img_dir = os.path.join(output_folder, "person_val2017_subset")
-        annot_file = os.path.join(output_folder, "person_keypoints_val2017.json")
-        im_paths = glob.glob(img_dir + "/*.jpg")
-        nums = np.array([int(Path(path).stem) for path in im_paths])
-        idxs = np.argsort(nums)
-        im_paths = list(np.array(im_paths)[idxs])
-        with open(annot_file) as file:
-            data = json.load(file)
-        imgs = data["images"]
-        anns = data["annotations"]
-
-        for path in im_paths:
-            gran = Path(path).name
-            img = [img for img in imgs if img["file_name"] == gran][0]
-            img_id = img["id"]
-            img_anns = [ann for ann in anns if ann["image_id"] == img_id]
-
-            im = cv2.imread(path)
-            height, width, _ = im.shape
-
-            if len(img_anns):
-                yield {
-                    "file": path,
-                    "class": "person",
-                    "type": "classification",
-                    "value": True,
-                }
-
-            for ann in img_anns:
-                seg = ann["segmentation"]
-                if isinstance(seg, list):
-                    poly = []
-                    for s in seg:
-                        poly_arr = np.array(s).reshape(-1, 2)
-                        poly += [
-                            (poly_arr[i, 0] / width, poly_arr[i, 1] / height)
-                            for i in range(len(poly_arr))
-                        ]
-                    yield {
-                        "file": path,
-                        "class": "person",
-                        "type": "polyline",
-                        "value": poly,
-                    }
-
-                x, y, w, h = ann["bbox"]
-                yield {
-                    "file": path,
-                    "class": "person",
-                    "type": "box",
-                    "value": (x / width, y / height, w / width, h / height),
-                }
-
-                kps = np.array(ann["keypoints"]).reshape(-1, 3)
-                keypoint = []
-                for kp in kps:
-                    keypoint.append(
-                        (float(kp[0] / width), float(kp[1] / height), int(kp[2]))
-                    )
-                yield {
-                    "file": path,
-                    "class": "person",
-                    "type": "keypoints",
-                    "value": keypoint,
-                }
-
-    dataset.set_classes(["person"])
-
-    annot_file = os.path.join(output_folder, "person_keypoints_val2017.json")
-    with open(annot_file) as file:
-        data = json.load(file)
-    dataset.set_skeletons(
-        {
-            "person": {
-                "labels": data["categories"][0]["keypoints"],
-                "edges": (np.array(data["categories"][0]["skeleton"]) - 1).tolist(),
-            }
-        }
-    )
-    dataset.add(COCO_people_subset_generator())
-    dataset.make_splits()
+    parser = LuxonisParser(output_zip, dataset_name=dataset_name, delete_existing=True)
+    parser.parse(random_split=True)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def create_cifar10_dataset():
-    dataset = create_dataset("cifar10_test")
+def _create_cifar10(dataset_name: str, task_name: str) -> None:
+    dataset = create_dataset(dataset_name)
     output_folder = "../data/"
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
@@ -154,12 +66,22 @@ def create_cifar10_dataset():
             image.save(path)
             yield {
                 "file": path,
-                "class": classes[label],
-                "type": "classification",
-                "value": True,
+                "annotation": {
+                    "type": "classification",
+                    "task": task_name,
+                    "class": classes[label],
+                },
             }
-
-    dataset.set_classes(classes)
 
     dataset.add(CIFAR10_subset_generator())
     dataset.make_splits()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_cifar10_dataset():
+    _create_cifar10("cifar10_test", "classification")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_cifar10_task_dataset():
+    _create_cifar10("cifar10_task_test", "cifar10_task")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,7 +37,7 @@ def create_coco_dataset():
     parser.parse(random_split=True)
 
 
-def _create_cifar10(dataset_name: str, task_name: str) -> None:
+def _create_cifar10(dataset_name: str, task_names: list[str]) -> None:
     dataset = create_dataset(dataset_name)
     output_folder = "../data/"
     if not os.path.exists(output_folder):
@@ -64,14 +64,15 @@ def _create_cifar10(dataset_name: str, task_name: str) -> None:
                 break
             path = os.path.join(output_folder, f"cifar_{i}.png")
             image.save(path)
-            yield {
-                "file": path,
-                "annotation": {
-                    "type": "classification",
-                    "task": task_name,
-                    "class": classes[label],
-                },
-            }
+            for task_name in task_names:
+                yield {
+                    "file": path,
+                    "annotation": {
+                        "type": "classification",
+                        "task": task_name,
+                        "class": classes[label],
+                    },
+                }
 
     dataset.add(CIFAR10_subset_generator())
     dataset.make_splits()
@@ -79,9 +80,9 @@ def _create_cifar10(dataset_name: str, task_name: str) -> None:
 
 @pytest.fixture(scope="session", autouse=True)
 def create_cifar10_dataset():
-    _create_cifar10("cifar10_test", "classification")
+    _create_cifar10("cifar10_test", ["classification"])
 
 
 @pytest.fixture(scope="session", autouse=True)
 def create_cifar10_task_dataset():
-    _create_cifar10("cifar10_task_test", "cifar10_task")
+    _create_cifar10("cifar10_task_test", [f"classification_{i}" for i in [1, 2, 3]])

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -66,6 +66,27 @@ def test_sanity(config_file):
     shutil.rmtree(save_dir, ignore_errors=True)
 
 
+def test_task():
+    opts = [
+        "trainer.epochs",
+        "1",
+        "trainer.validation_interval",
+        "1",
+        "trainer.callbacks",
+        "[]",
+        "trainer.batch_size",
+        "1",
+        "model.nodes.1.task",
+        "cifar10_task",
+        "loader.params.dataset_name",
+        "cifar10_task_test",
+    ]
+    result = subprocess.run(
+        ["luxonis_train", "train", "--config", "configs/resnet_model.yaml", *opts],
+    )
+    assert result.returncode == 0
+
+
 def test_tuner():
     Path("study_local.db").unlink(missing_ok=True)
     result = subprocess.run(

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -66,27 +66,6 @@ def test_sanity(config_file):
     shutil.rmtree(save_dir, ignore_errors=True)
 
 
-def test_task():
-    opts = [
-        "trainer.epochs",
-        "1",
-        "trainer.validation_interval",
-        "1",
-        "trainer.callbacks",
-        "[]",
-        "trainer.batch_size",
-        "1",
-        "model.nodes.1.task",
-        "cifar10_task",
-        "loader.params.dataset_name",
-        "cifar10_task_test",
-    ]
-    result = subprocess.run(
-        ["luxonis_train", "train", "--config", "configs/resnet_model.yaml", *opts],
-    )
-    assert result.returncode == 0
-
-
 def test_tuner():
     Path("study_local.db").unlink(missing_ok=True)
     result = subprocess.run(

--- a/tests/unittests/test_utils/test_loaders/test_base_loader.py
+++ b/tests/unittests/test_utils/test_loaders/test_base_loader.py
@@ -12,27 +12,25 @@ def test_collate_fn():
     batch = [
         (
             torch.rand(3, 224, 224, dtype=torch.float32),
-            {"default": {LabelType.CLASSIFICATION: torch.tensor([1, 0])}},
+            {"classification": (torch.tensor([1, 0]), LabelType.CLASSIFICATION)},
         ),
         (
             torch.rand(3, 224, 224, dtype=torch.float32),
-            {"default": {LabelType.CLASSIFICATION: torch.tensor([0, 1])}},
+            {"classification": (torch.tensor([0, 1]), LabelType.CLASSIFICATION)},
         ),
     ]
 
     # Call collate_fn
-    imgs, annotations = collate_fn(batch)
+    imgs, annotations = collate_fn(batch)  # type: ignore
 
     # Check images tensor
     assert imgs.shape == (2, 3, 224, 224)
     assert imgs.dtype == torch.float32
 
     # Check annotations
-    assert "default" in annotations
-    annotations = annotations["default"]
-    assert LabelType.CLASSIFICATION in annotations
-    assert annotations[LabelType.CLASSIFICATION].shape == (2, 2)
-    assert annotations[LabelType.CLASSIFICATION].dtype == torch.int64
+    assert "classification" in annotations
+    assert annotations["classification"][0].shape == (2, 2)
+    assert annotations["classification"][0].dtype == torch.int64
 
     # TODO: test also segmentation, boundingbox and keypoint
 


### PR DESCRIPTION
- Support for refactored annotations in LuxonisML ([110](https://github.com/luxonis/luxonis-ml/pull/110))
  - Option to specify `task` field under `node`'s config
  - The specified `task` is used by the node and all the attached modules
- Test case for multi-task model