### PR TITLE
Fix: Loading saved configs

### DIFF
--- a/luxonis_train/callbacks/metadata_logger.py
+++ b/luxonis_train/callbacks/metadata_logger.py
@@ -46,7 +46,7 @@ class MetadataLogger(pl.Callback):
 
         pl_module.logger.log_hyperparams(hparams)
         with open(osp.join(pl_module.save_dir, "metadata.yaml"), "w") as f:
-            yaml.dump(hparams, f, default_flow_style=False)
+            yaml.safe_dump(hparams, f, default_flow_style=False)
 
     @staticmethod
     def _get_editable_package_git_hash(

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -80,7 +80,9 @@ class PredefinedModelConfig(BaseModelExtraForbid):
 
 class ModelConfig(BaseModelExtraForbid):
     name: str = "model"
-    predefined_model: PredefinedModelConfig | None = None
+    predefined_model: Annotated[
+        PredefinedModelConfig | None, Field(exclude=True)
+    ] = None
     weights: FilePath | None = None
     nodes: list[ModelNodeConfig] = []
     losses: list[LossModuleConfig] = []

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -550,10 +550,7 @@ class TunerConfig(BaseModelExtraForbid):
     n_trials: PositiveInt | None = 15
     timeout: PositiveInt | None = None
     storage: StorageConfig = StorageConfig()
-    params: Annotated[
-        dict[str, list[str | int | float | bool | list]],
-        Field(default={}, min_length=1),
-    ]
+    params: dict[str, list[str | int | float | bool | list]] = {}
 
 
 class Config(LuxonisConfig):

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -394,7 +394,7 @@ class LuxonisModel:
                 LuxonisFileSystem.upload(path, self.cfg.exporter.upload_url)
 
         with open(export_path.with_suffix(".yaml"), "w") as f:
-            yaml.dump(modelconverter_config, f)
+            yaml.safe_dump(modelconverter_config, f)
             if self.cfg.exporter.upload_to_run:
                 self.tracker.upload_artifact(f.name, name=f.name, typ="export")
             if self.cfg.exporter.upload_url is not None:  # pragma: no cover

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,17 +17,17 @@ WORK_DIR = Path("tests", "data").absolute()
 
 
 @pytest.fixture(scope="session")
-def test_output_dir() -> Path:
+def output_dir() -> Path:
     return Path("tests/integration/save-directory")
 
 
 @pytest.fixture(scope="session", autouse=True)
-def setup(test_output_dir: Path):
+def setup(output_dir: Path):
     WORK_DIR.mkdir(parents=True, exist_ok=True)
     shutil.rmtree(WORK_DIR / "luxonisml", ignore_errors=True)
-    shutil.rmtree(test_output_dir, ignore_errors=True)
+    shutil.rmtree(output_dir, ignore_errors=True)
     environ.LUXONISML_BASE_PATH = WORK_DIR / "luxonisml"
-    test_output_dir.mkdir(exist_ok=True)
+    output_dir.mkdir(exist_ok=True)
 
 
 @pytest.fixture

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -30,13 +30,13 @@ def infer_path() -> Path:
 
 
 @pytest.fixture
-def opts(test_output_dir: Path) -> dict[str, Any]:
+def opts(output_dir: Path) -> dict[str, Any]:
     return {
         "trainer.epochs": 1,
         "trainer.batch_size": 1,
         "trainer.validation_interval": 1,
         "trainer.callbacks": "[]",
-        "tracker.save_directory": str(test_output_dir),
+        "tracker.save_directory": str(output_dir),
         "tuner.n_trials": 4,
     }
 
@@ -49,7 +49,7 @@ def clear_files():
 
 
 @pytest.mark.parametrize(
-    "config_file",
+    "config_name",
     [
         "classification_heavy_model",
         "classification_light_model",
@@ -67,14 +67,14 @@ def clear_files():
 )
 def test_predefined_models(
     opts: dict[str, Any],
-    config_file: str,
+    config_name: str,
     coco_dataset: LuxonisDataset,
     cifar10_dataset: LuxonisDataset,
     mnist_dataset: LuxonisDataset,
     output_dir: Path,
     subtests: SubTests,
 ):
-    config_file = f"configs/{config_file}.yaml"
+    config_file = f"configs/{config_name}.yaml"
     opts |= {
         "loader.params.dataset_name": (
             cifar10_dataset.identifier
@@ -84,15 +84,16 @@ def test_predefined_models(
             else coco_dataset.identifier
         ),
         "trainer.epochs": 1,
-        "tracker.run_name": config_file,
+        "tracker.run_name": config_name,
     }
     with subtests.test("original_config"):
         model = LuxonisModel(config_file, opts)
         model.train()
         model.test(view="train")
     with subtests.test("saved_config"):
+        opts["tracker.run_name"] = f"{config_name}_reload"
         model = LuxonisModel(
-            str(output_dir / config_file / "training_config.yaml"), opts
+            str(output_dir / config_name / "training_config.yaml"), opts
         )
         model.test(view="train")
 

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -136,9 +136,9 @@ def test_custom_tasks(
         with tarfile.open(archive_path) as tar:
             extracted_cfg = tar.extractfile("config.json")
 
-            assert extracted_cfg is not None, (
-                "Config JSON not found in the archive."
-            )
+            assert (
+                extracted_cfg is not None
+            ), "Config JSON not found in the archive."
             generated_config = json.loads(extracted_cfg.read().decode())
 
         # Sort the fields in the config to make the comparison consistent

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -233,9 +233,9 @@ def test_infer(
         model.infer(source_path="tests/data/invalid.jpg", save_dir=infer_path)
 
 
-def test_archive(test_output_dir: Path, coco_dataset: LuxonisDataset):
+def test_archive(output_dir: Path, coco_dataset: LuxonisDataset):
     opts = {
-        "tracker.save_directory": str(test_output_dir),
+        "tracker.save_directory": str(output_dir),
         "loader.params.dataset_name": coco_dataset.identifier,
     }
     model = LuxonisModel("tests/configs/archive_config.yaml", opts)

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -89,13 +89,13 @@ def test_predefined_models(
     with subtests.test("original_config"):
         model = LuxonisModel(config_file, opts)
         model.train()
-        model.test(view="train")
+        model.test()
     with subtests.test("saved_config"):
         opts["tracker.run_name"] = f"{config_name}_reload"
         model = LuxonisModel(
             str(output_dir / config_name / "training_config.yaml"), opts
         )
-        model.test(view="train")
+        model.test()
 
 
 def test_multi_input(opts: dict[str, Any], infer_path: Path):


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it possible to load back previously saved config file.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Excluded `predefined_model` field from the config
- Replaced `yaml.dump` with `yaml.safe_dump` (unrelated to the config, but we should be only using `safe_dump`/`safe_load`)

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Added tests for all predefined models