### PR TITLE
Add support for multi-label visualization

### DIFF
--- a/luxonis_train/attached_modules/metrics/README.md
+++ b/luxonis_train/attached_modules/metrics/README.md
@@ -19,6 +19,8 @@ Metrics from the [`torchmetrics`](https://lightning.ai/docs/torchmetrics/stable/
 - [Precision](https://lightning.ai/docs/torchmetrics/stable/classification/precision.html)
 - [Recall](https://lightning.ai/docs/torchmetrics/stable/classification/recall.html)
 
+> **Note:** For multi-label classification, ensure that you specify the `params.task` as `multilabel` when using these metrics.
+
 ## ObjectKeypointSimilarity
 
 For more information, see [object-keypoint-similarity](https://learnopencv.com/object-keypoint-similarity/).

--- a/luxonis_train/attached_modules/visualizers/README.md
+++ b/luxonis_train/attached_modules/visualizers/README.md
@@ -60,12 +60,13 @@ Visualizer for bounding boxes.
 
 **Parameters:**
 
-| Key            | Type                   | Default value | Description                                                               |
-| -------------- | ---------------------- | ------------- | ------------------------------------------------------------------------- |
-| `include_plot` | `bool`                 | `True`        | Whether to include a plot of the class probabilities in the visualization |
-| `color`        | `tuple[int, int, int]` | `(255, 0, 0)` | Color of the text                                                         |
-| `font_scale`   | `float`                | `1.0`         | Scale of the font                                                         |
-| `thickness`    | `int`                  | `1`           | Line thickness of the font                                                |
+| Key            | Type                   | Default value | Description                                                                      |
+| -------------- | ---------------------- | ------------- | -------------------------------------------------------------------------------- |
+| `include_plot` | `bool`                 | `True`        | Whether to include a plot of the class probabilities in the visualization        |
+| `color`        | `tuple[int, int, int]` | `(255, 0, 0)` | Color of the text                                                                |
+| `font_scale`   | `float`                | `1.0`         | Scale of the font                                                                |
+| `thickness`    | `int`                  | `1`           | Line thickness of the font                                                       |
+| `multi_label`  | `bool`                 | `False`       | Set to `True` for multi-label classification, otherwise `False` for single-label |
 
 **Example:**
 

--- a/luxonis_train/attached_modules/visualizers/classification_visualizer.py
+++ b/luxonis_train/attached_modules/visualizers/classification_visualizer.py
@@ -20,7 +20,7 @@ class ClassificationVisualizer(BaseVisualizer[Tensor, Tensor]):
         font_scale: float = 1.0,
         color: tuple[int, int, int] = (255, 0, 0),
         thickness: int = 1,
-        multi_label: bool = False,
+        multilabel: bool = False,
         **kwargs,
     ):
         """Visualizer for classification tasks.
@@ -34,11 +34,11 @@ class ClassificationVisualizer(BaseVisualizer[Tensor, Tensor]):
         self.font_scale = font_scale
         self.color = color
         self.thickness = thickness
-        self.multi_label = multi_label
+        self.multilabel = multilabel
 
     def _get_class_name(self, pred: Tensor) -> str:
         """Handles both single-label and multi-label classification."""
-        if self.multi_label:
+        if self.multilabel:
             idxs = (pred > 0.5).nonzero(as_tuple=True)[0].tolist()
             if self.class_names is None:
                 return ", ".join([str(idx) for idx in idxs])
@@ -52,7 +52,7 @@ class ClassificationVisualizer(BaseVisualizer[Tensor, Tensor]):
     def _generate_plot(
         self, prediction: Tensor, width: int, height: int
     ) -> Tensor:
-        if self.multi_label:
+        if self.multilabel:
             pred = prediction.sigmoid().detach().cpu().numpy()
         else:
             pred = prediction.softmax(-1).detach().cpu().numpy()

--- a/luxonis_train/attached_modules/visualizers/classification_visualizer.py
+++ b/luxonis_train/attached_modules/visualizers/classification_visualizer.py
@@ -35,15 +35,15 @@ class ClassificationVisualizer(BaseVisualizer[Tensor, Tensor]):
         self.thickness = thickness
 
     def _get_class_name(self, pred: Tensor) -> str:
-        idx = int((pred.argmax()).item())
+        idxs = (pred > 0.5).nonzero(as_tuple=True)[0].tolist()
         if self.class_names is None:
-            return str(idx)
-        return self.class_names[idx]
+            return ", ".join([str(idx) for idx in idxs])
+        return ", ".join([self.class_names[idx] for idx in idxs])
 
     def _generate_plot(
         self, prediction: Tensor, width: int, height: int
     ) -> Tensor:
-        pred = prediction.softmax(-1).detach().cpu().numpy()
+        pred = prediction.sigmoid().detach().cpu().numpy()
         fig, ax = plt.subplots(figsize=(width / 100, height / 100))
         ax.bar(np.arange(len(pred)), pred)
         ax.set_xticks(np.arange(len(pred)))


### PR DESCRIPTION
# Multiclass and Multilabel Classification Support in Luxonis-ML

## Overview

Luxonis-ML supports both multiclass and multi-label classification datasets. Our model components, including the `ClassificationHead` and the `BCEWithLogitsLoss`, were already compatible with multi-label tasks. However, there was an issue with the visualization of predictions due to the incorrect use of **softmax** for multi-label classification.

This PR improves the visualization logic to handle both multiclass and multi-label classification. The `multi_label` flag in the visualizer dictates whether **softmax** (for multiclass tasks) or **sigmoid** (for multi-label tasks) is applied, ensuring accurate representation of class probabilities based on the classification type.

## Changes

- **`multi_label` Flag**: The `multi_label` flag controls whether the visualizer operates in multiclass or multi-label mode. Set this flag to `True` to enable multi-label classification visualization, where independent probabilities for each class are displayed using `sigmoid`. Leave it as `False` (default) for multiclass tasks that use `softmax`.
