### PR TITLE
Add export output names specification for individual nodes

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -388,7 +388,7 @@ Here you can define configuration for exporting.
 | `mean_values`            | `list[float] \| None`             | `None`        | What mean values to use for input normalization. If not provided, inferred from augmentations  |
 | `upload_to_run`          | `bool`                            | `True`        | Whether to upload the exported files to tracked run as artifact                                |
 | `upload_url`             | `str \| None`                     | `None`        | Exported model will be uploaded to this URL if specified                                       |
-| `output_names`           | `list[str] \| None`               | `None`        | Optional list of output names to override the default ones                                     |
+| `output_names`           | `list[str] \| None`               | `None`        | Optional list of output names to override the default ones (deprecated)                        |
 
 ### `ONNX`
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -411,7 +411,6 @@ Option specific for `ONNX` export.
 
 ```yaml
 exporter:
-  output_names: ["output1", "output2"]
   onnx:
     opset_version: 11
   blobconverter:

--- a/configs/example_export.yaml
+++ b/configs/example_export.yaml
@@ -7,6 +7,8 @@ model:
     name: DetectionModel
     params:
       variant: light
+      head_params:
+       export_output_names: [output1_yolov6r2, output2_yolov6r2, output3_yolov6r2]
 
 loader:
   params:
@@ -42,7 +44,6 @@ trainer:
       last_epoch: -1
 
 exporter:
-  output_names: [output1_yolov6r2, output2_yolov6r2, output3_yolov6r2]
   onnx:
     opset_version: 11
   blobconverter:

--- a/luxonis_train/core/utils/archive_utils.py
+++ b/luxonis_train/core/utils/archive_utils.py
@@ -186,27 +186,7 @@ def _get_head_outputs(
         if name == head_name:
             output_names.append(output["name"])
 
-    if output_names:
-        return output_names
-
-    # TODO: Fix this, will require refactoring custom ONNX output names
-    logger.error(
-        "ONNX model uses custom output names, trying to determine outputs based on the head type. "
-        "This will likely result in incorrect archive for multi-head models. "
-        "You can ignore this error if your model has only one head."
-    )
-
-    if head_type == "ClassificationHead":
-        return [outputs[0]["name"]]
-    elif head_type == "EfficientBBoxHead":
-        return [output["name"] for output in outputs]
-    elif head_type in ["SegmentationHead", "BiSeNetHead"]:
-        return [outputs[0]["name"]]
-    elif head_type == "EfficientKeypointBBoxHead":
-        return [outputs[0]["name"]]
-    else:
-        raise ValueError("Unknown head name")
-
+    return output_names
 
 def get_heads(
     cfg: Config,
@@ -238,9 +218,15 @@ def get_heads(
                     task = str(next(iter(task.values())))
 
                 classes = _get_classes(node_name, task, class_dict)
-                head_outputs = _get_head_outputs(
-                    outputs, node_alias, node_name
-                )
+
+                export_output_names = nodes[node_alias].export_output_names
+                if export_output_names is not None:
+                    head_outputs = export_output_names
+                else:
+                    head_outputs = _get_head_outputs(
+                        outputs, node_alias, node_name
+                    )
+                
                 if node_alias in head_names:
                     curr_head_name = f"{node_alias}_{len(head_names)}"  # add suffix if name is already present
                 else:

--- a/luxonis_train/core/utils/archive_utils.py
+++ b/luxonis_train/core/utils/archive_utils.py
@@ -188,6 +188,7 @@ def _get_head_outputs(
 
     return output_names
 
+
 def get_heads(
     cfg: Config,
     outputs: list[dict],
@@ -226,7 +227,7 @@ def get_heads(
                     head_outputs = _get_head_outputs(
                         outputs, node_alias, node_name
                     )
-                
+
                 if node_alias in head_names:
                     curr_head_name = f"{node_alias}_{len(head_names)}"  # add suffix if name is already present
                 else:

--- a/luxonis_train/models/luxonis_lightning.py
+++ b/luxonis_train/models/luxonis_lightning.py
@@ -528,7 +528,7 @@ class LuxonisLightningModule(pl.LightningModule):
             logger.warning(
                 "The use of 'exporter.output_names' is deprecated and will be removed in a future version. "
                 "If 'node.export_output_names' are provided, they will take precedence and overwrite 'exporter.output_names'. "
-                "Please update your code to use 'node.export_output_names' directly."
+                "Please update your config to use 'node.export_output_names' directly."
             )
 
         export_output_names_used = False

--- a/luxonis_train/models/luxonis_lightning.py
+++ b/luxonis_train/models/luxonis_lightning.py
@@ -524,9 +524,18 @@ class LuxonisLightningModule(pl.LightningModule):
         for node_name, outs in outputs.items():
             output_counts[node_name] = sum(len(out) for out in outs.values())
 
+        if self.cfg.exporter.output_names is not None:
+            logger.warning(
+                "The use of 'exporter.output_names' is deprecated and will be removed in a future version. "
+                "If 'node.export_output_names' are provided, they will take precedence and overwrite 'exporter.output_names'. "
+                "Please update your code to use 'node.export_output_names' directly."
+            )
+
+        export_output_names_used = False
         export_output_names_dict = {}
         for node_name, node in self.nodes.items():
             if node.export_output_names is not None:
+                export_output_names_used = True
                 if len(node.export_output_names) != output_counts[node_name]:
                     logger.warning(
                         f"Number of provided output names for node {node_name} "
@@ -539,12 +548,37 @@ class LuxonisLightningModule(pl.LightningModule):
                         node.export_output_names
                     )
 
-        output_names = []
-        for node_name, output_name, i in output_order:
-            if node_name in export_output_names_dict:
-                output_names.append(export_output_names_dict[node_name][i])
-            else:
-                output_names.append(f"{node_name}/{output_name}/{i}")
+        if (
+            not export_output_names_used
+            and self.cfg.exporter.output_names is not None
+        ):
+            len_names = len(self.cfg.exporter.output_names)
+            if len_names != len(output_order):
+                logger.warning(
+                    f"Number of provided output names ({len_names}) does not match "
+                    f"number of outputs ({len(output_order)}). Using default names."
+                )
+                self.cfg.exporter.output_names = None
+
+            output_names = self.cfg.exporter.output_names or [
+                f"{node_name}/{output_name}/{i}"
+                for node_name, output_name, i in output_order
+            ]
+
+            if not self.cfg.exporter.output_names:
+                idx = 1
+                # Set to output names required by DAI
+                for i, output_name in enumerate(output_names):
+                    if output_name.startswith("EfficientBBoxHead"):
+                        output_names[i] = f"output{idx}_yolov6r2"
+                        idx += 1
+        else:
+            output_names = []
+            for node_name, output_name, i in output_order:
+                if node_name in export_output_names_dict:
+                    output_names.append(export_output_names_dict[node_name][i])
+                else:
+                    output_names.append(f"{node_name}/{output_name}/{i}")
 
         old_forward = self.forward
 

--- a/luxonis_train/nodes/base_node.py
+++ b/luxonis_train/nodes/base_node.py
@@ -119,6 +119,7 @@ class BaseNode(
         n_keypoints: int | None = None,
         in_sizes: Size | list[Size] | None = None,
         remove_on_export: bool = False,
+        export_output_names: list[str] | None = None,
         attach_index: AttachIndexType | None = None,
         _tasks: dict[TaskType, str] | None = None,
     ):
@@ -139,6 +140,11 @@ class BaseNode(
         @type in_sizes: Size | list[Size] | None
         @param in_sizes: List of input sizes for the node. Provide only
             in case the C{input_shapes} were not provided.
+        @type remove_on_export: bool
+        @param remove_on_export: If set to True, the node will be removed
+            from the model during export. Defaults to False.
+        @type export_output_names: list[str] | None
+        @param export_output_names: List of output names for the export.
         @type attach_index: AttachIndexType
         @param attach_index: Index of previous output that this node
             attaches to. Can be a single integer to specify a single
@@ -186,6 +192,7 @@ class BaseNode(
         self._n_keypoints = n_keypoints
         self._export = False
         self._remove_on_export = remove_on_export
+        self._export_output_names = export_output_names
         self._epoch = 0
         self._in_sizes = in_sizes
 
@@ -512,6 +519,11 @@ class BaseNode(
     def remove_on_export(self) -> bool:
         """Getter for the remove_on_export attribute."""
         return self._remove_on_export
+
+    @property
+    def export_output_names(self) -> list[str] | None:
+        """Getter for the export_output_names attribute."""
+        return self._export_output_names
 
     def unwrap(self, inputs: list[Packet[Tensor]]) -> ForwardInputT:
         """Prepares inputs for the forward pass.

--- a/luxonis_train/nodes/heads/efficient_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_bbox_head.py
@@ -78,7 +78,10 @@ class EfficientBBoxHead(
             self.export_output_names is None
             or len(self.export_output_names) != self.n_heads
         ):
-            if len(self.export_output_names) != self.n_heads:
+            if (
+                self.export_output_names is not None
+                and len(self.export_output_names) != self.n_heads
+            ):
                 logger.warning(
                     f"Number of provided output names ({len(self.export_output_names)}) "
                     f"does not match number of heads ({self.n_heads}). "

--- a/luxonis_train/nodes/heads/efficient_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_bbox_head.py
@@ -74,6 +74,19 @@ class EfficientBBoxHead(
                 in_channels=self.in_channels[i],
             )
             self.heads.append(curr_head)
+        if (
+            self.export_output_names is None
+            or len(self.export_output_names) != self.n_heads
+        ):
+            if len(self.export_output_names) != self.n_heads:
+                logger.warning(
+                    f"Number of provided output names ({len(self.export_output_names)}) "
+                    f"does not match number of heads ({self.n_heads}). "
+                    f"Using default names."
+                )
+            self._export_output_names = [
+                f"output{i+1}_yolov6r2" for i in range(self.n_heads)
+            ]
 
     def forward(
         self, inputs: list[Tensor]

--- a/luxonis_train/nodes/heads/efficient_keypoint_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_keypoint_bbox_head.py
@@ -64,6 +64,8 @@ class EfficientKeypointBBoxHead(EfficientBBoxHead):
             for x in self.in_channels
         )
 
+        self._export_output_names = None
+
     def forward(
         self, inputs: list[Tensor]
     ) -> tuple[list[Tensor], list[Tensor], list[Tensor], list[Tensor]]:

--- a/tests/configs/archive_config.yaml
+++ b/tests/configs/archive_config.yaml
@@ -7,33 +7,30 @@ model:
     - name: EfficientBBoxHead
       inputs:
         - EfficientRep
+      params:
+        export_output_names: [bbox0, bbox1, bbox2]
 
     - name: EfficientKeypointBBoxHead
       inputs:
         - EfficientRep
+      params:
+        export_output_names: [effkpt0, effkpt1, effkpt2]
 
     - name: SegmentationHead
       inputs:
         - EfficientRep
+      params:
+        export_output_names: [seg0, seg1]
 
     - name: BiSeNetHead
       inputs:
         - EfficientRep
+      params:
+        export_output_names: [impl]
 
     - name: ClassificationHead
       inputs:
         - EfficientRep
-
-exporter:
-  output_names:
-    - seg0
-    - class0
-    - bbox0
-    - bbox1
-    - bbox2
-    - effkpt0
-    - effkpt1
-    - effkpt2
-    - impl
-    - seg1
+      params:
+        export_output_names: [class0]
 

--- a/tests/integration/parking_lot.json
+++ b/tests/integration/parking_lot.json
@@ -164,9 +164,9 @@
                     "subtype": "yolov6"
                 },
                 "outputs": [
-                    "bbox-head/boundingbox/0",
-                    "bbox-head/boundingbox/1",
-                    "bbox-head/boundingbox/2"
+                    "output1_yolov6r2",
+                    "output2_yolov6r2",
+                    "output3_yolov6r2"
                 ]
             },
             {

--- a/tests/integration/parking_lot.json
+++ b/tests/integration/parking_lot.json
@@ -47,7 +47,7 @@
                 "layout": "NCHW"
             },
             {
-                "name": "bbox-head/boundingbox/0",
+                "name": "output1_yolov6r2",
                 "dtype": "float32",
                 "shape": [
                     1,
@@ -58,7 +58,7 @@
                 "layout": "NCHW"
             },
             {
-                "name": "bbox-head/boundingbox/1",
+                "name": "output2_yolov6r2",
                 "dtype": "float32",
                 "shape": [
                     1,
@@ -69,7 +69,7 @@
                 "layout": "NCHW"
             },
             {
-                "name": "bbox-head/boundingbox/2",
+                "name": "output3_yolov6r2",
                 "dtype": "float32",
                 "shape": [
                     1,


### PR DESCRIPTION
This pull request includes changes to deprecate the `output_names` configuration in favor of `export_output_names` for more granular control. It updates the documentation, configuration files, and relevant code to reflect this change.

### Deprecation of `output_names`:

* [`configs/README.md`](diffhunk://#diff-26db36ffc817266dc58ecfee77c2d48a7b42090938e644ab8bf35b4696f3e3e3L391-R391): Marked `output_names` as deprecated in the documentation.
* [`luxonis_train/models/luxonis_lightning.py`](diffhunk://#diff-81464460706d481358131ac236b9102acacfcc172680c2b8f976dc70ba37e7e1R523-R554): Added a warning message about the deprecation of `exporter.output_names` and implemented logic to use `node.export_output_names` if provided. [[1]](diffhunk://#diff-81464460706d481358131ac236b9102acacfcc172680c2b8f976dc70ba37e7e1R523-R554) [[2]](diffhunk://#diff-81464460706d481358131ac236b9102acacfcc172680c2b8f976dc70ba37e7e1R575-R581)

### Configuration updates:

* [`configs/example_export.yaml`](diffhunk://#diff-6fe37fe278ac632dc5b25f81091c2789216142578dd5a89049cf3129f11577ccR10-R11): Removed `output_names` and added `export_output_names` under `head_params`. [[1]](diffhunk://#diff-6fe37fe278ac632dc5b25f81091c2789216142578dd5a89049cf3129f11577ccR10-R11) [[2]](diffhunk://#diff-6fe37fe278ac632dc5b25f81091c2789216142578dd5a89049cf3129f11577ccL45)
* [`tests/configs/archive_config.yaml`](diffhunk://#diff-f8bf6e01fff53ac1f5ce162552749eeb5cd7ed58fb15c3d5dcfc8074d4896e29R10-R35): Updated the configuration to use `export_output_names` for various nodes.

### Code changes:

* [`luxonis_train/nodes/base_node.py`](diffhunk://#diff-d2c6ee7bd11bfb00ba122300c93a3127e45450548f2022228c482465e35f358eR122): Added `export_output_names` as an attribute and updated the constructor and property methods accordingly. [[1]](diffhunk://#diff-d2c6ee7bd11bfb00ba122300c93a3127e45450548f2022228c482465e35f358eR122) [[2]](diffhunk://#diff-d2c6ee7bd11bfb00ba122300c93a3127e45450548f2022228c482465e35f358eR143-R147) [[3]](diffhunk://#diff-d2c6ee7bd11bfb00ba122300c93a3127e45450548f2022228c482465e35f358eR195) [[4]](diffhunk://#diff-d2c6ee7bd11bfb00ba122300c93a3127e45450548f2022228c482465e35f358eR523-R527)
* [`luxonis_train/nodes/heads/efficient_bbox_head.py`](diffhunk://#diff-976671347651a5d336e4f712bcf9afc07ae0f24be5907a71dac72d4ead40dcf7R77-R92): Added logic to handle `export_output_names` in the constructor.