### PR TITLE
fix missing task names

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -66,18 +66,19 @@ The `Model` section is a crucial part of the configuration and **must always be 
 
 For all available node names and their `params`, see [nodes](../luxonis_train/nodes/README.md).
 
-| Key                       | Type                   | Default value | Description                                                                                                                                 |
-| ------------------------- | ---------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                    | `str`                  | -             | Name of the node                                                                                                                            |
-| `alias`                   | `str`                  | `None`        | Custom name for the node                                                                                                                    |
-| `params`                  | `dict`                 | `{}`          | Parameters for the node                                                                                                                     |
-| `inputs`                  | `list`                 | `[]`          | List of input nodes for this node, if empty, the node is understood to be an input node of the model                                        |
-| `freezing.active`         | `bool`                 | `False`       | whether to freeze the modules so the weights are not updated                                                                                |
-| `freezing.unfreeze_after` | `int \| float \| None` | `None`        | After how many epochs should the modules be unfrozen, can be `int` for a specific number of epochs or `float` for a portion of the training |
-| `remove_on_export`        | `bool`                 | `False`       | Whether the node should be removed when exporting                                                                                           |
-| `losses`                  | `list`                 | `[]`          | List of losses attached to this node (see [Losses](#losses))                                                                                |
-| `metrics`                 | `list`                 | `[]`          | List of metrics attached to this node (see [Metrics](#metrics))                                                                             |
-| `visualizers`             | `list`                 | `[]`          | List of visualizers attached to this node (see [Visualizers](#visualizers))                                                                 |
+| Key                       | Type                   | Default value | Description                                                                                                                                                                   |
+| ------------------------- | ---------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                    | `str`                  | -             | Name of the node                                                                                                                                                              |
+| `task_name`               | `str`                  | `""`          | A task name for the head node. It should match one of the task_names from the dataset. If the dataset was created without task_names, it should be left as the default value. |
+| `alias`                   | `str`                  | `None`        | Custom name for the node. The node graph will use this as the node name instead of the default `name`. Weights will be linked to it.                                          |
+| `params`                  | `dict`                 | `{}`          | Parameters for the node                                                                                                                                                       |
+| `inputs`                  | `list`                 | `[]`          | List of input nodes for this node, if empty, the node is understood to be an input node of the model                                                                          |
+| `freezing.active`         | `bool`                 | `False`       | whether to freeze the modules so the weights are not updated                                                                                                                  |
+| `freezing.unfreeze_after` | `int \| float \| None` | `None`        | After how many epochs should the modules be unfrozen, can be `int` for a specific number of epochs or `float` for a portion of the training                                   |
+| `remove_on_export`        | `bool`                 | `False`       | Whether the node should be removed when exporting                                                                                                                             |
+| `losses`                  | `list`                 | `[]`          | List of losses attached to this node (see [Losses](#losses))                                                                                                                  |
+| `metrics`                 | `list`                 | `[]`          | List of metrics attached to this node (see [Metrics](#metrics))                                                                                                               |
+| `visualizers`             | `list`                 | `[]`          | List of visualizers attached to this node (see [Visualizers](#visualizers))                                                                                                   |
 
 #### Losses
 

--- a/luxonis_train/config/predefined_models/anomaly_detection_model.py
+++ b/luxonis_train/config/predefined_models/anomaly_detection_model.py
@@ -67,7 +67,7 @@ class AnomalyDetectionModel(BasePredefinedModel):
         self.head_params = head_params or var_config.head_params
         self.loss_params = loss_params or {}
         self.visualizer_params = visualizer_params or {}
-        self.task_name = task_name or "anomaly_detection"
+        self.task_name = task_name
 
     @property
     def nodes(self) -> list[ModelNodeConfig]:
@@ -76,14 +76,13 @@ class AnomalyDetectionModel(BasePredefinedModel):
         return [
             ModelNodeConfig(
                 name=self.backbone,
-                alias=f"{self.task_name}-{self.backbone}",
                 params=self.backbone_params,
             ),
             ModelNodeConfig(
                 name="DiscSubNetHead",
-                alias=f"{self.task_name}-DiscSubNetHead",
-                inputs=[f"{self.task_name}-{self.backbone}"],
+                inputs=[f"{self.backbone}"],
                 params=self.head_params,
+                task_name=self.task_name,
             ),
         ]
 
@@ -93,7 +92,7 @@ class AnomalyDetectionModel(BasePredefinedModel):
         return [
             LossModuleConfig(
                 name="ReconstructionSegmentationLoss",
-                attached_to=f"{self.task_name}-DiscSubNetHead",
+                attached_to="DiscSubNetHead",
                 params=self.loss_params,
                 weight=1.0,
             )
@@ -105,7 +104,7 @@ class AnomalyDetectionModel(BasePredefinedModel):
         return [
             MetricModuleConfig(
                 name="JaccardIndex",
-                attached_to=f"{self.task_name}-DiscSubNetHead",
+                attached_to="DiscSubNetHead",
                 params={"num_classes": 2, "task": "multiclass"},
                 is_main_metric=True,
             ),
@@ -118,7 +117,7 @@ class AnomalyDetectionModel(BasePredefinedModel):
         return [
             AttachedModuleConfig(
                 name="SegmentationVisualizer",
-                attached_to=f"{self.task_name}-DiscSubNetHead",
+                attached_to="DiscSubNetHead",
                 params=self.visualizer_params,
             )
         ]

--- a/luxonis_train/config/predefined_models/classification_model.py
+++ b/luxonis_train/config/predefined_models/classification_model.py
@@ -78,14 +78,12 @@ class ClassificationModel(BasePredefinedModel):
         return [
             ModelNodeConfig(
                 name=self.backbone,
-                alias=f"{self.task_name}-{self.backbone}",
                 freezing=self.backbone_params.pop("freezing", {}),
                 params=self.backbone_params,
             ),
             ModelNodeConfig(
                 name="ClassificationHead",
-                alias=f"{self.task_name}-ClassificationHead",
-                inputs=[f"{self.task_name}-{self.backbone}"],
+                inputs=[f"{self.backbone}"],
                 freezing=self.head_params.pop("freezing", {}),
                 params=self.head_params,
                 task_name=self.task_name,
@@ -98,7 +96,7 @@ class ClassificationModel(BasePredefinedModel):
         return [
             LossModuleConfig(
                 name="CrossEntropyLoss",
-                attached_to=f"{self.task_name}-ClassificationHead",
+                attached_to="ClassificationHead",
                 params=self.loss_params,
                 weight=1.0,
             )
@@ -111,17 +109,17 @@ class ClassificationModel(BasePredefinedModel):
             MetricModuleConfig(
                 name="F1Score",
                 is_main_metric=True,
-                attached_to=f"{self.task_name}-ClassificationHead",
+                attached_to="ClassificationHead",
                 params={"task": self.task},
             ),
             MetricModuleConfig(
                 name="Accuracy",
-                attached_to=f"{self.task_name}-ClassificationHead",
+                attached_to="ClassificationHead",
                 params={"task": self.task},
             ),
             MetricModuleConfig(
                 name="Recall",
-                attached_to=f"{self.task_name}-ClassificationHead",
+                attached_to="ClassificationHead",
                 params={"task": self.task},
             ),
         ]
@@ -129,8 +127,7 @@ class ClassificationModel(BasePredefinedModel):
             metrics.append(
                 MetricModuleConfig(
                     name="ConfusionMatrix",
-                    alias=f"{self.task_name}-ConfusionMatrix",
-                    attached_to=f"{self.task_name}-ClassificationHead",
+                    attached_to="ClassificationHead",
                     params={**self.confusion_matrix_params},
                 )
             )
@@ -142,7 +139,7 @@ class ClassificationModel(BasePredefinedModel):
         return [
             AttachedModuleConfig(
                 name="ClassificationVisualizer",
-                attached_to=f"{self.task_name}-ClassificationHead",
+                attached_to="ClassificationHead",
                 params=self.visualizer_params,
             )
         ]

--- a/luxonis_train/config/predefined_models/detection_fomo_model.py
+++ b/luxonis_train/config/predefined_models/detection_fomo_model.py
@@ -69,14 +69,12 @@ class FOMOModel(BasePredefinedModel):
         nodes = [
             ModelNodeConfig(
                 name=self.backbone,
-                alias=f"{self.task_name}-{self.backbone}",
                 freezing=self.backbone_params.pop("freezing", {}),
                 params=self.backbone_params,
             ),
             ModelNodeConfig(
                 name="FOMOHead",
-                alias=f"{self.task_name}-FOMOHead",
-                inputs=[f"{self.task_name}-{self.backbone}"],
+                inputs=[f"{self.backbone}"],
                 params=self.head_params,
                 task_name=self.task_name,
             ),
@@ -88,7 +86,7 @@ class FOMOModel(BasePredefinedModel):
         return [
             LossModuleConfig(
                 name="FOMOLocalizationLoss",
-                attached_to=f"{self.task_name}-FOMOHead",
+                attached_to="FOMOHead",
                 params=self.loss_params,
                 weight=1.0,
             )
@@ -99,7 +97,7 @@ class FOMOModel(BasePredefinedModel):
         return [
             MetricModuleConfig(
                 name="ObjectKeypointSimilarity",
-                attached_to=f"{self.task_name}-FOMOHead",
+                attached_to="FOMOHead",
                 is_main_metric=True,
             ),
         ]
@@ -109,7 +107,7 @@ class FOMOModel(BasePredefinedModel):
         return [
             AttachedModuleConfig(
                 name="FOMOVisualizer",
-                attached_to=f"{self.task_name}-FOMOHead",
+                attached_to="FOMOHead",
                 params=self.visualizer_params,
             )
         ]

--- a/luxonis_train/config/predefined_models/detection_model.py
+++ b/luxonis_train/config/predefined_models/detection_model.py
@@ -93,7 +93,6 @@ class DetectionModel(BasePredefinedModel):
         nodes = [
             ModelNodeConfig(
                 name=self.backbone,
-                alias=f"{self.task_name}-{self.backbone}",
                 freezing=self.backbone_params.pop("freezing", {}),
                 params=self.backbone_params,
             ),
@@ -102,8 +101,7 @@ class DetectionModel(BasePredefinedModel):
             nodes.append(
                 ModelNodeConfig(
                     name="RepPANNeck",
-                    alias=f"{self.task_name}-RepPANNeck",
-                    inputs=[f"{self.task_name}-{self.backbone}"],
+                    inputs=[f"{self.backbone}"],
                     freezing=self.neck_params.pop("freezing", {}),
                     params=self.neck_params,
                 )
@@ -112,11 +110,10 @@ class DetectionModel(BasePredefinedModel):
         nodes.append(
             ModelNodeConfig(
                 name="EfficientBBoxHead",
-                alias=f"{self.task_name}-EfficientBBoxHead",
                 freezing=self.head_params.pop("freezing", {}),
-                inputs=[f"{self.task_name}-RepPANNeck"]
+                inputs=["RepPANNeck"]
                 if self.use_neck
-                else [f"{self.task_name}-{self.backbone}"],
+                else [f"{self.backbone}"],
                 params=self.head_params,
                 task_name=self.task_name,
             )
@@ -129,7 +126,7 @@ class DetectionModel(BasePredefinedModel):
         return [
             LossModuleConfig(
                 name="AdaptiveDetectionLoss",
-                attached_to=f"{self.task_name}-EfficientBBoxHead",
+                attached_to="EfficientBBoxHead",
                 params=self.loss_params,
                 weight=1.0,
             )
@@ -141,7 +138,7 @@ class DetectionModel(BasePredefinedModel):
         metrics = [
             MetricModuleConfig(
                 name="MeanAveragePrecision",
-                attached_to=f"{self.task_name}-EfficientBBoxHead",
+                attached_to="EfficientBBoxHead",
                 is_main_metric=True,
             ),
         ]
@@ -149,8 +146,8 @@ class DetectionModel(BasePredefinedModel):
             metrics.append(
                 MetricModuleConfig(
                     name="ConfusionMatrix",
-                    alias=f"{self.task_name}-ConfusionMatrix",
-                    attached_to=f"{self.task_name}-EfficientBBoxHead",
+                    alias="ConfusionMatrix",
+                    attached_to="EfficientBBoxHead",
                     params={**self.confusion_matrix_params},
                 )
             )
@@ -162,7 +159,7 @@ class DetectionModel(BasePredefinedModel):
         return [
             AttachedModuleConfig(
                 name="BBoxVisualizer",
-                attached_to=f"{self.task_name}-EfficientBBoxHead",
+                attached_to="EfficientBBoxHead",
                 params=self.visualizer_params,
             )
         ]

--- a/luxonis_train/config/predefined_models/ocr_recognition_model.py
+++ b/luxonis_train/config/predefined_models/ocr_recognition_model.py
@@ -66,7 +66,7 @@ class OCRRecognitionModel(BasePredefinedModel):
         head_params: Params | None = None,
         loss_params: Params | None = None,
         visualizer_params: Params | None = None,
-        task_name: str | None = None,
+        task_name: str = "",
         alphabet: list[str] | AlphabetName = "english",
         max_text_len: int = 40,
         ignore_unknown: bool = True,
@@ -88,7 +88,7 @@ class OCRRecognitionModel(BasePredefinedModel):
         self.head_params["ignore_unknown"] = ignore_unknown
         self.loss_params = loss_params or {}
         self.visualizer_params = visualizer_params or {}
-        self.task_name = task_name or "ocr_recognition"
+        self.task_name = task_name
 
     @property
     def nodes(self) -> list[ModelNodeConfig]:

--- a/luxonis_train/config/predefined_models/ocr_recognition_model.py
+++ b/luxonis_train/config/predefined_models/ocr_recognition_model.py
@@ -96,23 +96,21 @@ class OCRRecognitionModel(BasePredefinedModel):
         return [
             ModelNodeConfig(
                 name=self.backbone,
-                alias=f"{self.task_name}-{self.backbone}",
                 freezing=self.backbone_params.pop("freezing", {}),
                 params=self.backbone_params,
             ),
             ModelNodeConfig(
                 name="SVTRNeck",
-                alias=f"{self.task_name}-SVTRNeck",
-                inputs=[f"{self.task_name}-{self.backbone}"],
+                inputs=[f"{self.backbone}"],
                 freezing=self.neck_params.pop("freezing", {}),
                 params=self.neck_params,
             ),
             ModelNodeConfig(
                 name="OCRCTCHead",
-                alias=f"{self.task_name}-OCRCTCHead",
-                inputs=[f"{self.task_name}-SVTRNeck"],
+                inputs=["SVTRNeck"],
                 freezing=self.head_params.pop("freezing", {}),
                 params=self.head_params,
+                task_name=self.task_name,
             ),
         ]
 
@@ -122,8 +120,7 @@ class OCRRecognitionModel(BasePredefinedModel):
         return [
             LossModuleConfig(
                 name="CTCLoss",
-                alias=f"{self.task_name}-CTCLoss",
-                attached_to=f"{self.task_name}-OCRCTCHead",
+                attached_to="OCRCTCHead",
                 params=self.loss_params,
                 weight=1.0,
             )
@@ -135,7 +132,7 @@ class OCRRecognitionModel(BasePredefinedModel):
         metrics = [
             MetricModuleConfig(
                 name="OCRAccuracy",
-                attached_to=f"{self.task_name}-OCRCTCHead",
+                attached_to="OCRCTCHead",
                 is_main_metric=True,
             ),
         ]
@@ -147,7 +144,7 @@ class OCRRecognitionModel(BasePredefinedModel):
         return [
             AttachedModuleConfig(
                 name="OCRVisualizer",
-                attached_to=f"{self.task_name}-OCRCTCHead",
+                attached_to="OCRCTCHead",
                 params=self.visualizer_params,
             )
         ]

--- a/luxonis_train/config/predefined_models/segmentation_model.py
+++ b/luxonis_train/config/predefined_models/segmentation_model.py
@@ -86,15 +86,13 @@ class SegmentationModel(BasePredefinedModel):
         node_list = [
             ModelNodeConfig(
                 name=self.backbone,
-                alias=f"{self.task_name}-{self.backbone}",
                 freezing=self.backbone_params.pop("freezing", {}),
                 params=self.backbone_params,
                 task_name=self.task_name,
             ),
             ModelNodeConfig(
                 name="DDRNetSegmentationHead",
-                alias=f"{self.task_name}-DDRNetSegmentationHead",
-                inputs=[f"{self.task_name}-{self.backbone}"],
+                inputs=[f"{self.backbone}"],
                 freezing=self.head_params.pop("freezing", {}),
                 params=self.head_params,
                 task_name=self.task_name,
@@ -104,8 +102,7 @@ class SegmentationModel(BasePredefinedModel):
             node_list.append(
                 ModelNodeConfig(
                     name="DDRNetSegmentationHead",
-                    alias=f"{self.task_name}-DDRNetSegmentationHead_aux",
-                    inputs=[f"{self.task_name}-{self.backbone}"],
+                    inputs=[f"{self.backbone}"],
                     freezing=self.aux_head_params.pop("freezing", {}),
                     params=self.aux_head_params,
                     task_name=self.task_name,
@@ -126,7 +123,7 @@ class SegmentationModel(BasePredefinedModel):
                     if self.task == "binary"
                     else "OHEMCrossEntropyLoss"
                 ),
-                attached_to=f"{self.task_name}-DDRNetSegmentationHead",
+                attached_to="DDRNetSegmentationHead",
                 params=self.loss_params,
                 weight=1.0,
             ),
@@ -139,7 +136,7 @@ class SegmentationModel(BasePredefinedModel):
                         if self.task == "binary"
                         else "OHEMCrossEntropyLoss"
                     ),
-                    attached_to=f"{self.task_name}-DDRNetSegmentationHead_aux",
+                    attached_to="DDRNetSegmentationHead_aux",
                     params=self.loss_params,
                     weight=0.4,
                 )
@@ -152,13 +149,13 @@ class SegmentationModel(BasePredefinedModel):
         metrics = [
             MetricModuleConfig(
                 name="JaccardIndex",
-                attached_to=f"{self.task_name}-DDRNetSegmentationHead",
+                attached_to="DDRNetSegmentationHead",
                 is_main_metric=True,
                 params={"task": self.task},
             ),
             MetricModuleConfig(
                 name="F1Score",
-                attached_to=f"{self.task_name}-DDRNetSegmentationHead",
+                attached_to="DDRNetSegmentationHead",
                 params={"task": self.task},
             ),
         ]
@@ -166,8 +163,7 @@ class SegmentationModel(BasePredefinedModel):
             metrics.append(
                 MetricModuleConfig(
                     name="ConfusionMatrix",
-                    alias=f"{self.task_name}-ConfusionMatrix",
-                    attached_to=f"{self.task_name}-DDRNetSegmentationHead",
+                    attached_to="DDRNetSegmentationHead",
                     params={**self.confusion_matrix_params},
                 )
             )
@@ -179,7 +175,7 @@ class SegmentationModel(BasePredefinedModel):
         return [
             AttachedModuleConfig(
                 name="SegmentationVisualizer",
-                attached_to=f"{self.task_name}-DDRNetSegmentationHead",
+                attached_to="DDRNetSegmentationHead",
                 params=self.visualizer_params,
             )
         ]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

This is a fix for task names. Previously, we did not log correctly when the dataset had a task, such as `coco`. For example, we logged `val/visualizations/-EfficientBBoxHead/BBoxVisualizer` instead of `val/visualizations/coco-EfficientBBoxHead/BBoxVisualizer,` and the same issue occurred for loss and metrics.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable