### PR TITLE
Add model EMA (Exponential Moving Average)

### DIFF
--- a/luxonis_train/callbacks/README.md
+++ b/luxonis_train/callbacks/README.md
@@ -65,3 +65,16 @@ Callback to perform a test run at the end of the training.
 ## `UploadCheckpoint`
 
 Callback that uploads currently the best checkpoint (based on validation loss) to the tracker location - where all other logs are stored.
+
+## `EMACallback`
+
+Callback that updates the stored parameters using a moving average.
+
+**Parameters:**
+
+| Key                 | Type    | Default value | Description                                                                                     |
+| ------------------- | ------- | ------------- | ----------------------------------------------------------------------------------------------- |
+| `decay`             | `float` | `0.5`         | Decay factor for the moving average.                                                            |
+| `use_dynamic_decay` | `bool`  | `True`        | Whether to use dynamic decay.                                                                   |
+| `decay_tau`         | `float` | `2000`        | Decay tau for dynamic decay.                                                                    |
+| `device`            | `str`   | `None`        | Device to use for the moving average. If `None`, the device is inferred from the model's device |

--- a/luxonis_train/callbacks/__init__.py
+++ b/luxonis_train/callbacks/__init__.py
@@ -13,6 +13,7 @@ from lightning.pytorch.callbacks import (
 from luxonis_train.utils.registry import CALLBACKS
 
 from .archive_on_train_end import ArchiveOnTrainEnd
+from .ema import EMACallback
 from .export_on_train_end import ExportOnTrainEnd
 from .gpu_stats_monitor import GPUStatsMonitor
 from .luxonis_progress_bar import (
@@ -34,6 +35,7 @@ CALLBACKS.register_module(module=GradientAccumulationScheduler)
 CALLBACKS.register_module(module=StochasticWeightAveraging)
 CALLBACKS.register_module(module=Timer)
 CALLBACKS.register_module(module=ModelPruning)
+CALLBACKS.register_module(module=EMACallback)
 
 
 __all__ = [
@@ -47,4 +49,5 @@ __all__ = [
     "TestOnTrainEnd",
     "UploadCheckpoint",
     "GPUStatsMonitor",
+    "EMACallback",
 ]

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -154,8 +154,8 @@ class EMACallback(Callback):
         @type batch_idx: int
         @param batch_idx: Batch index.
         """
-
-        self.ema.update(pl_module)  # type: ignore
+        if self.ema is not None:
+            self.ema.update(pl_module)
 
     def on_validation_epoch_start(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -83,6 +83,8 @@ class ModelEma(nn.Module):
                 self.state_dict_ema.values(), model.state_dict().values()
             ):
                 if ema_v.is_floating_point():
+                    if self.device is not None:
+                        model_v = model_v.to(device=self.device)
                     ema_lerp_values.append(ema_v)
                     model_lerp_values.append(model_v)
                 else:

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -171,7 +171,8 @@ class EMACallback(Callback):
 
         self.collected_state_dict = deepcopy(pl_module.state_dict())
 
-        pl_module.load_state_dict(self.ema.state_dict_ema)
+        if self.ema is not None:
+            pl_module.load_state_dict(self.ema.state_dict_ema)
 
     def on_validation_end(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule
@@ -183,7 +184,8 @@ class EMACallback(Callback):
         @type pl_module: L{pl.LightningModule}
         @param pl_module: Pytorch Lightning module.
         """
-        pl_module.load_state_dict(self.collected_state_dict)
+        if self.collected_state_dict is not None:
+            pl_module.load_state_dict(self.collected_state_dict)
 
     def on_train_end(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule
@@ -195,8 +197,9 @@ class EMACallback(Callback):
         @type pl_module: L{pl.LightningModule}
         @param pl_module: Pytorch Lightning module.
         """
-        pl_module.load_state_dict(self.ema.state_dict_ema)
-        logger.info("Model weights replaced with the EMA weights.")
+        if self.ema is not None:
+            pl_module.load_state_dict(self.ema.state_dict_ema)
+            logger.info("Model weights replaced with the EMA weights.")
 
     def on_save_checkpoint(
         self,
@@ -213,7 +216,8 @@ class EMACallback(Callback):
         @type checkpoint: dict
         @param checkpoint: Pytorch Lightning checkpoint.
         """
-        checkpoint["state_dict"] = self.ema.state_dict_ema
+        if self.ema is not None:
+            checkpoint["state_dict"] = self.ema.state_dict_ema
 
     def on_load_checkpoint(self, callback_state: dict) -> None:
         """Load the EMA state_dict from the checkpoint.
@@ -221,4 +225,5 @@ class EMACallback(Callback):
         @type callback_state: dict
         @param callback_state: Pytorch Lightning callback state.
         """
-        self.ema.state_dict_ema = callback_state["state_dict"]
+        if self.ema is not None:
+            self.ema.state_dict_ema = callback_state["state_dict"]

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -155,7 +155,7 @@ class EMACallback(Callback):
         @param batch_idx: Batch index.
         """
 
-        self.ema.update(pl_module) # type: ignore
+        self.ema.update(pl_module)  # type: ignore
 
     def on_validation_epoch_start(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -1,25 +1,31 @@
 import logging
-from typing import Any, List, Tuple, Union
+import math
+from copy import deepcopy
+from typing import Any
 
 import pytorch_lightning as pl
 import torch
-from copy import deepcopy
-from torch import nn
-from torch import Tensor
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.utilities.types import STEP_OUTPUT
-import math
-
+from torch import nn
 
 logger = logging.getLogger(__name__)
 
 
 class ModelEma(nn.Module):
     """Model Exponential Moving Average.
-    Keeps a moving average of everything in the model.state_dict (parameters and buffers).
+
+    Keeps a moving average of everything in the model.state_dict
+    (parameters and buffers).
     """
 
-    def __init__(self, model: pl.LightningModule, decay: float = 0.9999, use_dynamic_decay: bool = True, device: str = None):
+    def __init__(
+        self,
+        model: pl.LightningModule,
+        decay: float = 0.9999,
+        use_dynamic_decay: bool = True,
+        device: str = None,
+    ):
         """Constructs `ModelEma`.
 
         @type model: L{pl.LightningModule}
@@ -43,10 +49,12 @@ class ModelEma(nn.Module):
         self.use_dynamic_decay = use_dynamic_decay
         self.device = device
         if self.device is not None:
-            self.state_dict = {k: v.to(device=device) for k, v in self.state_dict.items()}
+            self.state_dict = {
+                k: v.to(device=device) for k, v in self.state_dict.items()
+            }
 
     def update(self, model: pl.LightningModule) -> None:
-        """Update the stored parameters using a moving average
+        """Update the stored parameters using a moving average.
 
         @type model: L{pl.LightningModule}
         @param model: Pytorch Lightning module.
@@ -57,7 +65,9 @@ class ModelEma(nn.Module):
                     self.updates += 1
 
                     if self.use_dynamic_decay:
-                        decay = self.decay * (1 - math.exp(-self.updates / 2000))
+                        decay = self.decay * (
+                            1 - math.exp(-self.updates / 2000)
+                        )
                     else:
                         decay = self.decay
 
@@ -65,22 +75,30 @@ class ModelEma(nn.Module):
                     if self.device is not None:
                         model_p = model_p.to(device=self.device)
                     ema_p *= decay
-                    ema_p += (1. - decay) * model_p
+                    ema_p += (1.0 - decay) * model_p
+
 
 class EMACallback(Callback):
-    """
-    Callback that updates the stored parameters using a moving average.
-    """
+    """Callback that updates the stored parameters using a moving
+    average."""
 
-    def __init__(self, decay: float = 0.9999, use_dynamic_decay: bool = True, use_ema_weights: bool = True, device: str = None):
+    def __init__(
+        self,
+        decay: float = 0.9999,
+        use_dynamic_decay: bool = True,
+        use_ema_weights: bool = True,
+        device: str = None,
+    ):
         """Constructs `EMACallback`.
 
         @type decay: float
         @param decay: Decay rate for the moving average.
         @type use_dynamic_decay: bool
-        @param use_dynamic_decay: Use dynamic decay rate. If True, the decay rate will be updated based on the number of updates.
+        @param use_dynamic_decay: Use dynamic decay rate. If True, the
+            decay rate will be updated based on the number of updates.
         @type use_ema_weights: bool
-        @param use_ema_weights: Use EMA weights (replace model weights with EMA weights)
+        @param use_ema_weights: Use EMA weights (replace model weights
+            with EMA weights)
         @type device: str
         @param device: Device to perform EMA on.
         """
@@ -92,8 +110,11 @@ class EMACallback(Callback):
         self.ema = None
         self.collected_state_dict = None
 
-    def on_fit_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
-        """Initialize `ModelEma` to keep a copy of the moving average of the weights
+    def on_fit_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        """Initialize `ModelEma` to keep a copy of the moving average of
+        the weights.
 
         @type trainer: L{pl.Trainer}
         @param trainer: Pytorch Lightning trainer.
@@ -101,7 +122,12 @@ class EMACallback(Callback):
         @param pl_module: Pytorch Lightning module.
         """
 
-        self.ema = ModelEma(pl_module, decay=self.decay, use_dynamic_decay = self.use_dynamic_decay, device=self.device)
+        self.ema = ModelEma(
+            pl_module,
+            decay=self.decay,
+            use_dynamic_decay=self.use_dynamic_decay,
+            device=self.device,
+        )
 
     def on_train_batch_end(
         self,
@@ -111,7 +137,7 @@ class EMACallback(Callback):
         batch: Any,
         batch_idx: int,
     ) -> None:
-        """Update the stored parameters using a moving average
+        """Update the stored parameters using a moving average.
 
         @type trainer: L{pl.Trainer}
         @param trainer: Pytorch Lightning trainer.
@@ -124,11 +150,14 @@ class EMACallback(Callback):
         @type batch_idx: int
         @param batch_idx: Batch index.
         """
-        
+
         self.ema.update(pl_module)
 
-    def on_validation_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
-        """Do validation using the stored parameters. Save the original parameters before replacing with EMA version.
+    def on_validation_epoch_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        """Do validation using the stored parameters. Save the original
+        parameters before replacing with EMA version.
 
         @type trainer: L{pl.Trainer}
         @param trainer: Pytorch Lightning trainer.
@@ -140,8 +169,10 @@ class EMACallback(Callback):
 
         pl_module.load_state_dict(self.ema.state_dict)
 
-    def on_validation_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
-        """Restore original parameters to resume training later
+    def on_validation_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        """Restore original parameters to resume training later.
 
         @type trainer: L{pl.Trainer}
         @param trainer: Pytorch Lightning trainer.
@@ -150,8 +181,10 @@ class EMACallback(Callback):
         """
         pl_module.load_state_dict(self.collected_state_dict)
 
-    def on_train_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
-        """Update the LightningModule with the EMA weights 
+    def on_train_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        """Update the LightningModule with the EMA weights.
 
         @type trainer: L{pl.Trainer}
         @param trainer: Pytorch Lightning trainer.
@@ -162,8 +195,13 @@ class EMACallback(Callback):
             pl_module.load_state_dict(self.ema.state_dict)
             logger.info("Model weights replaced with the EMA weights.")
 
-    def on_save_checkpoint(self, trainer: pl.Trainer, pl_module: pl.LightningModule, checkpoint: dict) -> None: # or dict?
-        """Save the EMA state_dict to the checkpoint
+    def on_save_checkpoint(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        checkpoint: dict,
+    ) -> None:  # or dict?
+        """Save the EMA state_dict to the checkpoint.
 
         @type trainer: L{pl.Trainer}
         @param trainer: Pytorch Lightning trainer.
@@ -178,8 +216,8 @@ class EMACallback(Callback):
             checkpoint["state_dict_ema"] = self.ema.state_dict
 
     def on_load_checkpoint(self, callback_state: dict) -> None:
-        """Load the EMA state_dict from the checkpoint
-        
+        """Load the EMA state_dict from the checkpoint.
+
         @type callback_state: dict
         @param callback_state: Pytorch Lightning callback state.
         """

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -1,0 +1,189 @@
+import logging
+from typing import Any, List, Tuple, Union
+
+import pytorch_lightning as pl
+import torch
+from copy import deepcopy
+from torch import nn
+from torch import Tensor
+from pytorch_lightning.callbacks import Callback
+from pytorch_lightning.utilities.types import STEP_OUTPUT
+import math
+
+
+logger = logging.getLogger(__name__)
+
+
+class ModelEma(nn.Module):
+    """Model Exponential Moving Average.
+    Keeps a moving average of everything in the model.state_dict (parameters and buffers).
+    """
+
+    def __init__(self, model: pl.LightningModule, decay: float = 0.9999, use_dynamic_decay: bool = True, device: str = None):
+        """Constructs `ModelEma`.
+
+        @type model: L{pl.LightningModule}
+        @param model: Pytorch Lightning module.
+        @type decay: float
+        @param decay: Decay rate for the moving average.
+        @type use_dynamic_decay: bool
+        @param use_dynamic_decay: Use dynamic decay rate.
+        @type device: str
+        @param device: Device to perform EMA on.
+        """
+        super(ModelEma, self).__init__()
+        model.eval()
+        self.state_dict = deepcopy(model.state_dict())
+        model.train()
+
+        for p in self.state_dict.values():
+            p.requires_grad = False
+        self.updates = 0
+        self.decay = decay
+        self.use_dynamic_decay = use_dynamic_decay
+        self.device = device
+        if self.device is not None:
+            self.state_dict = {k: v.to(device=device) for k, v in self.state_dict.items()}
+
+    def update(self, model: pl.LightningModule) -> None:
+        """Update the stored parameters using a moving average
+
+        @type model: L{pl.LightningModule}
+        @param model: Pytorch Lightning module.
+        """
+        with torch.no_grad():
+            for k, ema_p in self.state_dict.items():
+                if ema_p.dtype.is_floating_point:
+                    self.updates += 1
+
+                    if self.use_dynamic_decay:
+                        decay = self.decay * (1 - math.exp(-self.updates / 2000))
+                    else:
+                        decay = self.decay
+
+                    model_p = model.state_dict()[k]
+                    if self.device is not None:
+                        model_p = model_p.to(device=self.device)
+                    ema_p *= decay
+                    ema_p += (1. - decay) * model_p
+
+class EMACallback(Callback):
+    """
+    Callback that updates the stored parameters using a moving average.
+    """
+
+    def __init__(self, decay: float = 0.9999, use_dynamic_decay: bool = True, use_ema_weights: bool = True, device: str = None):
+        """Constructs `EMACallback`.
+
+        @type decay: float
+        @param decay: Decay rate for the moving average.
+        @type use_dynamic_decay: bool
+        @param use_dynamic_decay: Use dynamic decay rate. If True, the decay rate will be updated based on the number of updates.
+        @type use_ema_weights: bool
+        @param use_ema_weights: Use EMA weights (replace model weights with EMA weights)
+        @type device: str
+        @param device: Device to perform EMA on.
+        """
+        self.decay = decay
+        self.use_dynamic_decay = use_dynamic_decay
+        self.use_ema_weights = use_ema_weights
+        self.device = device
+
+        self.ema = None
+        self.collected_state_dict = None
+
+    def on_fit_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Initialize `ModelEma` to keep a copy of the moving average of the weights
+
+        @type trainer: L{pl.Trainer}
+        @param trainer: Pytorch Lightning trainer.
+        @type pl_module: L{pl.LightningModule}
+        @param pl_module: Pytorch Lightning module.
+        """
+
+        self.ema = ModelEma(pl_module, decay=self.decay, use_dynamic_decay = self.use_dynamic_decay, device=self.device)
+
+    def on_train_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        """Update the stored parameters using a moving average
+
+        @type trainer: L{pl.Trainer}
+        @param trainer: Pytorch Lightning trainer.
+        @type pl_module: L{pl.LightningModule}
+        @param pl_module: Pytorch Lightning module.
+        @type outputs: Any
+        @param outputs: Outputs from the training step.
+        @type batch: Any
+        @param batch: Batch data.
+        @type batch_idx: int
+        @param batch_idx: Batch index.
+        """
+        
+        self.ema.update(pl_module)
+
+    def on_validation_epoch_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Do validation using the stored parameters. Save the original parameters before replacing with EMA version.
+
+        @type trainer: L{pl.Trainer}
+        @param trainer: Pytorch Lightning trainer.
+        @type pl_module: L{pl.LightningModule}
+        @param pl_module: Pytorch Lightning module.
+        """
+
+        self.collected_state_dict = deepcopy(pl_module.state_dict())
+
+        pl_module.load_state_dict(self.ema.state_dict)
+
+    def on_validation_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Restore original parameters to resume training later
+
+        @type trainer: L{pl.Trainer}
+        @param trainer: Pytorch Lightning trainer.
+        @type pl_module: L{pl.LightningModule}
+        @param pl_module: Pytorch Lightning module.
+        """
+        pl_module.load_state_dict(self.collected_state_dict)
+
+    def on_train_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Update the LightningModule with the EMA weights 
+
+        @type trainer: L{pl.Trainer}
+        @param trainer: Pytorch Lightning trainer.
+        @type pl_module: L{pl.LightningModule}
+        @param pl_module: Pytorch Lightning module.
+        """
+        if self.use_ema_weights:
+            pl_module.load_state_dict(self.ema.state_dict)
+            logger.info("Model weights replaced with the EMA weights.")
+
+    def on_save_checkpoint(self, trainer: pl.Trainer, pl_module: pl.LightningModule, checkpoint: dict) -> None: # or dict?
+        """Save the EMA state_dict to the checkpoint
+
+        @type trainer: L{pl.Trainer}
+        @param trainer: Pytorch Lightning trainer.
+        @type pl_module: L{pl.LightningModule}
+        @param pl_module: Pytorch Lightning module.
+        @type checkpoint: dict
+        @param checkpoint: Pytorch Lightning checkpoint.
+        """
+        if self.use_ema_weights:
+            checkpoint["state_dict"] = self.ema.state_dict
+        elif self.ema is not None:
+            checkpoint["state_dict_ema"] = self.ema.state_dict
+
+    def on_load_checkpoint(self, callback_state: dict) -> None:
+        """Load the EMA state_dict from the checkpoint
+        
+        @type callback_state: dict
+        @param callback_state: Pytorch Lightning callback state.
+        """
+        if self.use_ema_weights:
+            self.ema.state_dict = callback_state["state_dict"]
+        elif self.ema is not None:
+            self.ema.state_dict = callback_state["state_dict_ema"]

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -60,26 +60,43 @@ class ModelEma(nn.Module):
     def update(self, model: pl.LightningModule) -> None:
         """Update the stored parameters using a moving average.
 
+        Source: U{<https://github.com/huggingface/pytorch-image-models/blob/main/timm/utils/model_ema.py>}
+
+        @license: U{Apache License 2.0<https://github.com/huggingface/pytorch-image-models/tree/main?tab=Apache-2.0-1-ov-file#readme>}
+
         @type model: L{pl.LightningModule}
         @param model: Pytorch Lightning module.
         """
         with torch.no_grad():
-            for k, ema_p in self.state_dict_ema.items():
-                if ema_p.dtype.is_floating_point:
-                    self.updates += 1
+            self.updates += 1
 
-                    if self.use_dynamic_decay:
-                        decay = self.decay * (
-                            1 - math.exp(-self.updates / self.decay_tau)
-                        )
-                    else:
-                        decay = self.decay
+            if self.use_dynamic_decay:
+                decay = self.decay * (
+                    1 - math.exp(-self.updates / self.decay_tau)
+                )
+            else:
+                decay = self.decay
 
-                    model_p = model.state_dict()[k]
-                    if self.device is not None:
-                        model_p = model_p.to(device=self.device)
-                    ema_p *= decay
-                    ema_p += (1.0 - decay) * model_p
+            ema_lerp_values = []
+            model_lerp_values = []
+            for ema_v, model_v in zip(
+                self.state_dict_ema.values(), model.state_dict().values()
+            ):
+                if ema_v.is_floating_point():
+                    ema_lerp_values.append(ema_v)
+                    model_lerp_values.append(model_v)
+                else:
+                    ema_v.copy_(model_v)
+
+            if hasattr(torch, "_foreach_lerp_"):
+                torch._foreach_lerp_(
+                    ema_lerp_values, model_lerp_values, weight=1.0 - decay
+                )
+            else:
+                torch._foreach_mul_(ema_lerp_values, scalar=decay)
+                torch._foreach_add_(
+                    ema_lerp_values, model_lerp_values, alpha=1.0 - decay
+                )
 
 
 class EMACallback(Callback):
@@ -154,8 +171,9 @@ class EMACallback(Callback):
         @type batch_idx: int
         @param batch_idx: Batch index.
         """
-        if self.ema is not None:
-            self.ema.update(pl_module)
+        if batch_idx % trainer.accumulate_grad_batches == 0:
+            if self.ema is not None:
+                self.ema.update(pl_module)
 
     def on_validation_epoch_start(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -411,6 +411,21 @@ class TrainerConfig(BaseModelExtraForbid):
             self.validation_interval = self.epochs
         return self
 
+    @model_validator(mode="after")
+    def reorder_callbacks(self) -> Self:
+        """Reorder callbacks so that EMA is the first callback, since it
+        needs to be updated before other callbacks."""
+        ema_index = None
+        for i, callback in enumerate(self.callbacks):
+            if callback.name == "EMACallback":
+                ema_index = i
+                break
+        if ema_index is not None:
+            ema_callback = self.callbacks.pop(ema_index)
+            self.callbacks.insert(0, ema_callback)
+
+        return self
+
 
 class OnnxExportConfig(BaseModelExtraForbid):
     opset_version: PositiveInt = 12

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -415,15 +415,7 @@ class TrainerConfig(BaseModelExtraForbid):
     def reorder_callbacks(self) -> Self:
         """Reorder callbacks so that EMA is the first callback, since it
         needs to be updated before other callbacks."""
-        ema_index = None
-        for i, callback in enumerate(self.callbacks):
-            if callback.name == "EMACallback":
-                ema_index = i
-                break
-        if ema_index is not None:
-            ema_callback = self.callbacks.pop(ema_index)
-            self.callbacks.insert(0, ema_callback)
-
+        self.callbacks.sort(key=lambda v: 0 if v.name == "EMACallback" else 1)
         return self
 
 

--- a/tests/unittests/test_callbacks/test_ema.py
+++ b/tests/unittests/test_callbacks/test_ema.py
@@ -44,9 +44,11 @@ def test_ema_update_on_batch_end(model, ema_callback):
         k: v.clone() for k, v in ema_callback.ema.state_dict_ema.items()
     }
 
-    outputs = None  # Use a dummy output
     batch = torch.rand(2, 2)
     batch_idx = 0
+
+    model.train()
+    outputs = model(batch)
 
     ema_callback.on_train_batch_end(trainer, model, outputs, batch, batch_idx)
 

--- a/tests/unittests/test_callbacks/test_ema.py
+++ b/tests/unittests/test_callbacks/test_ema.py
@@ -38,6 +38,7 @@ def test_ema_initialization(model, ema_callback):
 
 def test_ema_update_on_batch_end(model, ema_callback):
     trainer = Trainer()
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     ema_callback.on_fit_start(trainer, model)
 
     initial_ema_state = {
@@ -49,6 +50,9 @@ def test_ema_update_on_batch_end(model, ema_callback):
 
     model.train()
     outputs = model(batch)
+    model.zero_grad()
+    outputs.sum().backward()
+    optimizer.step()
 
     ema_callback.on_train_batch_end(trainer, model, outputs, batch, batch_idx)
 

--- a/tests/unittests/test_callbacks/test_ema.py
+++ b/tests/unittests/test_callbacks/test_ema.py
@@ -41,7 +41,7 @@ def test_ema_update_on_batch_end(model, ema_callback):
     ema_callback.on_fit_start(trainer, model)
 
     initial_ema_state = {
-        k: v.clone() for k, v in ema_callback.ema.state_dict.items()
+        k: v.clone() for k, v in ema_callback.ema.state_dict_ema.items()
     }
 
     outputs = None  # Use a dummy output
@@ -51,7 +51,7 @@ def test_ema_update_on_batch_end(model, ema_callback):
     ema_callback.on_train_batch_end(trainer, model, outputs, batch, batch_idx)
 
     # Check that the EMA has been updated
-    updated_state = ema_callback.ema.state_dict
+    updated_state = ema_callback.ema.state_dict_ema
     assert any(
         not torch.equal(initial_ema_state[k], updated_state[k])
         for k in initial_ema_state
@@ -76,7 +76,8 @@ def test_load_from_checkpoint(model, ema_callback):
     ema_callback.on_load_checkpoint(checkpoint)
 
     assert (
-        ema_callback.ema.state_dict.keys() == checkpoint["state_dict"].keys()
+        ema_callback.ema.state_dict_ema.keys()
+        == checkpoint["state_dict"].keys()
     )
 
 

--- a/tests/unittests/test_callbacks/test_ema.py
+++ b/tests/unittests/test_callbacks/test_ema.py
@@ -1,0 +1,79 @@
+import pytest
+import torch
+from pytorch_lightning import Trainer, LightningModule
+from pytorch_lightning.utilities.types import STEP_OUTPUT
+from unittest.mock import MagicMock
+from copy import deepcopy
+
+from luxonis_train.callbacks.ema import EMACallback, ModelEma
+
+class SimpleModel(LightningModule):
+    def __init__(self):
+        super(SimpleModel, self).__init__()
+        self.layer = torch.nn.Linear(2, 2)
+
+    def forward(self, x):
+        return self.layer(x)
+
+@pytest.fixture
+def model():
+    return SimpleModel()
+
+@pytest.fixture
+def ema_callback():
+    return EMACallback()
+
+def test_ema_initialization(model, ema_callback):
+    trainer = Trainer()
+    ema_callback.on_fit_start(trainer, model)
+    
+    assert isinstance(ema_callback.ema, ModelEma)
+    assert ema_callback.ema.decay == ema_callback.decay
+    assert ema_callback.ema.use_dynamic_decay == ema_callback.use_dynamic_decay
+    assert ema_callback.ema.device == ema_callback.device
+
+def test_ema_update_on_batch_end(model, ema_callback):
+    trainer = Trainer()
+    ema_callback.on_fit_start(trainer, model)
+
+    initial_ema_state = {k: v.clone() for k, v in ema_callback.ema.state_dict.items()}
+    
+    outputs = None  # Use a dummy output
+    batch = torch.rand(2, 2)
+    batch_idx = 0
+    
+    ema_callback.on_train_batch_end(trainer, model, outputs, batch, batch_idx)
+
+    # Check that the EMA has been updated
+    updated_state = ema_callback.ema.state_dict
+    assert any(not torch.equal(initial_ema_state[k], updated_state[k]) for k in initial_ema_state)
+
+def test_ema_state_saved_to_checkpoint(model, ema_callback):
+    trainer = Trainer()
+    ema_callback.on_fit_start(trainer, model)
+
+    checkpoint = {}
+    ema_callback.on_save_checkpoint(trainer, model, checkpoint)
+
+    assert "state_dict" in checkpoint or "state_dict_ema" in checkpoint
+
+def test_load_from_checkpoint(model, ema_callback):
+    trainer = Trainer()
+    ema_callback.on_fit_start(trainer, model)
+
+    checkpoint = {"state_dict": deepcopy(model.state_dict())}
+    ema_callback.on_load_checkpoint(checkpoint)
+
+    assert ema_callback.ema.state_dict.keys() == checkpoint["state_dict"].keys()
+
+def test_validation_epoch_start_and_end(model, ema_callback):
+    trainer = Trainer()
+    ema_callback.on_fit_start(trainer, model)
+
+    ema_callback.on_validation_epoch_start(trainer, model)
+    assert ema_callback.collected_state_dict is not None
+
+    ema_callback.on_validation_end(trainer, model)
+    for k in ema_callback.collected_state_dict.keys():
+        assert torch.equal(ema_callback.collected_state_dict[k], model.state_dict()[k])
+


### PR DESCRIPTION
This pull request introduces a new Exponential Moving Average (EMA) callback for model training, along with its integration and corresponding unit tests. The main changes include the addition of the `EMACallback` class, its registration, and tests to ensure its functionality.

### New EMA Callback

* [`luxonis_train/callbacks/ema.py`](diffhunk://#diff-e73f9f2330d6d2ca1a016ad0d897f901c38cf58e9a33d905374798ff41d2a301R1-R227): Added the `EMACallback` class, which includes methods for initializing the EMA, updating EMA weights, and handling checkpoint saving/loading. This class helps in maintaining a moving average of model parameters to potentially improve model performance.

### Integration

* [`luxonis_train/callbacks/__init__.py`](diffhunk://#diff-9fb27879fda34ab85599e83a085fe46f99a42acbaeea39b48c714be901cce3ebR16): Registered the `EMACallback` in the `CALLBACKS` registry and added it to the `__all__` list for proper module export. [[1]](diffhunk://#diff-9fb27879fda34ab85599e83a085fe46f99a42acbaeea39b48c714be901cce3ebR16) [[2]](diffhunk://#diff-9fb27879fda34ab85599e83a085fe46f99a42acbaeea39b48c714be901cce3ebR38) [[3]](diffhunk://#diff-9fb27879fda34ab85599e83a085fe46f99a42acbaeea39b48c714be901cce3ebR52)

### Unit Tests

* [`tests/unittests/test_callbacks/test_ema.py`](diffhunk://#diff-1059ecbad0484c2a7851bf6780e22dbbed5b04955b1b1c687d1da8066b6a54eaR1-R94): Added unit tests for the `EMACallback` to verify its initialization, batch update, checkpoint saving/loading, and validation epoch handling.