### PR TITLE
Fix: Resuming Training from Checkpoint

### DIFF
--- a/configs/detection_light_model.yaml
+++ b/configs/detection_light_model.yaml
@@ -2,6 +2,7 @@
 # NOTE: This example downloads pretrained COCO weights and training parameters are already prepared for fine tuning
 
 model:
+  weights:  "C:\\Users\\jerne\\Desktop\\luxonis-train-ml\\luxonis-train\\output\\197-salmon-swan\\best_val_metric\\detection_light_EfficientBBoxHead_MeanAveragePrecision=nan_loss=24.4528_09.ckpt"
   name: detection_light
   predefined_model:
     name: DetectionModel
@@ -25,6 +26,7 @@ loader:
 
 trainer:
   precision: "16-mixed"
+  # resume_training: true
   preprocessing:
     train_image_size: [384, 512]
     keep_aspect_ratio: true
@@ -35,7 +37,7 @@ trainer:
         std: [1, 1, 1]
 
   batch_size: 8
-  epochs: 300
+  epochs: 15
   # For best results, always accumulate gradients to
   # effectively use 64 batch size
   accumulate_grad_batches: 8
@@ -44,6 +46,7 @@ trainer:
   n_log_images: 8
 
   callbacks:
+    # - name: UploadCheckpoint
     - name: EMACallback
       params:
         decay: 0.9999
@@ -51,6 +54,7 @@ trainer:
         decay_tau: 2000
     - name: ExportOnTrainEnd
     - name: TestOnTrainEnd
+
 
   training_strategy:
     name: "TripleLRSGDStrategy"
@@ -63,3 +67,9 @@ trainer:
       momentum: 0.843
       weight_decay: 0.00036
       nesterov: True
+
+
+# tracker:
+#   is_mlflow: true
+#   is_wandb: false
+#   project_name: test_tuner

--- a/configs/detection_light_model.yaml
+++ b/configs/detection_light_model.yaml
@@ -2,7 +2,6 @@
 # NOTE: This example downloads pretrained COCO weights and training parameters are already prepared for fine tuning
 
 model:
-  weights:  "C:\\Users\\jerne\\Desktop\\luxonis-train-ml\\luxonis-train\\output\\197-salmon-swan\\best_val_metric\\detection_light_EfficientBBoxHead_MeanAveragePrecision=nan_loss=24.4528_09.ckpt"
   name: detection_light
   predefined_model:
     name: DetectionModel
@@ -26,7 +25,6 @@ loader:
 
 trainer:
   precision: "16-mixed"
-  # resume_training: true
   preprocessing:
     train_image_size: [384, 512]
     keep_aspect_ratio: true
@@ -37,7 +35,7 @@ trainer:
         std: [1, 1, 1]
 
   batch_size: 8
-  epochs: 15
+  epochs: 300
   # For best results, always accumulate gradients to
   # effectively use 64 batch size
   accumulate_grad_batches: 8
@@ -46,7 +44,6 @@ trainer:
   n_log_images: 8
 
   callbacks:
-    # - name: UploadCheckpoint
     - name: EMACallback
       params:
         decay: 0.9999
@@ -54,7 +51,6 @@ trainer:
         decay_tau: 2000
     - name: ExportOnTrainEnd
     - name: TestOnTrainEnd
-
 
   training_strategy:
     name: "TripleLRSGDStrategy"
@@ -67,9 +63,3 @@ trainer:
       momentum: 0.843
       weight_decay: 0.00036
       nesterov: True
-
-
-# tracker:
-#   is_mlflow: true
-#   is_wandb: false
-#   project_name: test_tuner

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -39,18 +39,18 @@ def train(
     /,
     *,
     config: str | None = None,
-    resume_weights: str | None = None,
+    weights: str | None = None,
 ):
     """Start the training process.
 
     @type config: str
     @param config: Path to the configuration file.
-    @type resume_weights: str
-    @param resume_weights: Path to the model weights to resume training
-        from. @type *opts: tuple[str, str]
+    @type weights: str
+    @param weights: Path to the model weights. from. @type *opts:
+        tuple[str, str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    create_model(config, opts).train(resume_weights=resume_weights)
+    create_model(config, opts).train(weights=weights)
 
 
 @app.command(group=training_group, sort_key=2)

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -46,8 +46,8 @@ def train(
     @type config: str
     @param config: Path to the configuration file.
     @type weights: str
-    @param weights: Path to the model weights. from. @type *opts:
-        tuple[str, str]
+    @param weights: Path to the model weights.
+    @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
     create_model(config, opts).train(weights=weights)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -270,6 +270,12 @@ class LuxonisModel:
 
         resume_weights = weights if self.cfg.trainer.resume_training else None
 
+        if self.cfg.trainer.resume_training and resume_weights is None:
+            logger.warning(
+                "Resume training is enabled but no weights were provided. "
+                "Training will start from scratch."
+            )
+
         def graceful_exit(signum: int, _: Any) -> None:  # pragma: no cover
             logger.info(
                 f"{signal.Signals(signum).name} received, stopping training..."

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -235,15 +235,16 @@ class LuxonisModel:
             self.tracker._finalize(status)
 
     def train(
-        self, new_thread: bool = False, resume_weights: PathType | None = None
+        self, new_thread: bool = False, weights: PathType | None = None
     ) -> None:
         """Runs training.
 
         @type new_thread: bool
         @param new_thread: Runs training in new thread if set to True.
-        @type resume_weights: str | None
-        @param resume_weights: Path to the checkpoint from which to to
-            resume the training.
+        @type weights: str | None
+        @param weights: Path to the weights. If user specifies weights
+            in the config file, the weights provided here will take
+            precedence.
         """
 
         if self.cfg.trainer.matmul_precision is not None:
@@ -254,10 +255,20 @@ class LuxonisModel:
                 self.cfg.trainer.matmul_precision
             )
 
-        if resume_weights is not None:
-            resume_weights = LuxonisFileSystem.download(
-                str(resume_weights), self.run_save_dir
+        if weights is not None:
+            weights = LuxonisFileSystem.download(
+                str(weights), self.run_save_dir
             )
+            if self.cfg.model.weights is not None:
+                logger.warning(
+                    "Weights provided in the command line, but config weights are set. "
+                    "Ignoring weights provided in config."
+                )
+            self.lightning_module.load_checkpoint(weights)
+        else:
+            weights = self.cfg.model.weights
+
+        resume_weights = weights if self.cfg.trainer.resume_training else None
 
         def graceful_exit(signum: int, _: Any) -> None:  # pragma: no cover
             logger.info(
@@ -275,12 +286,6 @@ class LuxonisModel:
 
         if not new_thread:
             logger.info(f"Checkpoints will be saved in: {self.run_save_dir}")
-            if self.cfg.trainer.resume_training:
-                if resume_weights is not None:
-                    logger.warning(
-                        "Resume weights provided in the command line, but resume_training in config is set to True. Ignoring resume weights provided in the command line."
-                    )
-                resume_weights = self.cfg.model.weights
             logger.info("Starting training...")
             self._train(
                 resume_weights,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Now, the weights passed to `model.train()` will function the same way as those in the config. So, to resume training, you need to set the `resume_training `flag in the `config.yaml` file.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

IMPORTANT: Python API will change from `.train(resume_weights:...)` to `.train(weights=...)` to be more inline with what it actually does.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable