### PR TITLE
Option to Parse Data in `LuxonisLoaderTorch`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ mlruns
 wandb
 tests/_data
 tests/integration/_test-output
+data

--- a/luxonis_train/attached_modules/metrics/common.py
+++ b/luxonis_train/attached_modules/metrics/common.py
@@ -14,15 +14,26 @@ class TorchMetricWrapper(BaseMetric):
         super().__init__(node=kwargs.pop("node", None))
         task = kwargs.get("task")
 
-        if task is None:
-            if self.node.n_classes > 1:
-                task = "multiclass"
-            else:
-                task = "binary"
+        if self.node.n_classes > 1:
+            if task == "binary":
+                raise ValueError(
+                    f"Task type set to '{task}', but the dataset has more than 1 class. "
+                    f"Set the `task` parameter for {self.name} to either 'multiclass' or 'multilabel'."
+                )
+            task = "multiclass"
+        else:
+            if task == "multiclass":
+                raise ValueError(
+                    f"Task type set to '{task}', but the dataset has only 1 class. "
+                    f"Set the `task` parameter for {self.name} to 'binary'."
+                )
+            task = "binary"
+        if "task" not in kwargs:
             logger.warning(
-                f"Task type not specified for {self.name}, assuming '{task}'."
+                f"Task type not specified for {self.name}, assuming '{task}'. "
+                "If this is not correct, please set the `task` parameter explicitly."
             )
-            kwargs["task"] = task
+        kwargs["task"] = task
         self._task = task
 
         if self._task == "multiclass":

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -3,6 +3,7 @@ import sys
 from typing import Annotated, Any, Literal, TypeAlias
 
 from luxonis_ml.data import LabelType
+from luxonis_ml.enums import DatasetType
 from luxonis_ml.utils import (
     BaseModelExtraForbid,
     Environ,
@@ -166,6 +167,20 @@ class LoaderConfig(BaseModelExtraForbid):
         if isinstance(splits, str):
             return [splits]
         return splits
+
+    @model_validator(mode="after")
+    def validate_params(self) -> Self:
+        dataset_type = self.params.get("dataset_type")
+        if dataset_type is None:
+            return self
+
+        if dataset_type not in DatasetType.__members__:
+            raise ValueError(
+                f"Dataset type '{dataset_type}' not supported."
+                f"Supported types are: {', '.join(DatasetType.__members__)}."
+            )
+        self.params["dataset_type"] = DatasetType(dataset_type.lower())
+        return self
 
 
 class NormalizeAugmentationConfig(BaseModelExtraForbid):

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -173,6 +173,7 @@ class LoaderConfig(BaseModelExtraForbid):
         dataset_type = self.params.get("dataset_type")
         if dataset_type is None:
             return self
+        dataset_type = dataset_type.upper()
 
         if dataset_type not in DatasetType.__members__:
             raise ValueError(

--- a/luxonis_train/utils/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/utils/loaders/luxonis_loader_torch.py
@@ -152,7 +152,7 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
             logger.warning(
                 "Dataset type is not set. "
                 "Attempting to infer it from the directory structure. "
-                "If this fails, please set the dataset type manually."
+                "If this fails, please set the dataset type manually. "
                 f"Supported types are: {', '.join(DatasetType.__members__)}."
             )
 

--- a/luxonis_train/utils/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/utils/loaders/luxonis_loader_torch.py
@@ -78,7 +78,6 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         """
         super().__init__(view=view, augmentations=augmentations, **kwargs)
         if dataset_dir is not None:
-            logger.info(f"Parsing dataset from {dataset_dir}")
             self.dataset = self._parse_dataset(
                 dataset_dir, dataset_name, dataset_type, delete_existing
             )
@@ -134,14 +133,6 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         dataset_type: DatasetType | None,
         delete_existing: bool,
     ) -> LuxonisDataset:
-        if dataset_type is None:
-            logger.warning(
-                "Dataset type is not set. "
-                "Attempting to infer it from the directory structure. "
-                "If this fails, please set the dataset type manually."
-                f"Supported types are: {', '.join(DatasetType.__members__)}."
-            )
-
         if dataset_name is None:
             dataset_name = Path(dataset_dir).stem
             if dataset_type is not None:
@@ -153,9 +144,19 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
             else:
                 logger.warning(
                     f"Dataset {dataset_name} already exists. "
-                    "The dataset will be generated again in case new data was added. "
+                    "The dataset will be generated again to ensure the latest data are used. "
                     "If you don't want to regenerate the dataset every time, set `delete_existing=False`'"
                 )
+
+        if dataset_type is None:
+            logger.warning(
+                "Dataset type is not set. "
+                "Attempting to infer it from the directory structure. "
+                "If this fails, please set the dataset type manually."
+                f"Supported types are: {', '.join(DatasetType.__members__)}."
+            )
+
+        logger.info(f"Parsing dataset from {dataset_dir} with name '{dataset_name}'")
 
         return cast(
             LuxonisDataset,

--- a/luxonis_train/utils/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/utils/loaders/luxonis_loader_torch.py
@@ -1,29 +1,98 @@
-from typing import Literal
+import logging
+from pathlib import Path
+from typing import Literal, cast
 
 import numpy as np
-from luxonis_ml.data import BucketStorage, BucketType, LuxonisDataset, LuxonisLoader
+from luxonis_ml.data import (
+    Augmentations,
+    BucketStorage,
+    BucketType,
+    LuxonisDataset,
+    LuxonisLoader,
+)
+from luxonis_ml.data.parsers import LuxonisParser
+from luxonis_ml.enums import DatasetType
 from torch import Size, Tensor
+from typeguard import typechecked
 
 from .base_loader import BaseLoaderTorch, LuxonisLoaderTorchOutput
 
+logger = logging.getLogger(__name__)
+
 
 class LuxonisLoaderTorch(BaseLoaderTorch):
+    @typechecked
     def __init__(
         self,
-        dataset_name: str,
+        dataset_name: str | None = None,
+        dataset_dir: str | None = None,
+        dataset_type: DatasetType | None = None,
         team_id: str | None = None,
         bucket_type: Literal["internal", "external"] = "internal",
         bucket_storage: Literal["local", "s3", "gcs", "azure"] = "local",
         stream: bool = False,
+        delete_existing: bool = True,
+        view: str | list[str] = "train",
+        augmentations: Augmentations | None = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
-        self.dataset = LuxonisDataset(
-            dataset_name=dataset_name,
-            team_id=team_id,
-            bucket_type=BucketType(bucket_type),
-            bucket_storage=BucketStorage(bucket_storage),
-        )
+        """Torch-compatible loader for Luxonis datasets.
+
+        Can either use an already existing dataset or parse a new one from a directory.
+
+        @type dataset_name: str | None
+        @param dataset_name: Name of the dataset to load. If not provided, the
+            C{dataset_dir} argument must be provided instead. If both C{dataset_dir} and
+            C{dataset_name} are provided, the dataset will be parsed from the directory
+            and saved with the provided name.
+        @type dataset_dir: str | None
+        @param dataset_dir: Path to the dataset directory. It can be either a local path
+            or a URL. The data can be in a zip file. If not provided, C{dataset_name} of
+            an existing dataset must be provided.
+        @type dataset_type: str | None
+        @param dataset_type: Type of the dataset. Only relevant when C{dataset_dir} is
+            provided. If not provided, the type will be inferred from the directory
+            structure.
+        @type team_id: str | None
+        @param team_id: Optional unique team identifier for the cloud.
+        @type bucket_type: Literal["internal", "external"]
+        @param bucket_type: Type of the bucket. Only relevant for remote datasets.
+            Defaults to 'internal'.
+        @type bucket_storage: Literal["local", "s3", "gcs", "azure"]
+        @param bucket_storage: Type of the bucket storage. Defaults to 'local'.
+        @type stream: bool
+        @param stream: Flag for data streaming. Defaults to C{False}.
+        @type delete_existing: bool
+        @param delete_existing: Only relevant when C{dataset_dir} is provided. By
+            default, the dataset is parsed again every time the loader is created
+            because the underlying data might have changed. If C{delete_existing} is set
+            to C{False} and a dataset of the same name already exists, the existing
+            dataset will be used instead of re-parsing the data.
+        @type view: str | list[str]
+        @param view: A single split or a list of splits that will be used to create a
+            view of the dataset. Each split is a string that represents a subset of the
+            dataset. The available splits depend on the dataset, but usually include
+            'train', 'val', and 'test'. Defaults to 'train'.
+        @type augmentations: Augmentations | None
+        @param augmentations: Augmentations to apply to the data. Defaults to C{None}.
+        """
+        super().__init__(view=view, augmentations=augmentations, **kwargs)
+        if dataset_dir is not None:
+            logger.info(f"Parsing dataset from {dataset_dir}")
+            self.dataset = self._parse_dataset(
+                dataset_dir, dataset_name, dataset_type, delete_existing
+            )
+        else:
+            if dataset_name is None:
+                raise ValueError(
+                    "Either `dataset_dir` or `dataset_name` must be provided."
+                )
+            self.dataset = LuxonisDataset(
+                dataset_name=dataset_name,
+                team_id=team_id,
+                bucket_type=BucketType(bucket_type),
+                bucket_storage=BucketStorage(bucket_storage),
+            )
         self.base_loader = LuxonisLoader(
             dataset=self.dataset,
             view=self.view,
@@ -57,3 +126,43 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
     def get_n_keypoints(self) -> dict[str, int]:
         skeletons = self.dataset.get_skeletons()
         return {task: len(skeletons[task][0]) for task in skeletons}
+
+    def _parse_dataset(
+        self,
+        dataset_dir: str,
+        dataset_name: str | None,
+        dataset_type: DatasetType | None,
+        delete_existing: bool,
+    ) -> LuxonisDataset:
+        if dataset_type is None:
+            logger.warning(
+                "Dataset type is not set. "
+                "Attempting to infer it from the directory structure. "
+                "If this fails, please set the dataset type manually."
+                f"Supported types are: {', '.join(DatasetType.__members__)}."
+            )
+
+        if dataset_name is None:
+            dataset_name = Path(dataset_dir).stem
+            if dataset_type is not None:
+                dataset_name += f"_{dataset_type.value}"
+
+        if LuxonisDataset.exists(dataset_name):
+            if not delete_existing:
+                return LuxonisDataset(dataset_name=dataset_name)
+            else:
+                logger.warning(
+                    f"Dataset {dataset_name} already exists. "
+                    "The dataset will be generated again in case new data was added. "
+                    "If you don't want to regenerate the dataset every time, set `delete_existing=False`'"
+                )
+
+        return cast(
+            LuxonisDataset,
+            LuxonisParser(
+                dataset_dir,
+                dataset_name=dataset_name,
+                dataset_type=dataset_type,
+                delete_existing=True,
+            ).parse(),
+        )

--- a/luxonis_train/utils/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/utils/loaders/luxonis_loader_torch.py
@@ -164,6 +164,7 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
                 dataset_dir,
                 dataset_name=dataset_name,
                 dataset_type=dataset_type,
+                save_dir="data",
                 delete_existing=True,
             ).parse(),
         )

--- a/tests/configs/segmentation_parse_loader.yaml
+++ b/tests/configs/segmentation_parse_loader.yaml
@@ -1,0 +1,27 @@
+# Example configuration for training a predefined segmentation model
+
+model:
+  name: parse_loader_test
+  predefined_model:
+    name: SegmentationModel
+    params:
+      backbone: MicroNet
+      task: multiclass
+
+loader:
+  params:
+    dataset_dir: gs://luxonis-test-bucket/luxonis-ml-test-data/D2_Tile.png-mask-semantic.zip
+    dataset_name: _parse_loader_test_dataset
+
+trainer:
+  preprocessing:
+    train_image_size: [&height 128, &width 128]
+    keep_aspect_ratio: False
+    normalize:
+      active: True
+
+  batch_size: 4
+  epochs: &epochs 1
+  num_workers: 4
+  validation_interval: 1
+  num_log_images: 8

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -42,6 +42,8 @@ def clear_output():
         "detection_model",
         "keypoint_bbox_model",
         "resnet_model",
+        "coco_model",
+        "efficient_coco_model",
     ],
 )
 def test_simple_models(config_file: str):
@@ -96,6 +98,12 @@ def test_custom_tasks(parking_lot_dataset: LuxonisDataset):
     )
     model.train()
     assert model.archive().exists()
+    del model
+
+
+def test_parsing_loader():
+    model = LuxonisModel("tests/configs/segmentation_parse_loader.yaml")
+    model.train()
     del model
 
 


### PR DESCRIPTION
Added support for loading data from a directory instead of using an existing `LuxonisDataset`. 

The following example would create a new `LuxonisDataset` from the dataset directory and save it under the name `"dataset_coco"`. When run for a second time, the dataset will be re-used instead of being generated again.

**`config.yaml:`**
```yaml
loader:
  params:
    dataset_dir: path/to/dataset
    dataset_type: coco
    dataset_name: dataset_coco
    delete_existing: false

```