### PR TITLE
Removed GitHub version of `luxonis-ml` from `requirements-dev.txt`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-luxonis-ml[data,tracker]@git+https://github.com/luxonis/luxonis-ml.git@main
 coverage-badge>=1.1.0
 gdown>=4.2.0
 pre-commit>=3.2.1,<4.0.0


### PR DESCRIPTION
Removed GH version of `luxonis-ml` package from dev requirements for publishing on PyPI to work