### PR TITLE
Increased default validation interval

### DIFF
--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -280,7 +280,7 @@ class TrainerConfig(BaseModelExtraForbid):
     epochs: PositiveInt = 100
     num_workers: NonNegativeInt = 4
     train_metrics_interval: Literal[-1] | PositiveInt = -1
-    validation_interval: Literal[-1] | PositiveInt = 1
+    validation_interval: Literal[-1] | PositiveInt = 5
     num_log_images: NonNegativeInt = 4
     skip_last_batch: bool = True
     pin_memory: bool = True


### PR DESCRIPTION
Increased default validation interval from 1 to 5 because it makes more sense for real training runs.