### PR TITLE
Archive without Export

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -179,11 +179,11 @@ def inspect(
 @app.command()
 def archive(
     executable: Annotated[
-        str,
+        str | None,
         typer.Option(
             help="Path to the model file.", show_default=False, metavar="FILE"
         ),
-    ],
+    ] = None,
     config: ConfigType = None,
     opts: OptsType = None,
 ):

--- a/luxonis_train/callbacks/archive_on_train_end.py
+++ b/luxonis_train/callbacks/archive_on_train_end.py
@@ -31,7 +31,7 @@ class ArchiveOnTrainEnd(NeedsCheckpoint):
             if checkpoint is None:
                 logger.warning("Skipping model archiving.")
                 return
-            logger.info("Model executable not found, creating one.")
+            logger.info("Exported model not found. Exporting to ONNX...")
             pl_module.core.export(weights=checkpoint)
             onnx_path = pl_module.core._exported_models.get("onnx")
 

--- a/luxonis_train/callbacks/export_on_train_end.py
+++ b/luxonis_train/callbacks/export_on_train_end.py
@@ -24,9 +24,9 @@ class ExportOnTrainEnd(NeedsCheckpoint):
         @type pl_module: L{pl.LightningModule}
         @param pl_module: Pytorch Lightning module.
         """
-        path = self.get_checkpoint(pl_module)
-        if path is None:  # pragma: no cover
+        checkpoint = self.get_checkpoint(pl_module)
+        if checkpoint is None:  # pragma: no cover
             logger.warning("Skipping model export.")
             return
 
-        pl_module.core.export(weights=self.get_checkpoint(pl_module))
+        pl_module.core.export(weights=checkpoint)

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -498,7 +498,7 @@ class Config(LuxonisConfig):
         cls,
         cfg: str | dict[str, Any] | None = None,
         overrides: dict[str, Any] | list[str] | tuple[str, ...] | None = None,
-    ):
+    ) -> "Config":
         instance = super().get_config(cfg, overrides)
         if not isinstance(cfg, str):
             return instance

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -640,6 +640,7 @@ class LuxonisModel:
         outputs = []
 
         if path is None:
+            logger.warning("No model executable specified for archiving.")
             if "onnx" not in self._exported_models:
                 logger.info("Exporting model to ONNX...")
                 self.export()

--- a/luxonis_train/core/utils/archive_utils.py
+++ b/luxonis_train/core/utils/archive_utils.py
@@ -200,7 +200,8 @@ def _get_head_outputs(
     # TODO: Fix this, will require refactoring custom ONNX output names
     logger.error(
         "ONNX model uses custom output names, trying to determine outputs based on the head type. "
-        "This will likely result in incorrect archive for multi-head models."
+        "This will likely result in incorrect archive for multi-head models. "
+        "You can ignore this error if your model has only one head."
     )
 
     if head_type == "ClassificationHead":

--- a/luxonis_train/nodes/heads/ddrnet_segmentation_head.py
+++ b/luxonis_train/nodes/heads/ddrnet_segmentation_head.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -22,7 +23,15 @@ class DDRNetSegmentationHead(BaseNode[Tensor, Tensor]):
     def __init__(
         self,
         inter_channels: int = 64,
-        inter_mode: str = "bilinear",
+        inter_mode: Literal[
+            "nearest",
+            "linear",
+            "bilinear",
+            "bicubic",
+            "trilinear",
+            "area",
+            "pixel_shuffle",
+        ] = "bilinear",
         **kwargs,
     ):
         """DDRNet segmentation head.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage-badge>=1.1.0
 gdown>=4.2.0
-pre-commit>=3.2.1
+pre-commit>=3.2.1,<4.0.0
 opencv-stubs>=0.0.8
 pytest-cov>=4.1.0
 pytest-subtests>=0.12.1


### PR DESCRIPTION
`ArchiveOnTrainEnd` callback does no longer require `ExportOnTrainEnd` callback to be also defined.
If no exported model exists, `ArchiveOnTrainEnd` will export the model automatically.