### PR TITLE
Add video inference

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -50,10 +50,10 @@ SaveDirType = Annotated[
     typer.Option(help="Where to save the inference results."),
 ]
 
-ImgPathType = Annotated[
+SourcePathType = Annotated[
     str | None,
     typer.Option(
-        help="Path to an image file or a directory containing images for inference."
+        help="Path to an image file, a directory containing images or a video file for inference.",
     ),
 ]
 
@@ -106,14 +106,14 @@ def infer(
     config: ConfigType = None,
     view: ViewType = _ViewType.VAL,
     save_dir: SaveDirType = None,
-    img_path: ImgPathType = None,
+    source_path: SourcePathType = None,
     opts: OptsType = None,
 ):
     """Run inference."""
     from luxonis_train.core import LuxonisModel
 
     LuxonisModel(config, opts).infer(
-        view=view.value, save_dir=save_dir, img_path=img_path
+        view=view.value, save_dir=save_dir, source_path=source_path
     )
 
 

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -37,10 +37,25 @@ from .utils.export_utils import (
 from .utils.infer_utils import (
     process_dataset_images,
     process_images,
+    process_video,
 )
 from .utils.train_utils import create_trainer
 
 logger = getLogger(__name__)
+
+IMAGE_FORMATS = {
+    ".bmp",
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".dng",
+    ".webp",
+    ".mpo",
+    ".pfm",
+}
+VIDEO_FORMATS = {".mp4", ".mov", ".avi", ".mkv"}
 
 
 class LuxonisModel:
@@ -421,7 +436,7 @@ class LuxonisModel:
         self,
         view: Literal["train", "val", "test"] = "val",
         save_dir: str | Path | None = None,
-        img_path: str | None = None,
+        source_path: str | None = None,
     ) -> None:
         """Runs inference.
 
@@ -432,23 +447,29 @@ class LuxonisModel:
         @param save_dir: Directory where to save the visualizations. If
             not specified, visualizations will be rendered on the
             screen.
-        @type img_path: str | None
-        @param img_path: Path to the image file or directory for inference.
+        @type source_path: str | None
+        @param source_path: Path to the image file, video file or directory.
             If None, defaults to using dataset images.
         """
         self.lightning_module.eval()
 
-        if img_path:
-            img_path_obj = Path(img_path)
-            if img_path_obj.is_file():
-                process_images(self, [img_path_obj], view, save_dir)
-            elif img_path_obj.is_dir():
+        if source_path:
+            source_path_obj = Path(source_path)
+            if source_path_obj.suffix.lower() in VIDEO_FORMATS:
+                process_video(self, source_path_obj, view, save_dir)
+            elif source_path_obj.is_file():
+                process_images(self, [source_path_obj], view, save_dir)
+            elif source_path_obj.is_dir():
                 image_files = [
                     f
-                    for f in img_path_obj.iterdir()
-                    if f.suffix.lower() in {".png", ".jpg", ".jpeg"}
+                    for f in source_path_obj.iterdir()
+                    if f.suffix.lower() in IMAGE_FORMATS
                 ]
                 process_images(self, image_files, view, save_dir)
+            else:
+                raise ValueError(
+                    f"Source path {source_path} is not a valid file or directory."
+                )
         else:
             process_dataset_images(self, view, save_dir)
 

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -35,6 +35,8 @@ from .utils.export_utils import (
     try_onnx_simplify,
 )
 from .utils.infer_utils import (
+    IMAGE_FORMATS,
+    VIDEO_FORMATS,
     process_dataset_images,
     process_images,
     process_video,
@@ -42,20 +44,6 @@ from .utils.infer_utils import (
 from .utils.train_utils import create_trainer
 
 logger = getLogger(__name__)
-
-IMAGE_FORMATS = {
-    ".bmp",
-    ".jpg",
-    ".jpeg",
-    ".png",
-    ".tif",
-    ".tiff",
-    ".dng",
-    ".webp",
-    ".mpo",
-    ".pfm",
-}
-VIDEO_FORMATS = {".mp4", ".mov", ".avi", ".mkv"}
 
 
 class LuxonisModel:

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -101,7 +101,9 @@ def process_video(
             for name, viz_arrs in rendered_visualizations.items():
                 if name not in out_writers:
                     out_writers[name] = cv2.VideoWriter(
-                        filename=str(save_dir / f"{name.replace('/', '-')}.mp4"),
+                        filename=str(
+                            save_dir / f"{name.replace('/', '-')}.mp4"
+                        ),
                         fourcc=cv2.VideoWriter_fourcc(*"mp4v"),
                         fps=cap.get(cv2.CAP_PROP_FPS),
                         frameSize=(viz_arrs[0].shape[1], viz_arrs[0].shape[0]),

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -88,7 +88,6 @@ def process_video(
         model, view, (int(cap.get(4)), int(cap.get(3)), 3)
     )
 
-    counter = 0
     while cap.isOpened():
         ret, frame = cap.read()
         if not ret:

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -73,7 +73,7 @@ def process_video(
     show: bool = False,
 ) -> None:
     """Handles inference on a video."""
-    cap = cv2.VideoCapture(str(video_path))
+    cap = cv2.VideoCapture(filename=str(video_path))
     total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     progress_bar = tqdm.tqdm(
         total=total_frames, position=0, leave=True, desc="Processing video"
@@ -101,10 +101,10 @@ def process_video(
             for name, viz_arrs in rendered_visualizations.items():
                 if name not in out_writers:
                     out_writers[name] = cv2.VideoWriter(
-                        str(save_dir / f"{name.replace('/', '-')}.mp4"),
-                        cv2.VideoWriter_fourcc(*"mp4v"),
-                        cap.get(cv2.CAP_PROP_FPS),
-                        (viz_arrs[0].shape[1], viz_arrs[0].shape[0]),
+                        filename=str(save_dir / f"{name.replace('/', '-')}.mp4"),
+                        fourcc=cv2.VideoWriter_fourcc(*"mp4v"),
+                        fps=cap.get(cv2.CAP_PROP_FPS),
+                        frameSize=(viz_arrs[0].shape[1], viz_arrs[0].shape[0]),
                     )
                 for viz_arr in viz_arrs:
                     out_writers[name].write(viz_arr)

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -115,12 +115,12 @@ def process_video(
             for name, viz_arrs in rendered_visualizations.items():
                 if name not in out_writers:
                     out_writers[name] = cv2.VideoWriter(
-                        filename=str(
+                        filename=str(  # type: ignore
                             save_dir / f"{name.replace('/', '-')}.mp4"
                         ),
-                        fourcc=cv2.VideoWriter_fourcc(*"mp4v"),
-                        fps=cap.get(cv2.CAP_PROP_FPS),
-                        frameSize=(viz_arrs[0].shape[1], viz_arrs[0].shape[0]),
+                        fourcc=cv2.VideoWriter_fourcc(*"mp4v"),  # type: ignore
+                        fps=cap.get(cv2.CAP_PROP_FPS),  # type: ignore
+                        frameSize=(viz_arrs[0].shape[1], viz_arrs[0].shape[0]),  # type: ignore
                     )  # type: ignore
                 for viz_arr in viz_arrs:
                     out_writers[name].write(viz_arr)

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -15,7 +15,7 @@ def render_visualizations(
     visualizations: dict[str, dict[str, Tensor]],
     save_dir: str | Path | None,
     show: bool = True,
-) -> None:
+) -> dict[str, list[np.ndarray]]:
     """Render or save visualizations."""
     save_dir = Path(save_dir) if save_dir is not None else None
     if save_dir is not None:

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -10,6 +10,20 @@ from torch import Tensor
 from luxonis_train.attached_modules.visualizers import get_unnormalized_images
 from luxonis_train.enums import TaskType
 
+IMAGE_FORMATS = {
+    ".bmp",
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".dng",
+    ".webp",
+    ".mpo",
+    ".pfm",
+}
+VIDEO_FORMATS = {".mp4", ".mov", ".avi", ".mkv"}
+
 
 def render_visualizations(
     visualizations: dict[str, dict[str, Tensor]],

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -87,7 +87,7 @@ def process_video(
     show: bool = False,
 ) -> None:
     """Handles inference on a video."""
-    cap = cv2.VideoCapture(filename=str(video_path))
+    cap = cv2.VideoCapture(filename=str(video_path))  # type: ignore
     total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     progress_bar = tqdm.tqdm(
         total=total_frames, position=0, leave=True, desc="Processing video"
@@ -121,7 +121,7 @@ def process_video(
                         fourcc=cv2.VideoWriter_fourcc(*"mp4v"),
                         fps=cap.get(cv2.CAP_PROP_FPS),
                         frameSize=(viz_arrs[0].shape[1], viz_arrs[0].shape[0]),
-                    )
+                    )  # type: ignore
                 for viz_arr in viz_arrs:
                     out_writers[name].write(viz_arr)
 


### PR DESCRIPTION
This pull request includes several changes to enhance the inference capabilities of the `luxonis_train` module, particularly by adding support for video files and improving the handling of image and video sources. The most important changes include renaming variables for clarity, adding support for video processing, and updating the inference logic to accommodate these improvements.

### Enhancements to Inference Capabilities:

* [`luxonis_train/__main__.py`](diffhunk://#diff-edffd69fae1e1a3d23de321080cb35407f9591a2e03e22ba74074d48f9edec29L53-R56): Renamed `ImgPathType` to `SourcePathType` and updated the help text to include video files. Updated the `infer` function to use `source_path` instead of `img_path`. 

* [`luxonis_train/core/core.py`](diffhunk://#diff-aaa0e36bee1c6c3cd663a8dd04a39a455a1f4f21261356a5e86fc4bfc938bdb1R40-R59): Added `process_video` to the imports. Defined `IMAGE_FORMATS` and `VIDEO_FORMATS` sets for supported file types. Updated the `infer` method to handle video files and directories containing images.

### Improvements in Utility Functions:

* [`luxonis_train/core/utils/infer_utils.py`](diffhunk://#diff-c1fe3d7b3a9d1b7367a23592cfa87b8962cb754fe295823e6662c81611bf404eR1-R24): Added `process_video` function to handle video file inference. Refactored `process_images` and introduced `prepare_and_infer_image` for better code reuse. Updated `render_visualizations` to optionally return visualizations instead of displaying them.

### Possible improvements:

- Parallel video processing and batched inference
- Webcam/stream source for inference