### PR TITLE
Fix strides shape

### DIFF
--- a/luxonis_train/nodes/heads/efficient_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_bbox_head.py
@@ -211,7 +211,9 @@ class EfficientBBoxHead(
         index."""
         stride = torch.tensor(
             [
-                self.original_in_shape[1] / x[2]  # type: ignore
+                round(
+                    self.original_in_shape[1] / x[2]
+                )  # Ensure proper rounding of the stride
                 for x in self.in_sizes[: self.n_heads]
             ],
             dtype=torch.int,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

When using an input shape for detection models that is not divisible by 32 (540x960), the model still trains and produces correct results. However, it will be incompatible with DepthAI. This is due to a bug in the following code:
[Link to bug](https://github.com/luxonis/luxonis-train/blob/fbdc28bcfff9531bb72da2f4f4a1f1934b9b645b/luxonis_train/nodes/heads/efficient_bbox_head.py#L209C1-L219C22).
In this case, the stride becomes incorrectly calculated as tensor([7, 15, 31], dtype=[torch.int](http://torch.int/)) instead of tensor([8, 16, 32], dtype=[torch.int](http://torch.int/)). This leads to the model learning with an incorrect stride. While predictions might look correct during training, once the model is exported, it won't function as expected.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable
