### PR TITLE
fix: call tracker.close()

### DIFF
--- a/luxonis_train/utils/tracker.py
+++ b/luxonis_train/utils/tracker.py
@@ -35,6 +35,7 @@ class LuxonisTrackerPL(LuxonisTracker, Logger):
             else:
                 mlflow_status = "FAILED"
             self.experiment["mlflow"].end_run(mlflow_status)
+            self.close()
         if self.is_wandb:
             if status == "success":
                 wandb_status = 0


### PR DESCRIPTION
# Call `close()` on Tracker After Training Completion

## Summary
This update ensures `close()` is executed on the tracker after training finishes, aligning with recent changes in `luxonis-ml` ([This PR](https://github.com/luxonis/luxonis-ml/pull/193))
