### PR TITLE
Add OHEM losses

### DIFF
--- a/luxonis_train/attached_modules/losses/__init__.py
+++ b/luxonis_train/attached_modules/losses/__init__.py
@@ -3,6 +3,9 @@ from .base_loss import BaseLoss
 from .bce_with_logits import BCEWithLogitsLoss
 from .cross_entropy import CrossEntropyLoss
 from .efficient_keypoint_bbox_loss import EfficientKeypointBBoxLoss
+from .ohem_bce_with_logits import OHEMBCEWithLogitsLoss
+from .ohem_cross_entropy import OHEMCrossEntropyLoss
+from .ohem_loss import OHEMLoss
 from .sigmoid_focal_loss import SigmoidFocalLoss
 from .smooth_bce_with_logits import SmoothBCEWithLogitsLoss
 from .softmax_focal_loss import SoftmaxFocalLoss
@@ -16,4 +19,7 @@ __all__ = [
     "SigmoidFocalLoss",
     "SmoothBCEWithLogitsLoss",
     "SoftmaxFocalLoss",
+    "OHEMLoss",
+    "OHEMCrossEntropyLoss",
+    "OHEMBCEWithLogitsLoss",
 ]

--- a/luxonis_train/attached_modules/losses/ohem_bce_with_logits.py
+++ b/luxonis_train/attached_modules/losses/ohem_bce_with_logits.py
@@ -1,12 +1,12 @@
 from typing import Any
 
-from .ohem_loss import OHEMLoss
 from .bce_with_logits import BCEWithLogitsLoss
+from .ohem_loss import OHEMLoss
 
 
 class OHEMBCEWithLogitsLoss(OHEMLoss):
-    """This criterion computes the binary cross entropy loss between input
-    logits and target with OHEM (Online Hard Example Mining)."""
+    """This criterion computes the binary cross entropy loss between
+    input logits and target with OHEM (Online Hard Example Mining)."""
 
     def __init__(
         self,
@@ -14,4 +14,3 @@ class OHEMBCEWithLogitsLoss(OHEMLoss):
     ):
         kwargs.update(criterion=BCEWithLogitsLoss)
         super().__init__(**kwargs)
-

--- a/luxonis_train/attached_modules/losses/ohem_bce_with_logits.py
+++ b/luxonis_train/attached_modules/losses/ohem_bce_with_logits.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from .ohem_loss import OHEMLoss
+from .bce_with_logits import BCEWithLogitsLoss
+
+
+class OHEMBCEWithLogitsLoss(OHEMLoss):
+    """This criterion computes the binary cross entropy loss between input
+    logits and target with OHEM (Online Hard Example Mining)."""
+
+    def __init__(
+        self,
+        **kwargs: Any,
+    ):
+        kwargs.update(criterion=BCEWithLogitsLoss)
+        super().__init__(**kwargs)
+

--- a/luxonis_train/attached_modules/losses/ohem_cross_entropy.py
+++ b/luxonis_train/attached_modules/losses/ohem_cross_entropy.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from .ohem_loss import OHEMLoss
+from .cross_entropy import CrossEntropyLoss
+
+
+class OHEMCrossEntropyLoss(OHEMLoss):
+    """This criterion computes the cross entropy loss between input
+    logits and target with OHEM (Online Hard Example Mining)."""
+
+    def __init__(
+        self,
+        **kwargs: Any,
+    ):
+        kwargs.update(criterion=CrossEntropyLoss)
+        super().__init__(**kwargs)
+

--- a/luxonis_train/attached_modules/losses/ohem_cross_entropy.py
+++ b/luxonis_train/attached_modules/losses/ohem_cross_entropy.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from .ohem_loss import OHEMLoss
 from .cross_entropy import CrossEntropyLoss
+from .ohem_loss import OHEMLoss
 
 
 class OHEMCrossEntropyLoss(OHEMLoss):
@@ -14,4 +14,3 @@ class OHEMCrossEntropyLoss(OHEMLoss):
     ):
         kwargs.update(criterion=CrossEntropyLoss)
         super().__init__(**kwargs)
-

--- a/luxonis_train/attached_modules/losses/ohem_loss.py
+++ b/luxonis_train/attached_modules/losses/ohem_loss.py
@@ -19,14 +19,14 @@ class OHEMLoss(BaseLoss[Tensor, Tensor]):
 
     def __init__(
         self,
-        criterion: nn.Module,
+        criterion: BaseLoss,
         ohem_ratio: float = 0.1,
         ohem_threshold: float = 0.7,
         **kwargs: Any,
     ):
         """Initializes the criterion.
 
-        @type criterion: nn.Module
+        @type criterion: BaseLoss
         @param criterion: The criterion to use.
         @type ohem_ratio: float
         @param ohem_ratio: The ratio of pixels to keep.

--- a/luxonis_train/attached_modules/losses/ohem_loss.py
+++ b/luxonis_train/attached_modules/losses/ohem_loss.py
@@ -4,9 +4,9 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from .base_loss import BaseLoss
-
 from luxonis_train.enums import TaskType
+
+from .base_loss import BaseLoss
 
 
 class OHEMLoss(BaseLoss[Tensor, Tensor]):
@@ -59,4 +59,3 @@ class OHEMLoss(BaseLoss[Tensor, Tensor]):
             loss = loss[:ohem_num]
 
         return loss.mean()
-

--- a/luxonis_train/attached_modules/losses/ohem_loss.py
+++ b/luxonis_train/attached_modules/losses/ohem_loss.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from .base_loss import BaseLoss
+
+from luxonis_train.enums import TaskType
+
+
+class OHEMLoss(BaseLoss[Tensor, Tensor]):
+    """Generic OHEM loss that can be used with different criterions."""
+
+    supported_tasks: list[TaskType] = [
+        TaskType.SEGMENTATION,
+        TaskType.CLASSIFICATION,
+    ]
+
+    def __init__(
+        self,
+        criterion: nn.Module,
+        ohem_ratio: float = 0.1,
+        ohem_threshold: float = 0.7,
+        **kwargs: Any,
+    ):
+        """Initializes the criterion.
+
+        @type criterion: nn.Module
+        @param criterion: The criterion to use.
+        @type ohem_ratio: float
+        @param ohem_ratio: The ratio of pixels to keep.
+        @type ohem_threshold: float
+        @param ohem_threshold: The threshold for pixels to keep.
+        """
+        super().__init__(**kwargs)
+        kwargs.update(reduction="none")
+        self.criterion = criterion(**kwargs)
+        self.ohem_ratio = ohem_ratio
+        self.ohem_threshold = -torch.log(torch.tensor(ohem_threshold))
+
+        self._was_logged = False
+
+    def forward(self, preds: Tensor, target: Tensor) -> Tensor:
+        loss = self.criterion(preds, target).view(-1)
+
+        num_pixels = loss.numel()
+
+        if num_pixels == 0:
+            return loss
+
+        ohem_num = int(num_pixels * self.ohem_ratio)
+        ohem_num = min(ohem_num, num_pixels - 1)
+
+        loss, _ = loss.sort(descending=True)
+        if loss[ohem_num] > self.ohem_threshold:
+            loss = loss[loss > self.ohem_threshold]
+        else:
+            loss = loss[:ohem_num]
+
+        return loss.mean()
+

--- a/luxonis_train/attached_modules/losses/ohem_loss.py
+++ b/luxonis_train/attached_modules/losses/ohem_loss.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import torch
-import torch.nn as nn
 from torch import Tensor
 
 from luxonis_train.enums import TaskType

--- a/luxonis_train/config/predefined_models/segmentation_model.py
+++ b/luxonis_train/config/predefined_models/segmentation_model.py
@@ -114,9 +114,9 @@ class SegmentationModel(BasePredefinedModel):
         loss_list = [
             LossModuleConfig(
                 name=(
-                    "BCEWithLogitsLoss"
+                    "OHEMBCEWithLogitsLoss"
                     if self.task == "binary"
-                    else "CrossEntropyLoss"
+                    else "OHEMCrossEntropyLoss"
                 ),
                 alias="segmentation_loss",
                 attached_to="segmentation_head",
@@ -128,9 +128,9 @@ class SegmentationModel(BasePredefinedModel):
             loss_list.append(
                 LossModuleConfig(
                     name=(
-                        "BCEWithLogitsLoss"
+                        "OHEMBCEWithLogitsLoss"
                         if self.task == "binary"
-                        else "CrossEntropyLoss"
+                        else "OHEMCrossEntropyLoss"
                     ),
                     alias="aux_segmentation_loss",
                     attached_to="aux_segmentation_head",

--- a/tests/integration/parking_lot.json
+++ b/tests/integration/parking_lot.json
@@ -1,5 +1,5 @@
 {
-    "config_version": "1.1",
+    "config_version": "1.0",
     "model": {
         "metadata": {
             "name": "parking_lot_model",

--- a/tests/unittests/test_losses/test_ohem_losses.py
+++ b/tests/unittests/test_losses/test_ohem_losses.py
@@ -1,0 +1,23 @@
+import torch
+import torch.nn as nn
+import pytest
+
+from luxonis_train.attached_modules.losses import OHEMLoss, CrossEntropyLoss, BCEWithLogitsLoss
+from luxonis_train.enums import TaskType
+
+def test_ohem_loss_cross_entropy():
+    ohem_loss = OHEMLoss(CrossEntropyLoss, ohem_ratio=0.5, ohem_threshold=0.1)
+
+    preds = torch.tensor([[1.0, 2.0], [1.0, 0.5]], requires_grad=True)
+    target = torch.tensor([[1, 0], [0, 1]], dtype=torch.long)
+    loss = ohem_loss(preds, target)
+    assert loss.item() >= 0  # Loss should be non-negative
+
+def test_ohem_loss_bce_with_logits():
+    ohem_loss = OHEMLoss(BCEWithLogitsLoss, ohem_ratio=0.5, ohem_threshold=0.5)
+
+    preds = torch.tensor([0.6, -0.3, 0.9], requires_grad=True) 
+    target = torch.tensor([1.0, 0.0, 1.0])
+    loss = ohem_loss(preds, target)
+    assert loss.item() >= 0  # Loss should be non-negative
+

--- a/tests/unittests/test_losses/test_ohem_losses.py
+++ b/tests/unittests/test_losses/test_ohem_losses.py
@@ -1,9 +1,11 @@
 import torch
-import torch.nn as nn
-import pytest
 
-from luxonis_train.attached_modules.losses import OHEMLoss, CrossEntropyLoss, BCEWithLogitsLoss
-from luxonis_train.enums import TaskType
+from luxonis_train.attached_modules.losses import (
+    BCEWithLogitsLoss,
+    CrossEntropyLoss,
+    OHEMLoss,
+)
+
 
 def test_ohem_loss_cross_entropy():
     ohem_loss = OHEMLoss(CrossEntropyLoss, ohem_ratio=0.5, ohem_threshold=0.1)
@@ -13,11 +15,11 @@ def test_ohem_loss_cross_entropy():
     loss = ohem_loss(preds, target)
     assert loss.item() >= 0  # Loss should be non-negative
 
+
 def test_ohem_loss_bce_with_logits():
     ohem_loss = OHEMLoss(BCEWithLogitsLoss, ohem_ratio=0.5, ohem_threshold=0.5)
 
-    preds = torch.tensor([0.6, -0.3, 0.9], requires_grad=True) 
+    preds = torch.tensor([0.6, -0.3, 0.9], requires_grad=True)
     target = torch.tensor([1.0, 0.0, 1.0])
     loss = ohem_loss(preds, target)
     assert loss.item() >= 0  # Loss should be non-negative
-

--- a/tests/unittests/test_losses/test_ohem_losses.py
+++ b/tests/unittests/test_losses/test_ohem_losses.py
@@ -8,7 +8,7 @@ from luxonis_train.attached_modules.losses import (
 
 
 def test_ohem_loss_cross_entropy():
-    ohem_loss = OHEMLoss(CrossEntropyLoss, ohem_ratio=0.5, ohem_threshold=0.1)
+    ohem_loss = OHEMLoss(CrossEntropyLoss, ohem_ratio=0.5, ohem_threshold=0.1)  # type: ignore
 
     preds = torch.tensor([[1.0, 2.0], [1.0, 0.5]], requires_grad=True)
     target = torch.tensor([[1, 0], [0, 1]], dtype=torch.long)
@@ -17,7 +17,7 @@ def test_ohem_loss_cross_entropy():
 
 
 def test_ohem_loss_bce_with_logits():
-    ohem_loss = OHEMLoss(BCEWithLogitsLoss, ohem_ratio=0.5, ohem_threshold=0.5)
+    ohem_loss = OHEMLoss(BCEWithLogitsLoss, ohem_ratio=0.5, ohem_threshold=0.5)  # type: ignore
 
     preds = torch.tensor([0.6, -0.3, 0.9], requires_grad=True)
     target = torch.tensor([1.0, 0.0, 1.0])


### PR DESCRIPTION
This pull request introduces Online Hard Example Mining (OHEM) loss functions to the `luxonis_train` module, enhancing the model's ability to focus on more challenging examples during training. The most significant changes include the addition of new OHEM loss classes, updates to the loss configuration in segmentation models, and new unit tests to ensure the functionality of these loss functions.

- `OHEMCrossEntropyLoss` and `OHEMBCEWithLogitsLoss` added
- OHEM losses set as default for the predefined segmentation model
- Losses tests