### PR TITLE
Fix onnx export

### DIFF
--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -312,9 +312,9 @@ class LuxonisModel(pl.LightningModule):
         @rtype: L{LuxonisOutput}
         @return: Output of the model.
         """
-        losses: dict[
-            str, dict[str, Tensor | tuple[Tensor, dict[str, Tensor]]]
-        ] = defaultdict(dict)
+        losses: dict[str, dict[str, Tensor | tuple[Tensor, dict[str, Tensor]]]] = (
+            defaultdict(dict)
+        )
         visualizations: dict[str, dict[str, Tensor]] = defaultdict(dict)
 
         computed: dict[str, Packet[Tensor]] = {}
@@ -418,6 +418,7 @@ class LuxonisModel(pl.LightningModule):
         @rtype: list[str]
         @return: List of output names.
         """
+        self.eval()
 
         inputs = {
             input_name: torch.zeros([1, *shape]).to(self.device)
@@ -490,6 +491,9 @@ class LuxonisModel(pl.LightningModule):
                 module.set_export_mode(False)
 
         logger.info(f"Model exported to {save_path}")
+
+        self.train()
+
         return output_names
 
     def process_losses(
@@ -523,9 +527,9 @@ class LuxonisModel(pl.LightningModule):
 
                 loss *= self.loss_weights[loss_name]
                 final_loss += loss
-                training_step_output[
-                    f"loss/{node_name}/{loss_name}"
-                ] = loss.detach().cpu()
+                training_step_output[f"loss/{node_name}/{loss_name}"] = (
+                    loss.detach().cpu()
+                )
                 if self.cfg.trainer.log_sub_losses and sublosses:
                     for subloss_name, subloss_value in sublosses.items():
                         training_step_output[

--- a/luxonis_train/models/luxonis_model.py
+++ b/luxonis_train/models/luxonis_model.py
@@ -312,9 +312,9 @@ class LuxonisModel(pl.LightningModule):
         @rtype: L{LuxonisOutput}
         @return: Output of the model.
         """
-        losses: dict[str, dict[str, Tensor | tuple[Tensor, dict[str, Tensor]]]] = (
-            defaultdict(dict)
-        )
+        losses: dict[
+            str, dict[str, Tensor | tuple[Tensor, dict[str, Tensor]]]
+        ] = defaultdict(dict)
         visualizations: dict[str, dict[str, Tensor]] = defaultdict(dict)
 
         computed: dict[str, Packet[Tensor]] = {}
@@ -527,9 +527,9 @@ class LuxonisModel(pl.LightningModule):
 
                 loss *= self.loss_weights[loss_name]
                 final_loss += loss
-                training_step_output[f"loss/{node_name}/{loss_name}"] = (
-                    loss.detach().cpu()
-                )
+                training_step_output[
+                    f"loss/{node_name}/{loss_name}"
+                ] = loss.detach().cpu()
                 if self.cfg.trainer.log_sub_losses and sublosses:
                     for subloss_name, subloss_value in sublosses.items():
                         training_step_output[


### PR DESCRIPTION
Explicitly setting `LuxonisModel` to `eval` before export and back to `train` after it. Without this exported onnx model doesn't have same performance as original pytorch one.