### PR TITLE
fix ema checkpoint loading

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -202,31 +202,32 @@ loader:
 
 Here you can change everything related to actual training of the model.
 
-| Key                       | Type                                           | Default value | Description                                                                                                                                      |
-| ------------------------- | ---------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `seed`                    | `int`                                          | `None`        | Seed for reproducibility                                                                                                                         |
-| `deterministic`           | `bool \| "warn" \| None`                       | `None`        | Whether PyTorch should use deterministic backend                                                                                                 |
-| `batch_size`              | `int`                                          | `32`          | Batch size used for training                                                                                                                     |
-| `accumulate_grad_batches` | `int`                                          | `1`           | Number of batches for gradient accumulation                                                                                                      |
-| `gradient_clip_val`       | `NonNegativeFloat \| None`                     | `None`        | Value for gradient clipping. If `None`, gradient clipping is disabled. Clipping can help prevent exploding gradients.                            |
-| `gradient_clip_algorithm` | `Literal["norm", "value"] \| None`             | `None`        | Algorithm to use for gradient clipping. Options are `"norm"` (clip by norm) or `"value"` (clip element-wise).                                    |
-| `use_weighted_sampler`    | `bool`                                         | `False`       | Whether to use `WeightedRandomSampler` for training, only works with classification tasks                                                        |
-| `epochs`                  | `int`                                          | `100`         | Number of training epochs                                                                                                                        |
-| `n_workers`               | `int`                                          | `4`           | Number of workers for data loading                                                                                                               |
-| `validation_interval`     | `int`                                          | `5`           | Frequency of computing metrics on validation data                                                                                                |
-| `n_log_images`            | `int`                                          | `4`           | Maximum number of images to visualize and log                                                                                                    |
-| `skip_last_batch`         | `bool`                                         | `True`        | Whether to skip last batch while training                                                                                                        |
-| `accelerator`             | `Literal["auto", "cpu", "gpu"]`                | `"auto"`      | What accelerator to use for training                                                                                                             |
-| `devices`                 | `int \| list[int] \| str`                      | `"auto"`      | Either specify how many devices to use (int), list specific devices, or use "auto" for automatic configuration based on the selected accelerator |
-| `matmul_precision`        | `Literal["medium", "high", "highest"] \| None` | `None`        | Sets the internal precision of float32 matrix multiplications                                                                                    |
-| `strategy`                | `Literal["auto", "ddp"]`                       | `"auto"`      | What strategy to use for training                                                                                                                |
-| `n_sanity_val_steps`      | `int`                                          | `2`           | Number of sanity validation steps performed before training                                                                                      |
-| `profiler`                | `Literal["simple", "advanced"] \| None`        | `None`        | PL profiler for GPU/CPU/RAM utilization analysis                                                                                                 |
-| `verbose`                 | `bool`                                         | `True`        | Print all intermediate results to console                                                                                                        |
-| `pin_memory`              | `bool`                                         | `True`        | Whether to pin memory in the `DataLoader`                                                                                                        |
-| `save_top_k`              | `-1 \| NonNegativeInt`                         | `3`           | Save top K checkpoints based on validation loss when training                                                                                    |
-| `n_validation_batches`    | `PositiveInt \| None`                          | `None`        | Limits the number of validation/test batches and makes the val/test loaders deterministic                                                        |
-| `smart_cfg_auto_populate` | `bool`                                         | `True`        | Automatically populate sensible default values for missing config fields and log warnings                                                        |
+| Key                       | Type                                           | Default value | Description                                                                                                                                                                                            |
+| ------------------------- | ---------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `seed`                    | `int`                                          | `None`        | Seed for reproducibility                                                                                                                                                                               |
+| `deterministic`           | `bool \| "warn" \| None`                       | `None`        | Whether PyTorch should use deterministic backend                                                                                                                                                       |
+| `batch_size`              | `int`                                          | `32`          | Batch size used for training                                                                                                                                                                           |
+| `accumulate_grad_batches` | `int`                                          | `1`           | Number of batches for gradient accumulation                                                                                                                                                            |
+| `gradient_clip_val`       | `NonNegativeFloat \| None`                     | `None`        | Value for gradient clipping. If `None`, gradient clipping is disabled. Clipping can help prevent exploding gradients.                                                                                  |
+| `gradient_clip_algorithm` | `Literal["norm", "value"] \| None`             | `None`        | Algorithm to use for gradient clipping. Options are `"norm"` (clip by norm) or `"value"` (clip element-wise).                                                                                          |
+| `use_weighted_sampler`    | `bool`                                         | `False`       | Whether to use `WeightedRandomSampler` for training, only works with classification tasks                                                                                                              |
+| `epochs`                  | `int`                                          | `100`         | Number of training epochs                                                                                                                                                                              |
+| `n_workers`               | `int`                                          | `4`           | Number of workers for data loading                                                                                                                                                                     |
+| `validation_interval`     | `int`                                          | `5`           | Frequency of computing metrics on validation data                                                                                                                                                      |
+| `n_log_images`            | `int`                                          | `4`           | Maximum number of images to visualize and log                                                                                                                                                          |
+| `skip_last_batch`         | `bool`                                         | `True`        | Whether to skip last batch while training                                                                                                                                                              |
+| `accelerator`             | `Literal["auto", "cpu", "gpu"]`                | `"auto"`      | What accelerator to use for training                                                                                                                                                                   |
+| `devices`                 | `int \| list[int] \| str`                      | `"auto"`      | Either specify how many devices to use (int), list specific devices, or use "auto" for automatic configuration based on the selected accelerator                                                       |
+| `matmul_precision`        | `Literal["medium", "high", "highest"] \| None` | `None`        | Sets the internal precision of float32 matrix multiplications                                                                                                                                          |
+| `strategy`                | `Literal["auto", "ddp"]`                       | `"auto"`      | What strategy to use for training                                                                                                                                                                      |
+| `n_sanity_val_steps`      | `int`                                          | `2`           | Number of sanity validation steps performed before training                                                                                                                                            |
+| `profiler`                | `Literal["simple", "advanced"] \| None`        | `None`        | PL profiler for GPU/CPU/RAM utilization analysis                                                                                                                                                       |
+| `verbose`                 | `bool`                                         | `True`        | Print all intermediate results to console                                                                                                                                                              |
+| `pin_memory`              | `bool`                                         | `True`        | Whether to pin memory in the `DataLoader`                                                                                                                                                              |
+| `save_top_k`              | `-1 \| NonNegativeInt`                         | `3`           | Save top K checkpoints based on validation loss when training                                                                                                                                          |
+| `n_validation_batches`    | `PositiveInt \| None`                          | `None`        | Limits the number of validation/test batches and makes the val/test loaders deterministic                                                                                                              |
+| `smart_cfg_auto_populate` | `bool`                                         | `True`        | Automatically populate sensible default values for missing config fields and log warnings                                                                                                              |
+| `resume_training`         | `bool`                                         | `False`       | Whether to resume training from a checkpoint. Loads not only the weights from `model.weights` but also the `optimizer state`, `scheduler state`, and other training parameters to continue seamlessly. |
 
 ```yaml
 
@@ -234,7 +235,7 @@ trainer:
   accelerator: "auto"
   devices: "auto"
   strategy: "auto"
-
+  resume_training: true
   n_sanity_val_steps: 1
   profiler: null
   verbose: true
@@ -249,6 +250,21 @@ trainer:
   save_top_k: 3
   smart_cfg_auto_populate: true
 ```
+
+### Model Fine-Tuning Options
+
+#### 1. **Fine-Tuning with Custom Configuration Example**
+
+- Do **not** set the `resume_training` flag to `true`.
+- Specify a **new LR** in the config (e.g., `0.1`), overriding the previous LR (e.g., `0.001`).
+- Training starts at the new LR, with the scheduler/optimizer reset (can use different schedulers/optimizers than the base run).
+
+#### 2. **Resume Training Continuously Example**
+
+- Use the `resume_training` flag to continue training from the last checkpoint specified in `model.weights`.
+- LR starts at the value where the previous run ended, maintaining continuity in the scheduler (e.g., combined LR plot would shows a seamless curve).
+- For example:
+  - Resuming training with extended epochs (e.g., 400 epochs after 300) and adjusted `T_max` (e.g., 400 after 300 for cosine annealing) and `eta_min` (e.g., 10x less than before) will use the final learning rate (LR) from the previous run. This ignores the initial LR specified in the config and finishes with the new `eta_min` LR.
 
 ### Smart Configuration Auto-population
 

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -70,7 +70,7 @@ SourcePathType = Annotated[
 @app.command()
 def train(
     config: ConfigType = None,
-    resume_checkpoint: Annotated[
+    resume_weights: Annotated[
         str | None,
         typer.Option(help="Resume training from this checkpoint."),
     ] = None,
@@ -79,7 +79,7 @@ def train(
     """Start training."""
     from luxonis_train.core import LuxonisModel
 
-    LuxonisModel(config, opts).train(resume_checkpoint=resume_checkpoint)
+    LuxonisModel(config, opts).train(resume_weights=resume_weights)
 
 
 @app.command()

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -70,7 +70,7 @@ SourcePathType = Annotated[
 @app.command()
 def train(
     config: ConfigType = None,
-    resume: Annotated[
+    resume_checkpoint: Annotated[
         str | None,
         typer.Option(help="Resume training from this checkpoint."),
     ] = None,
@@ -79,7 +79,7 @@ def train(
     """Start training."""
     from luxonis_train.core import LuxonisModel
 
-    LuxonisModel(config, opts).train(resume_weights=resume)
+    LuxonisModel(config, opts).train(resume_checkpoint=resume_checkpoint)
 
 
 @app.command()

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -380,6 +380,7 @@ class TrainerConfig(BaseModelExtraForbid):
     gradient_clip_algorithm: Literal["norm", "value"] | None = None
     use_weighted_sampler: bool = False
     epochs: PositiveInt = 100
+    resume_training: bool = False
     n_workers: Annotated[
         NonNegativeInt,
         Field(validation_alias=AliasChoices("n_workers", "num_workers")),

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -287,7 +287,7 @@ class LuxonisModel:
                     logger.warning(
                         "Resume weights provided in the command line, but resume_training in config is set to True. Ignoring resume weights provided in the command line."
                     )
-                resume_checkpoint = self.cfg.model.weights
+                resume_checkpoint = self.cfg.model.weights  # type: ignore
             logger.info("Starting training...")
             self._train(
                 resume_checkpoint,

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -240,15 +240,15 @@ class LuxonisModel:
             self.tracker._finalize(status)
 
     def train(
-        self, new_thread: bool = False, resume_weights: str | None = None
+        self, new_thread: bool = False, resume_checkpoint: str | None = None
     ) -> None:
         """Runs training.
 
         @type new_thread: bool
         @param new_thread: Runs training in new thread if set to True.
-        @type resume_weights: str | None
-        @param resume_weights: Path to the checkpoint from which to to
-            resume the training.
+        @type resume_checkpoint: str | None
+        @param resume_checkpoint: Path to the checkpoint from which to
+            to resume the training.
         """
 
         if self.cfg.trainer.matmul_precision is not None:
@@ -259,9 +259,11 @@ class LuxonisModel:
                 self.cfg.trainer.matmul_precision
             )
 
-        if resume_weights is not None:
-            resume_weights = str(
-                LuxonisFileSystem.download(resume_weights, self.run_save_dir)
+        if resume_checkpoint is not None:
+            resume_checkpoint = str(
+                LuxonisFileSystem.download(
+                    resume_checkpoint, self.run_save_dir
+                )
             )
 
         def graceful_exit(signum: int, _):  # pragma: no cover
@@ -280,9 +282,15 @@ class LuxonisModel:
 
         if not new_thread:
             logger.info(f"Checkpoints will be saved in: {self.run_save_dir}")
+            if self.cfg.trainer.resume_training:
+                if resume_checkpoint is not None:
+                    logger.warning(
+                        "Resume weights provided in the command line, but resume_training in config is set to True. Ignoring resume weights provided in the command line."
+                    )
+                resume_checkpoint = self.cfg.model.weights
             logger.info("Starting training...")
             self._train(
-                resume_weights,
+                resume_checkpoint,
                 self.lightning_module,
                 self.pytorch_loaders["train"],
                 self.pytorch_loaders["val"],
@@ -300,7 +308,7 @@ class LuxonisModel:
             self.thread = threading.Thread(
                 target=self._train,
                 args=(
-                    resume_weights,
+                    resume_checkpoint,
                     self.lightning_module,
                     self.pytorch_loaders["train"],
                     self.pytorch_loaders["val"],

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -240,15 +240,15 @@ class LuxonisModel:
             self.tracker._finalize(status)
 
     def train(
-        self, new_thread: bool = False, resume_checkpoint: str | None = None
+        self, new_thread: bool = False, resume_weights: str | None = None
     ) -> None:
         """Runs training.
 
         @type new_thread: bool
         @param new_thread: Runs training in new thread if set to True.
-        @type resume_checkpoint: str | None
-        @param resume_checkpoint: Path to the checkpoint from which to
-            to resume the training.
+        @type resume_weights: str | None
+        @param resume_weights: Path to the checkpoint from which to to
+            resume the training.
         """
 
         if self.cfg.trainer.matmul_precision is not None:
@@ -259,11 +259,9 @@ class LuxonisModel:
                 self.cfg.trainer.matmul_precision
             )
 
-        if resume_checkpoint is not None:
-            resume_checkpoint = str(
-                LuxonisFileSystem.download(
-                    resume_checkpoint, self.run_save_dir
-                )
+        if resume_weights is not None:
+            resume_weights = str(
+                LuxonisFileSystem.download(resume_weights, self.run_save_dir)
             )
 
         def graceful_exit(signum: int, _):  # pragma: no cover
@@ -283,14 +281,14 @@ class LuxonisModel:
         if not new_thread:
             logger.info(f"Checkpoints will be saved in: {self.run_save_dir}")
             if self.cfg.trainer.resume_training:
-                if resume_checkpoint is not None:
+                if resume_weights is not None:
                     logger.warning(
                         "Resume weights provided in the command line, but resume_training in config is set to True. Ignoring resume weights provided in the command line."
                     )
-                resume_checkpoint = self.cfg.model.weights  # type: ignore
+                resume_weights = self.cfg.model.weights  # type: ignore
             logger.info("Starting training...")
             self._train(
-                resume_checkpoint,
+                resume_weights,
                 self.lightning_module,
                 self.pytorch_loaders["train"],
                 self.pytorch_loaders["val"],
@@ -308,7 +306,7 @@ class LuxonisModel:
             self.thread = threading.Thread(
                 target=self._train,
                 args=(
-                    resume_checkpoint,
+                    resume_weights,
                     self.lightning_module,
                     self.pytorch_loaders["train"],
                     self.pytorch_loaders["val"],

--- a/tests/unittests/test_callbacks/test_ema.py
+++ b/tests/unittests/test_callbacks/test_ema.py
@@ -33,7 +33,6 @@ def test_ema_initialization(model, ema_callback):
     assert isinstance(ema_callback.ema, ModelEma)
     assert ema_callback.ema.decay == ema_callback.decay
     assert ema_callback.ema.use_dynamic_decay == ema_callback.use_dynamic_decay
-    assert ema_callback.ema.device == ema_callback.device
 
 
 def test_ema_update_on_batch_end(model, ema_callback):
@@ -76,11 +75,10 @@ def test_ema_state_saved_to_checkpoint(model, ema_callback):
 
 def test_load_from_checkpoint(model, ema_callback):
     trainer = Trainer()
-    ema_callback.on_fit_start(trainer, model)
 
     checkpoint = {"state_dict": deepcopy(model.state_dict())}
-    ema_callback.on_load_checkpoint(checkpoint)
-
+    ema_callback.on_load_checkpoint(trainer, model, checkpoint)
+    ema_callback.on_fit_start(trainer, model)
     assert (
         ema_callback.ema.state_dict_ema.keys()
         == checkpoint["state_dict"].keys()


### PR DESCRIPTION
We already support loading hyperparameters such as `lr_schedulers`, `epoch`, `global_step`, `optimizer_steps`, and `state_dict` (including EMA weights if used) via the `--resume` flag in the `train` command. This PR:
1. Fixes a bug in the EMA implementation.
2. Ensures proper handling of the `on_load_checkpoint` hook, which is called before the `on_fit_start` hook.
3. Introduces a new parameter `trainer.resume_training` to resume training from checkpoints specified in the config file (model.weights).