### PR TITLE
feat: add n_validation_batches option to trainer

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -222,6 +222,7 @@ Here you can change everything related to actual training of the model.
 | `verbose`                 | `bool`                                         | `True`        | Print all intermediate results to console                                                                                                        |
 | `pin_memory`              | `bool`                                         | `True`        | Whether to pin memory in the `DataLoader`                                                                                                        |
 | `save_top_k`              | `-1 \| NonNegativeInt`                         | `3`           | Save top K checkpoints based on validation loss when training                                                                                    |
+| `n_validation_batches`    | `PositiveInt \| None`                          | `None`        | Limits the number of validation/test batches and makes the val/test loaders deterministic                                                        |
 
 **Example:**
 

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -357,7 +357,7 @@ class TrainerConfig(BaseModelExtraForbid):
     verbose: bool = True
 
     seed: int | None = None
-    n_validation_batches: int | None = None
+    n_validation_batches: PositiveInt | None = None
     deterministic: bool | Literal["warn"] | None = None
     batch_size: PositiveInt = 32
     accumulate_grad_batches: PositiveInt = 1

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -357,6 +357,7 @@ class TrainerConfig(BaseModelExtraForbid):
     verbose: bool = True
 
     seed: int | None = None
+    n_validation_batches: int | None = None
     deterministic: bool | Literal["warn"] | None = None
     batch_size: PositiveInt = 32
     accumulate_grad_batches: PositiveInt = 1

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -179,9 +179,9 @@ class LuxonisModel:
                     indices = list(
                         range(min(n_samples, len(self.loaders[view])))
                     )
-                    self.loaders[view] = torch_data.Subset(
+                    self.loaders[view] = torch_data.Subset(  # type: ignore
                         self.loaders[view], indices
-                    )  # type: ignore
+                    )
 
         self.pytorch_loaders = {
             view: torch_data.DataLoader(

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -167,9 +167,9 @@ class LuxonisModel:
                 "Weighted sampler is not implemented yet."
             )
 
-        generator = torch.Generator()
-        generator.manual_seed(self.cfg.trainer.seed or 41)
         if self.cfg.trainer.n_validation_batches:
+            generator = torch.Generator()
+            generator.manual_seed(self.cfg.trainer.seed or 42)
             n_samples = (
                 self.cfg.trainer.n_validation_batches
                 * self.cfg.trainer.batch_size
@@ -197,7 +197,12 @@ class LuxonisModel:
                 ),
                 pin_memory=self.cfg.trainer.pin_memory,
                 sampler=sampler if view == "train" else None,
-                generator=generator if view in ["val", "test"] else None,
+                generator=generator
+                if (
+                    self.cfg.trainer.n_validation_batches is not None
+                    and view in ["val", "test"]
+                )
+                else None,
             )
             for view in ["train", "val", "test"]
         }

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -181,7 +181,7 @@ class LuxonisModel:
                     )
                     self.loaders[view] = torch_data.Subset(
                         self.loaders[view], indices
-                    )
+                    )  # type: ignore
 
         self.pytorch_loaders = {
             view: torch_data.DataLoader(

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -169,15 +169,19 @@ class LuxonisModel:
 
         generator = torch.Generator()
         generator.manual_seed(self.cfg.trainer.seed or 41)
-        if self.cfg.trainer.n_validation_batches is not None:
+        if self.cfg.trainer.n_validation_batches:
             n_samples = (
                 self.cfg.trainer.n_validation_batches
                 * self.cfg.trainer.batch_size
             )
-            val_indices = list(range(min(n_samples, len(self.loaders["val"]))))
-            self.loaders["val"] = torch_data.Subset(
-                self.loaders["val"], val_indices
-            )
+            for view in ["val", "test"]:
+                if view in self.loaders:
+                    indices = list(
+                        range(min(n_samples, len(self.loaders[view])))
+                    )
+                    self.loaders[view] = torch_data.Subset(
+                        self.loaders[view], indices
+                    )
 
         self.pytorch_loaders = {
             view: torch_data.DataLoader(

--- a/tests/integration/test_fixed_validation_batch_limit.py
+++ b/tests/integration/test_fixed_validation_batch_limit.py
@@ -56,3 +56,11 @@ def test_fixed_validation_batch_limit(parking_lot_dataset: LuxonisDataset):
     assert (
         len(model.pytorch_loaders["test"]) == 1
     ), "Test loader should contain exactly 1 batch"
+    config["trainer"]["n_validation_batches"] = None
+    model = LuxonisModel(config, opts)
+    assert (
+        len(model.pytorch_loaders["val"]) > 1
+    ), "Validation loader should contain all validation samples"
+    assert (
+        len(model.pytorch_loaders["test"]) > 1
+    ), "Test loader should contain all test samples"

--- a/tests/integration/test_fixed_validation_batch_limit.py
+++ b/tests/integration/test_fixed_validation_batch_limit.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from luxonis_ml.data import LuxonisDataset
+
+from luxonis_train.core import LuxonisModel
+
+
+def get_config() -> dict[str, Any]:
+    return {
+        "model": {
+            "nodes": [
+                {
+                    "name": "EfficientRep",
+                    "alias": "backbone",
+                    "params": {"variant": "n"},
+                },
+                {
+                    "name": "RepPANNeck",
+                    "alias": "neck",
+                    "inputs": ["backbone"],
+                },
+                {"name": "EfficientBBoxHead", "inputs": ["neck"]},
+            ],
+            "losses": [
+                {
+                    "name": "AdaptiveDetectionLoss",
+                    "attached_to": "EfficientBBoxHead",
+                }
+            ],
+            "metrics": [
+                {
+                    "name": "MeanAveragePrecision",
+                    "attached_to": "EfficientBBoxHead",
+                }
+            ],
+        },
+        "loader": {
+            "name": "LuxonisLoaderTorch",
+            "train_view": "train",
+            "val_view": "train",
+            "test_view": "train",
+        },
+        "trainer": {
+            "n_validation_batches": 1,
+        },
+    }
+
+
+def test_fixed_validation_batch_limit(parking_lot_dataset: LuxonisDataset):
+    config = get_config()
+    opts = {"loader.params.dataset_name": parking_lot_dataset.identifier}
+    model = LuxonisModel(config, opts)
+    assert (
+        len(model.pytorch_loaders["val"]) == 1
+    ), "Validation loader should contain exactly 1 batch"
+    assert (
+        len(model.pytorch_loaders["test"]) == 1
+    ), "Test loader should contain exactly 1 batch"


### PR DESCRIPTION
## Efficient Model Training Without Full Test/Validation and Test/Validation Split

If you want to just train the model and export it without extensive validation or testing, you can now achieve this more efficiently using the following configuration:

- **Skip Full Validation**: By setting `trainer.validation_interval` to be the same as `trainer.epochs` and using the same data for training, validation, and testing, you can minimize the validation overhead.
- **Fast Validation Setup**: Specify `n_validation_batches` with a small number to limit the number of validation batches, speeding up the process while ensuring checkpoints are saved correctly for export.
- **Deterministic Loaders**: Both validation and test DataLoaders are now fully deterministic, ensuring reproducibility.

### Example Configuration
```yaml

loader:
  train_view: train
  val_view: train
  test_view: train
  ...
 
trainer:
  validation_interval: *epochs
  n_validation_batches: 2  # Use a small number for faster validation
