### PR TITLE
Config smart auto populate

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -222,6 +222,7 @@ Here you can change everything related to actual training of the model.
 | `verbose`                 | `bool`                                         | `True`        | Print all intermediate results to console                                                                                                        |
 | `pin_memory`              | `bool`                                         | `True`        | Whether to pin memory in the `DataLoader`                                                                                                        |
 | `save_top_k`              | `-1 \| NonNegativeInt`                         | `3`           | Save top K checkpoints based on validation loss when training                                                                                    |
+| `smart_cfg_auto_populate` | `bool`                                         | `True`        | Automatically populate sensible default values for missing config fields and log warnings                                                        |
 
 **Example:**
 

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -528,7 +528,6 @@ class Config(LuxonisConfig):
     def smart_auto_populate(cls, instance: "Config") -> None:
         """Automatically populates config fields based on rules, with
         warnings."""
-        warnings = []
 
         # Rule: CosineAnnealingLR should have T_max set to the number of epochs if not provided
         scheduler = instance.trainer.scheduler
@@ -537,7 +536,7 @@ class Config(LuxonisConfig):
             and "T_max" not in scheduler.params
         ):
             scheduler.params["T_max"] = instance.trainer.epochs
-            warnings.append(
+            logger.warning(
                 "T_max was not set for CosineAnnealingLR. Automatically set T_max to number of epochs."
             )
 
@@ -551,12 +550,9 @@ class Config(LuxonisConfig):
                 augmentation.params.update(
                     {"out_width": train_size[0], "out_height": train_size[1]}
                 )
-                warnings.append(
-                    "Mosaic4 augmentation detected. Automatically set out_width and out_height to match train_image_size. "
+                logger.warning(
+                    "Mosaic4 augmentation detected. Automatically set out_width and out_height to match train_image_size."
                 )
-
-        for warning in warnings:
-            logger.warning(warning)
 
 
 def is_acyclic(graph: dict[str, list[str]]) -> bool:

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -537,7 +537,7 @@ class Config(LuxonisConfig):
         ):
             scheduler.params["T_max"] = instance.trainer.epochs
             logger.warning(
-                "T_max was not set for CosineAnnealingLR. Automatically set T_max to number of epochs."
+                "`T_max` was not set for `CosineAnnealingLR`. Automatically set `T_max` to number of epochs."
             )
 
         # Rule: Mosaic4 should have out_width and out_height matching train_image_size if not provided
@@ -551,7 +551,7 @@ class Config(LuxonisConfig):
                     {"out_width": train_size[0], "out_height": train_size[1]}
                 )
                 logger.warning(
-                    "Mosaic4 augmentation detected. Automatically set out_width and out_height to match train_image_size."
+                    "`Mosaic4` augmentation detected. Automatically set `out_width` and `out_height` to match `train_image_size`."
                 )
 
 

--- a/tests/configs/smart_cfg_populate_config.yaml
+++ b/tests/configs/smart_cfg_populate_config.yaml
@@ -1,0 +1,39 @@
+model:
+  nodes:
+    - name: EfficientRep
+      params:
+        variant: "n"
+
+    - name: RepPANNeck
+      inputs:
+        - EfficientRep
+
+    - name: EfficientBBoxHead
+      inputs:
+        - RepPANNeck
+
+  losses:
+    - name: AdaptiveDetectionLoss
+      attached_to: EfficientBBoxHead
+      params:
+        n_warmup_epochs: 0
+
+loader:
+  train_view: val
+  params:
+    dataset_name: D1ParkingLot
+
+trainer:
+  batch_size: 2
+  epochs: 200
+
+  preprocessing:
+    train_image_size: [256, 320]
+    keep_aspect_ratio: true
+    normalize:
+      active: true
+    augmentations:
+      - name: Mosaic4
+
+  scheduler:
+    name: CosineAnnealingLR

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -269,3 +269,24 @@ def test_freezing(opts: dict[str, Any], coco_dataset: LuxonisDataset):
     opts["loader.params.dataset_name"] = coco_dataset.identifier
     model = LuxonisModel(config_file, opts)
     model.train()
+
+
+def test_smart_cfg_auto_populate(
+    opts: dict[str, Any], parking_lot_dataset: LuxonisDataset
+):
+    config_file = "tests/configs/smart_cfg_populate_config.yaml"
+    opts = {
+        "loader.params.dataset_name": parking_lot_dataset.dataset_name,
+    }
+    model = LuxonisModel(config_file, opts)
+    assert (
+        model.cfg.trainer.scheduler.params["T_max"] == model.cfg.trainer.epochs
+    )
+    assert (
+        model.cfg.trainer.preprocessing.augmentations[0].params["out_width"]
+        == model.cfg.trainer.preprocessing.train_image_size[0]
+    )
+    assert (
+        model.cfg.trainer.preprocessing.augmentations[0].params["out_height"]
+        == model.cfg.trainer.preprocessing.train_image_size[1]
+    )


### PR DESCRIPTION
# Smart Configuration Auto-Populate Feature

This Pull Request introduces a feature to automatically populate certain configuration fields with sensible default values, enhancing usability and preventing runtime errors.

## Overview

Certain configuration fields have optimal default values that users may overlook. To address this, a step is added between validation and usage to check and fill missing values based on predefined rules.

### Key Features

1. **Auto-Populate Logic**
   - `smart_auto_populate` fills in default values when necessary.
   - Examples:
     - **CosineAnnealingLR**: Sets `T_max` to the number of epochs if missing.
     - **MosaicV4**: Sets `output_width` and `output_height` to match the training image size if unspecified.
   - Warnings inform users about auto-populated values.

2. **Configurable Behavior**
   - The `trainer.smart_cfg_auto_populate` flag (default: `True`) controls this feature.
