### PR TITLE
Pinned down mdormat-gfm version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     hooks:
       - id: mdformat
         additional_dependencies:
-          - mdformat-gfm
+          - mdformat-gfm==0.3.6


### PR DESCRIPTION
Newest version doesn't work correctly so we pinned down to the last compatible, working one.