### PR TITLE
Removed `semgrep` from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,10 +21,3 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm==0.3.6
-
-  - repo: https://github.com/semgrep/pre-commit
-    rev: 'v1.108.0'
-    hooks:
-      - id: semgrep
-        args: ['--config', 'auto', '--config', 'p/secrets', '--error', '--quiet']
-


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`semgrep` is not supported on Windows, so having it in pre-commit hooks blocks development for Windows users. We already have a specialized workflow for `semgrep` so the pre-commit hook is redundant. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. -->
Removed `semgrep` hook from `pre-commit-config.yaml`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? -->

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. -->

## Testing & Validation
<!-- How was this tested? Include relevant test results. -->
