### PR TITLE
Fix incorrect blob path

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -353,7 +353,7 @@ class LuxonisModel:
 
         if self.cfg.exporter.blobconverter.active:
             try:
-                blobconverter_export(
+                blob_path = blobconverter_export(
                     self.cfg.exporter,
                     scale_values,
                     mean_values,
@@ -361,9 +361,8 @@ class LuxonisModel:
                     str(export_save_dir),
                     onnx_save_path,
                 )
-                self._exported_models["blob"] = export_path.with_suffix(
-                    ".blob"
-                )
+                self._exported_models["blob"] = blob_path
+
             except ImportError:
                 logger.error("Failed to import `blobconverter`")
                 logger.warning(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

The blob converter generates a different name from the ONNX file.  
For example, if the ONNX file is named `detection_light.onnx`, the corresponding blob file will not be `detection_light.blob`.  
Instead, the blob name will include the OpenVINO version, resulting in :  
`detection_light_openvino_2022.1_8shave.blob`



## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable