### PR TITLE
Fix: Ensure Compatibility of Detection Model Input Shape

### DIFF
--- a/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
+++ b/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import Any, Literal
 
 from torch import Tensor, nn
@@ -71,6 +72,25 @@ class RepPANNeck(BaseNode[list[Tensor], list[Tensor]]):
         """
 
         super().__init__(**kwargs)
+
+        if (
+            self.original_in_shape[-1] % 32 != 0
+            or self.original_in_shape[-2] % 32 != 0
+        ):
+            logger.warning(
+                "Image dimensions should be divisible by 32. This may cause 'RepPANNeck' to crash."
+            )
+
+        if (
+            math.gcd(
+                math.gcd(self.in_width[-1], self.in_width[-2]),
+                self.in_width[-3],
+            )
+            == 1
+        ):
+            raise ValueError(
+                "The greatest common divisor of the input widths of 'RepPANNeck' s 1. Image dimensions should be divisible by 32."
+            )
 
         self.n_heads = n_heads
 

--- a/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
+++ b/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
@@ -84,9 +84,12 @@ class RepPANNeck(BaseNode[list[Tensor], list[Tensor]]):
 
         for i in range(1, n_heads):
             if (
-                self.in_width[-i] * 2 != self.in_width[-i - 1]
-                or self.in_height[-i] * 2 != self.in_height[-i - 1]
-            ):
+                (
+                    self.in_width[-i] * 2 != self.in_width[-i - 1]
+                    or self.in_height[-i] * 2 != self.in_height[-i - 1]
+                )
+                and self.attach_index == "all"
+            ):  # TODO: fix the attach_index and this condition
                 raise ValueError(
                     f"Expected width and height of feature map at index {len(self.in_width) - i} to be half of those at index {len(self.in_width) - i - 1}. "
                     f"Image shape {self.original_in_shape} must be divisible by 32 to avoid 'RepPANNeck' crashing."

--- a/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
+++ b/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from typing import Any, Literal
 
 from torch import Tensor, nn
@@ -81,16 +80,16 @@ class RepPANNeck(BaseNode[list[Tensor], list[Tensor]]):
                 "Image dimensions should be divisible by 32. This may cause 'RepPANNeck' to crash."
             )
 
-        if (
-            math.gcd(
-                math.gcd(self.in_width[-1], self.in_width[-2]),
-                self.in_width[-3],
-            )
-            == 1
-        ):
-            raise ValueError(
-                "The greatest common divisor of the input widths of 'RepPANNeck' s 1. Image dimensions should be divisible by 32."
-            )
+        for i in range(1, n_heads):
+            if (
+                self.in_width[-i] * 2 != self.in_width[-i - 1]
+                or self.in_height[-i] * 2 != self.in_height[-i - 1]
+            ):
+                raise ValueError(
+                    f"Inconsistent input dimensions at index {len(self.in_width) - i - 1}. "
+                    f"Expected width and height of feature map at index {len(self.in_width) - i} to be half of those at index {len(self.in_width) - i - 1}. "
+                    f"Image shape {self.original_in_shape} must be divisible by 32 to avoid 'RepPANNeck' crashing."
+                )
 
         self.n_heads = n_heads
 

--- a/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
+++ b/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
@@ -86,7 +86,6 @@ class RepPANNeck(BaseNode[list[Tensor], list[Tensor]]):
                 or self.in_height[-i] * 2 != self.in_height[-i - 1]
             ):
                 raise ValueError(
-                    f"Inconsistent feature map dimensions at index {len(self.in_width) - i - 1}. "
                     f"Expected width and height of feature map at index {len(self.in_width) - i} to be half of those at index {len(self.in_width) - i - 1}. "
                     f"Image shape {self.original_in_shape} must be divisible by 32 to avoid 'RepPANNeck' crashing."
                 )

--- a/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
+++ b/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
@@ -86,7 +86,7 @@ class RepPANNeck(BaseNode[list[Tensor], list[Tensor]]):
                 or self.in_height[-i] * 2 != self.in_height[-i - 1]
             ):
                 raise ValueError(
-                    f"Inconsistent input dimensions at index {len(self.in_width) - i - 1}. "
+                    f"Inconsistent feature map dimensions at index {len(self.in_width) - i - 1}. "
                     f"Expected width and height of feature map at index {len(self.in_width) - i} to be half of those at index {len(self.in_width) - i - 1}. "
                     f"Image shape {self.original_in_shape} must be divisible by 32 to avoid 'RepPANNeck' crashing."
                 )

--- a/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
+++ b/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
@@ -15,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 class RepPANNeck(BaseNode[list[Tensor], list[Tensor]]):
     in_channels: list[int]
+    in_width: list[int]
+    in_height: list[int]
 
     def __init__(
         self,


### PR DESCRIPTION
### PR Summary

Added validation for `RepPANNeck` input shapes (image dimensions divisible by 32 and GCD check for height and width of feature maps).
