### PR TITLE
SequentialLR Scheduler

### DIFF
--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -1,0 +1,69 @@
+import multiprocessing as mp
+
+import pytest
+from luxonis_ml.data import LuxonisDataset
+
+from luxonis_train.core import LuxonisModel
+
+
+def create_model_config():
+    return {
+        "trainer": {
+            "n_sanity_val_steps": 0,
+            "preprocessing": {"train_image_size": [32, 32]},
+            "epochs": 2,
+            "batch_size": 4,
+            "num_workers": mp.cpu_count(),
+        },
+        "loader": {
+            "name": "LuxonisLoaderTorch",
+            "train_view": "train",
+            "params": {"dataset_name": "coco_test"},
+        },
+        "model": {
+            "name": "detection_light_model",
+            "predefined_model": {
+                "name": "DetectionModel",
+                "params": {
+                    "variant": "light",
+                },
+            },
+        },
+    }
+
+
+def sequential_scheduler():
+    return {
+        "name": "SequentialLR",
+        "params": {
+            "schedulers": [
+                {
+                    "name": "LinearLR",
+                    "params": {"start_factor": 0.1, "total_iters": 10},
+                },
+                {
+                    "name": "CosineAnnealingLR",
+                    "params": {"T_max": 1, "eta_min": 0.01},
+                },
+            ],
+            "milestones": [1],
+        },
+    }
+
+
+def cosine_annealing_scheduler():
+    return {
+        "name": "CosineAnnealingLR",
+        "params": {"T_max": 2, "eta_min": 0.001},
+    }
+
+
+@pytest.mark.parametrize(
+    "scheduler_config", [sequential_scheduler(), cosine_annealing_scheduler()]
+)
+def test_scheduler(coco_dataset: LuxonisDataset, scheduler_config):
+    config = create_model_config()
+    config["trainer"]["scheduler"] = scheduler_config
+    opts = {"loader.params.dataset_name": coco_dataset.dataset_name}
+    model = LuxonisModel(config, opts)
+    model.train()


### PR DESCRIPTION
# SequentialLR Support for Training

## Overview

This PR adds support for the `SequentialLR` learning rate scheduler in the training configuration. The `SequentialLR` scheduler allows for chaining multiple learning rate schedulers, making it possible to implement a warm-up phase followed by a more complex learning rate schedule during training.

## Changes

- **SequentialLR Integration**: You can now use the `SequentialLR` scheduler in the training configuration to combine multiple schedulers, such as a warm-up phase (`LinearLR`) followed by `CosineAnnealingLR`.
- **Configuration Example**:
  ```yaml
  scheduler:
    name: SequentialLR
    params:
      schedulers:
        - name: LinearLR               # Warmup phase
          params:
            start_factor: 0.1
            total_iters: 10
        - name: CosineAnnealingLR      # After warmup, switch to Cosine Annealing
          params:
            T_max: 299
            eta_min: 0.00001
      milestones: [10]  # Switch to CosineAnnealingLR after 10 iterations
