### PR TITLE
Moved `assigner` and `labeler` to a separate workflow

### DIFF
--- a/.github/workflows/add-metadata.yaml
+++ b/.github/workflows/add-metadata.yaml
@@ -1,0 +1,29 @@
+name: Metadata
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: write
+  checks: write
+
+jobs:
+  assigner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign
+        uses: toshimaru/auto-author-assign@v2.1.1
+
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Labeler
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,25 +16,6 @@ permissions:
   checks: write
 
 jobs:
-  assigner:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Auto-assign
-        uses: toshimaru/auto-author-assign@v2.1.1
-
-  labeler:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-
-      - name: Labeler
-        uses: actions/labeler@v5
-        with:
-          configuration-path: .github/labeler.yaml
-
   pre-commit:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Moved the `assigner` and `labeler` jobs to a separate workflow.