### PR TITLE
[Fix] Corrected config valid sequence for predefined models

### DIFF
--- a/luxonis_train/utils/config.py
+++ b/luxonis_train/utils/config.py
@@ -78,27 +78,6 @@ class ModelConfig(BaseModelExtraForbid):
     outputs: list[str] = []
 
     @model_validator(mode="after")
-    def check_main_metric(self) -> Self:
-        for metric in self.metrics:
-            if metric.is_main_metric:
-                logger.info(f"Main metric: `{metric.name}`")
-                return self
-
-        logger.warning("No main metric specified.")
-        if self.metrics:
-            metric = self.metrics[0]
-            metric.is_main_metric = True
-            name = metric.alias or metric.name
-            logger.info(f"Setting '{name}' as main metric.")
-        else:
-            logger.error(
-                "No metrics specified. "
-                "This is likely unintended unless "
-                "the configuration is not used for training."
-            )
-        return self
-
-    @model_validator(mode="after")
     def check_predefined_model(self) -> Self:
         from luxonis_train.utils.registry import MODELS
 
@@ -118,6 +97,27 @@ class ModelConfig(BaseModelExtraForbid):
             self.metrics += metrics
             self.visualizers += visualizers
 
+        return self
+
+    @model_validator(mode="after")
+    def check_main_metric(self) -> Self:
+        for metric in self.metrics:
+            if metric.is_main_metric:
+                logger.info(f"Main metric: `{metric.name}`")
+                return self
+
+        logger.warning("No main metric specified.")
+        if self.metrics:
+            metric = self.metrics[0]
+            metric.is_main_metric = True
+            name = metric.alias or metric.name
+            logger.info(f"Setting '{name}' as main metric.")
+        else:
+            logger.error(
+                "No metrics specified. "
+                "This is likely unintended unless "
+                "the configuration is not used for training."
+            )
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
Previously if you use predefined model you would get an error in the logs saying "No metrics specified..." due to them not being taken from the predefined model definition.

Now model config gets populated first with predefined configs and after that the main metric validation occurs resulting in no error in the logs.