### PR TITLE
`pre-commit<4.0.0`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage-badge>=1.1.0
 gdown>=4.2.0
-pre-commit>=3.2.1
+pre-commit>=3.2.1,<4.0.0
 opencv-stubs>=0.0.8
 pytest-cov>=4.1.0
 pytest-subtests>=0.12.1


### PR DESCRIPTION
Restricted `pre-commit` version to be less than `4.0.0`.
`docformatter` is not compatible with the new `pre-commit` version ([289](https://github.com/PyCQA/docformatter/issues/289))