### PR TITLE
Generalized Progress Bar

### DIFF
--- a/luxonis_train/callbacks/__init__.py
+++ b/luxonis_train/callbacks/__init__.py
@@ -11,7 +11,11 @@ from luxonis_train.utils.registry import CALLBACKS
 from .archive_on_train_end import ArchiveOnTrainEnd
 from .export_on_train_end import ExportOnTrainEnd
 from .gpu_stats_monitor import GPUStatsMonitor
-from .luxonis_progress_bar import LuxonisProgressBar
+from .luxonis_progress_bar import (
+    BaseLuxonisProgressBar,
+    LuxonisRichProgressBar,
+    LuxonisTQDMProgressBar,
+)
 from .metadata_logger import MetadataLogger
 from .module_freezer import ModuleFreezer
 from .test_on_train_end import TestOnTrainEnd
@@ -27,7 +31,9 @@ CALLBACKS.register_module(module=DeviceStatsMonitor)
 __all__ = [
     "ArchiveOnTrainEnd",
     "ExportOnTrainEnd",
-    "LuxonisProgressBar",
+    "LuxonisTQDMProgressBar",
+    "LuxonisRichProgressBar",
+    "BaseLuxonisProgressBar",
     "MetadataLogger",
     "ModuleFreezer",
     "TestOnTrainEnd",

--- a/luxonis_train/callbacks/luxonis_progress_bar.py
+++ b/luxonis_train/callbacks/luxonis_progress_bar.py
@@ -44,7 +44,7 @@ class BaseLuxonisProgressBar(ABC, ProgressBar):
 
 @CALLBACKS.register_module()
 class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
-    """Custom rich text progress bar based on RichProgressBar from Pytorch Lightning."""
+    """Custom text progress bar based on TQDMProgressBar from Pytorch Lightning."""
 
     def __init__(self):
         super().__init__(leave=True)

--- a/luxonis_train/callbacks/luxonis_progress_bar.py
+++ b/luxonis_train/callbacks/luxonis_progress_bar.py
@@ -1,35 +1,16 @@
+from abc import ABC, abstractmethod
 from collections.abc import Mapping
 
 import lightning.pytorch as pl
-from lightning.pytorch.callbacks import RichProgressBar
+import tabulate
+from lightning.pytorch.callbacks import ProgressBar, RichProgressBar, TQDMProgressBar
 from rich.console import Console
 from rich.table import Table
 
 from luxonis_train.utils.registry import CALLBACKS
 
 
-@CALLBACKS.register_module()
-class LuxonisProgressBar(RichProgressBar):
-    """Custom rich text progress bar based on RichProgressBar from Pytorch Lightning."""
-
-    _console: Console
-
-    def __init__(self):
-        super().__init__(leave=True)
-
-    def print_single_line(self, text: str, style: str = "magenta") -> None:
-        """Prints single line of text to the console.
-
-        @type text: str
-        @param text: Text to print.
-        @type style: str
-        @param style: Style of the text. Defaults to C{"magenta"}.
-        """
-        if self._check_console():
-            self._console.print(f"[{style}]{text}[/{style}]")
-        else:
-            print(text)
-
+class BaseLuxonisProgressBar(ABC, ProgressBar):
     def get_metrics(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule
     ) -> dict[str, int | str | float | dict[str, float]]:
@@ -40,13 +21,90 @@ class LuxonisProgressBar(RichProgressBar):
             items["Loss"] = pl_module.training_step_outputs[-1]["loss"].item()
         return items
 
-    def _check_console(self) -> bool:
-        """Checks if console is set.
+    @abstractmethod
+    def print_results(
+        self,
+        stage: str,
+        loss: float,
+        metrics: Mapping[str, Mapping[str, int | str | float]],
+    ) -> None:
+        pass
 
-        @rtype: bool
-        @return: True if console is set, False otherwise.
+
+@CALLBACKS.register_module()
+class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
+    """Custom rich text progress bar based on RichProgressBar from Pytorch Lightning."""
+
+    def __init__(self):
+        super().__init__(leave=True)
+
+    def _print_table(
+        self,
+        title: str,
+        table: Mapping[str, int | str | float],
+        key_name: str = "Name",
+        value_name: str = "Value",
+    ) -> None:
+        """Prints table to the console using tabulate.
+
+        @type title: str
+        @param title: Title of the table
+        @type table: Mapping[str, int | str | float]
+        @param table: Table to print
+        @type key_name: str
+        @param key_name: Name of the key column. Defaults to C{"Name"}.
+        @type value_name: str
+        @param value_name: Name of the value column. Defaults to C{"Value"}.
         """
-        return self._console is not None
+        print(f"------{title}-----")
+        print(
+            tabulate.tabulate(
+                table.items(),
+                headers=[key_name, value_name],
+                tablefmt="fancy_grid",
+                numalign="right",
+            )
+        )
+        print()
+
+    def print_results(
+        self,
+        stage: str,
+        loss: float,
+        metrics: Mapping[str, Mapping[str, int | str | float]],
+    ) -> None:
+        """Prints results to the console using rich text.
+
+        @type stage: str
+        @param stage: Stage name.
+        @type loss: float
+        @param loss: Loss value.
+        @type metrics: Mapping[str, Mapping[str, int | str | float]]
+        @param metrics: Metrics in format {table_name: table}.
+        """
+        print(f"------{stage}-----")
+        print(f"Loss: {loss}")
+        print("Metrics:")
+        for table_name, table in metrics.items():
+            self._print_table(table_name, table)
+        print("-----------------")
+
+
+@CALLBACKS.register_module()
+class LuxonisRichProgressBar(RichProgressBar, BaseLuxonisProgressBar):
+    """Custom rich text progress bar based on RichProgressBar from Pytorch Lightning."""
+
+    def __init__(self):
+        super().__init__(leave=True)
+
+    @property
+    def console(self) -> Console:
+        if self._console is None:
+            raise RuntimeError(
+                "Console is not initialized for the `LuxonisRichProgressBar`. "
+                "Consider setting `tracker.use_rich_progress_bar` to `False` in the configuration."
+            )
+        return self._console
 
     def print_table(
         self,
@@ -66,35 +124,19 @@ class LuxonisProgressBar(RichProgressBar):
         @type value_name: str
         @param value_name: Name of the value column. Defaults to C{"Value"}.
         """
-        if self._check_console():
-            rich_table = Table(
-                title=title,
-                show_header=True,
-                header_style="bold magenta",
-            )
-            rich_table.add_column(key_name, style="magenta")
-            rich_table.add_column(value_name, style="white")
-            for name, value in table.items():
-                if isinstance(value, float):
-                    rich_table.add_row(name, f"{value:.5f}")
-                else:
-                    rich_table.add_row(name, str(value))
-            self._console.print(rich_table)
-        else:
-            print(f"------{title}-----")
-            for name, value in table.items():
-                print(f"{name}: {value}")
-
-    def print_tables(
-        self, tables: Mapping[str, Mapping[str, int | str | float]]
-    ) -> None:
-        """Prints multiple tables to the console using rich text.
-
-        @type tables: Mapping[str, Mapping[str, int | str | float]]
-        @param tables: Tables to print in format {table_name: table}.
-        """
-        for table_name, table in tables.items():
-            self.print_table(table_name, table)
+        rich_table = Table(
+            title=title,
+            show_header=True,
+            header_style="bold magenta",
+        )
+        rich_table.add_column(key_name, style="magenta")
+        rich_table.add_column(value_name, style="white")
+        for name, value in table.items():
+            if isinstance(value, float):
+                rich_table.add_row(name, f"{value:.5f}")
+            else:
+                rich_table.add_row(name, str(value))
+        self.console.print(rich_table)
 
     def print_results(
         self,
@@ -111,20 +153,9 @@ class LuxonisProgressBar(RichProgressBar):
         @type metrics: Mapping[str, Mapping[str, int | str | float]]
         @param metrics: Metrics in format {table_name: table}.
         """
-        if self._check_console():
-            self._console.rule(f"{stage}", style="bold magenta")
-            self._console.print(
-                f"[bold magenta]Loss:[/bold magenta] [white]{loss}[/white]"
-            )
-            self._console.print("[bold magenta]Metrics:[/bold magenta]")
-            self.print_tables(metrics)
-            self._console.rule(style="bold magenta")
-        else:
-            print(f"------{stage}-----")
-            print(f"Loss: {loss}")
-
-            for node_name, node_metrics in metrics.items():
-                for metric_name, metric_value in node_metrics.items():
-                    print(
-                        f"{stage} metric: {node_name}/{metric_name}: {metric_value:.4f}"
-                    )
+        self.console.rule(f"{stage}", style="bold magenta")
+        self.console.print(f"[bold magenta]Loss:[/bold magenta] [white]{loss}[/white]")
+        self.console.print("[bold magenta]Metrics:[/bold magenta]")
+        for table_name, table in metrics.items():
+            self.print_table(table_name, table)
+        self.console.rule(style="bold magenta")

--- a/luxonis_train/callbacks/luxonis_progress_bar.py
+++ b/luxonis_train/callbacks/luxonis_progress_bar.py
@@ -28,6 +28,17 @@ class BaseLuxonisProgressBar(ABC, ProgressBar):
         loss: float,
         metrics: Mapping[str, Mapping[str, int | str | float]],
     ) -> None:
+        """Prints results to the console.
+
+        This includes the stage name, loss value, and tables with metrics.
+
+        @type stage: str
+        @param stage: Stage name.
+        @type loss: float
+        @param loss: Loss value.
+        @type metrics: Mapping[str, Mapping[str, int | str | float]]
+        @param metrics: Metrics in format {table_name: table}.
+        """
         pass
 
 
@@ -37,6 +48,12 @@ class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
 
     def __init__(self):
         super().__init__(leave=True)
+
+    def _rule(self, title: str | None = None) -> None:
+        if title is not None:
+            print(f"------{title}-----")
+        else:
+            print("-----------------")
 
     def _print_table(
         self,
@@ -56,7 +73,7 @@ class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
         @type value_name: str
         @param value_name: Name of the value column. Defaults to C{"Value"}.
         """
-        print(f"------{title}-----")
+        self._rule(title)
         print(
             tabulate.tabulate(
                 table.items(),
@@ -73,21 +90,12 @@ class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
         loss: float,
         metrics: Mapping[str, Mapping[str, int | str | float]],
     ) -> None:
-        """Prints results to the console using rich text.
-
-        @type stage: str
-        @param stage: Stage name.
-        @type loss: float
-        @param loss: Loss value.
-        @type metrics: Mapping[str, Mapping[str, int | str | float]]
-        @param metrics: Metrics in format {table_name: table}.
-        """
-        print(f"------{stage}-----")
+        self._rule(stage)
         print(f"Loss: {loss}")
         print("Metrics:")
         for table_name, table in metrics.items():
             self._print_table(table_name, table)
-        print("-----------------")
+        self._rule()
 
 
 @CALLBACKS.register_module()
@@ -144,15 +152,6 @@ class LuxonisRichProgressBar(RichProgressBar, BaseLuxonisProgressBar):
         loss: float,
         metrics: Mapping[str, Mapping[str, int | str | float]],
     ) -> None:
-        """Prints results to the console using rich text.
-
-        @type stage: str
-        @param stage: Stage name.
-        @type loss: float
-        @param loss: Loss value.
-        @type metrics: Mapping[str, Mapping[str, int | str | float]]
-        @param metrics: Metrics in format {table_name: table}.
-        """
         self.console.rule(f"{stage}", style="bold magenta")
         self.console.print(f"[bold magenta]Loss:[/bold magenta] [white]{loss}[/white]")
         self.console.print("[bold magenta]Metrics:[/bold magenta]")

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -18,7 +18,7 @@ from luxonis_ml.nn_archive.config import CONFIG_VERSION
 from luxonis_ml.utils import LuxonisFileSystem, reset_logging, setup_logging
 
 from luxonis_train.attached_modules.visualizers import get_unnormalized_images
-from luxonis_train.callbacks import LuxonisProgressBar
+from luxonis_train.callbacks import LuxonisRichProgressBar, LuxonisTQDMProgressBar
 from luxonis_train.models import LuxonisLightningModule
 from luxonis_train.utils.config import Config
 from luxonis_train.utils.general import DatasetMetadata
@@ -118,7 +118,9 @@ class LuxonisModel:
             self.cfg,
             logger=self.tracker,
             deterministic=deterministic,
-            callbacks=LuxonisProgressBar(),
+            callbacks=LuxonisRichProgressBar()
+            if self.cfg.trainer.use_rich_progress_bar
+            else LuxonisTQDMProgressBar(),
         )
 
         self.loaders: dict[str, BaseLoaderTorch] = {}
@@ -441,7 +443,11 @@ class LuxonisModel:
                 input_shapes=self.loaders["train"].input_shapes,
                 _core=self,
             )
-            callbacks = [LuxonisProgressBar()]
+            callbacks = [
+                LuxonisRichProgressBar()
+                if cfg.trainer.use_rich_progress_bar
+                else LuxonisTQDMProgressBar()
+            ]
 
             pruner_callback = PyTorchLightningPruningCallback(trial, monitor="val/loss")
             callbacks.append(pruner_callback)

--- a/luxonis_train/models/luxonis_lightning.py
+++ b/luxonis_train/models/luxonis_lightning.py
@@ -22,7 +22,10 @@ from luxonis_train.attached_modules.visualizers import (
     combine_visualizations,
     get_unnormalized_images,
 )
-from luxonis_train.callbacks import LuxonisProgressBar, ModuleFreezer
+from luxonis_train.callbacks import (
+    BaseLuxonisProgressBar,
+    ModuleFreezer,
+)
 from luxonis_train.nodes import BaseNode
 from luxonis_train.utils.config import AttachedModuleConfig, Config
 from luxonis_train.utils.general import DatasetMetadata, to_shape_packet, traverse_graph
@@ -815,8 +818,8 @@ class LuxonisLightningModule(pl.LightningModule):
         )
 
     @property
-    def _progress_bar(self) -> LuxonisProgressBar:
-        return cast(LuxonisProgressBar, self._trainer.progress_bar_callback)
+    def _progress_bar(self) -> BaseLuxonisProgressBar:
+        return cast(BaseLuxonisProgressBar, self._trainer.progress_bar_callback)
 
     @rank_zero_only
     def _print_results(

--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -242,6 +242,7 @@ class SchedulerConfig(BaseModelExtraForbid):
 
 class TrainerConfig(BaseModelExtraForbid):
     preprocessing: PreprocessingConfig = PreprocessingConfig()
+    use_rich_progress_bar: bool = True
 
     accelerator: Literal["auto", "cpu", "gpu", "tpu"] = "auto"
     devices: int | list[int] | str = "auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 blobconverter>=1.4.2
-lightning>=2.0.0
+lightning>=2.4.0
 #luxonis-ml[all]>=0.1.0
 luxonis-ml[all]@git+https://github.com/luxonis/luxonis-ml.git@dev
 onnx>=1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ torchvision>=0.16.0
 typer>=0.9.0
 mlflow>=2.10.0
 psutil>=5.0.0
+tabulate>=0.9.0


### PR DESCRIPTION
- Added back the option to disable `RichProgressBar` to fix issues with logs not showing up when using `torchx`.
- The option is now under `trainer.use_rich_progress_bar`, set to `True` by default.
- `LuxonisProgressBar` split into `LuxonisRichProgressBar` and `LuxonisTQDMProgressBar`
  - `LuxonisRichProgressBar` uses `rich` to render progress bars and tables
  - `LuxonisTQDMProgressBar` uses `tqdm` and `tabulate`  