### PR TITLE
Ensure checkpoint is always generated

### DIFF
--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -236,6 +236,15 @@ class TrainerConfig(CustomBaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def check_validation_interval(self):
+        if self.validation_interval > self.epochs:
+            logger.warning(
+                "Setting `validation_interval` same as `epochs` otherwise no checkpoint would be generated."
+            )
+            self.validation_interval = self.epochs
+        return self
+
 
 class OnnxExportConfig(CustomBaseModel):
     opset_version: int = 12


### PR DESCRIPTION
Set max bound of `validation_interval` to `epochs` during config validation which ensures that at least one checkpoint is generated on every training run.