### PR TITLE
Changed Imports in Config

### DIFF
--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -5,9 +5,6 @@ from typing import Annotated, Any, Literal
 from luxonis_ml.utils import Environ, LuxonisConfig, LuxonisFileSystem, setup_logging
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from luxonis_train.utils.general import is_acyclic
-from luxonis_train.utils.registry import MODELS
-
 logger = logging.getLogger(__name__)
 
 
@@ -65,6 +62,8 @@ class ModelConfig(CustomBaseModel):
 
     @model_validator(mode="after")
     def check_predefined_model(self):
+        from luxonis_train.utils.registry import MODELS
+
         if self.predefined_model:
             logger.info(f"Using predefined model: `{self.predefined_model.name}`")
             model = MODELS.get(self.predefined_model.name)(
@@ -85,6 +84,8 @@ class ModelConfig(CustomBaseModel):
 
     @model_validator(mode="after")
     def check_graph(self):
+        from luxonis_train.utils.general import is_acyclic
+
         graph = {node.alias or node.name: node.inputs for node in self.nodes}
         if not is_acyclic(graph):
             raise ValueError("Model graph is not acyclic.")

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">77%</text>
-        <text x="80" y="14">77%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">76%</text>
+        <text x="80" y="14">76%</text>
     </g>
 </svg>


### PR DESCRIPTION
Moved top level `luxonis-train` imports to individual `Config` methods. This makes it possible to use just the `Config` module outside of `luxonis-train`. 