### PR TITLE
Fix: loss, archive, ema

### DIFF
--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -245,18 +245,6 @@ class EMACallback(pl.Callback):
         """
         self._swap_to_ema_weights(pl_module)
 
-    def on_train_epoch_start(
-        self, trainer: pl.Trainer, pl_module: pl.LightningModule
-    ) -> None:
-        """Restore the original model weights at the start of training.
-
-        @type trainer: L{pl.Trainer}
-        @param trainer: Pytorch Lightning trainer.
-        @type pl_module: L{pl.LightningModule}
-        @param pl_module: Pytorch Lightning module.
-        """
-        self._restore_original_weights(pl_module)
-
     def on_save_checkpoint(
         self,
         trainer: pl.Trainer,
@@ -306,4 +294,3 @@ class EMACallback(pl.Callback):
         """
         if self.collected_state_dict is not None:
             pl_module.load_state_dict(self.collected_state_dict)
-            self.collected_state_dict = None

--- a/luxonis_train/callbacks/ema.py
+++ b/luxonis_train/callbacks/ema.py
@@ -306,3 +306,4 @@ class EMACallback(pl.Callback):
         """
         if self.collected_state_dict is not None:
             pl_module.load_state_dict(self.collected_state_dict)
+            self.collected_state_dict = None

--- a/luxonis_train/core/utils/archive_utils.py
+++ b/luxonis_train/core/utils/archive_utils.py
@@ -43,7 +43,7 @@ def get_outputs(path: Path) -> dict[str, ArchiveMetadataDict]:
     )
 
 
-def _from_onnx_dtype(dtype: TensorProto.DataType | int) -> DataType:
+def _from_onnx_dtype(dtype: int) -> DataType:
     dtype_map: dict[int, str] = {
         TensorProto.INT8: "int8",
         TensorProto.INT32: "int32",

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -502,6 +502,11 @@ class LuxonisLightningModule(pl.LightningModule):
         return outputs
 
     @override
+    def on_train_epoch_start(self):
+        for node in self.nodes.values():
+            node.current_epoch = self.current_epoch
+
+    @override
     def on_train_epoch_end(self) -> None:
         for key, value in self._loss_accumulator.items():
             self.log(f"train/{key}", value, sync_dist=True)

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -505,6 +505,7 @@ class LuxonisLightningModule(pl.LightningModule):
     def on_train_epoch_end(self) -> None:
         for key, value in self._loss_accumulator.items():
             self.log(f"train/{key}", value, sync_dist=True)
+        self._loss_accumulator.clear()
 
     @override
     def on_validation_epoch_end(self) -> None:
@@ -650,6 +651,7 @@ class LuxonisLightningModule(pl.LightningModule):
         )
 
         self._n_logged_images = 0
+        self._loss_accumulator.clear()
 
     @rank_zero_only
     def _print_results(

--- a/tests/unittests/test_callbacks/test_ema.py
+++ b/tests/unittests/test_callbacks/test_ema.py
@@ -1,9 +1,11 @@
+import shutil
 from copy import deepcopy
 
 import lightning.pytorch as pl
 import pytest
 import torch
 from lightning.pytorch import LightningModule, Trainer
+from lightning.pytorch.callbacks import ModelCheckpoint
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -22,6 +24,12 @@ class DummyModel(pl.LightningModule):
         x, y = batch
         loss = nn.MSELoss()(self(x), y)
         return loss
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        loss = nn.MSELoss()(self(x), y)
+        self.log("val_loss", loss, prog_bar=True)
+        self.log("val_metric", -loss, prog_bar=True)
 
     def configure_optimizers(self):
         return torch.optim.SGD(self.parameters(), lr=0.1)
@@ -108,17 +116,26 @@ def test_validation_epoch_start_and_end(
     trainer = Trainer()
     ema_callback.on_fit_start(trainer, model)
 
+    # Slightly modify the EMA state dict to simulate a different state
+    for param_key in ema_callback.ema.state_dict_ema:
+        ema_callback.ema.state_dict_ema[param_key] += 0.1 * torch.randn_like(
+            ema_callback.ema.state_dict_ema[param_key]
+        )
+
     ema_callback.on_validation_epoch_start(trainer, model)
     assert ema_callback.collected_state_dict is not None
 
+    collected_state = model.state_dict()
     ema_callback.on_validation_end(trainer, model)
-    for k in ema_callback.collected_state_dict:
-        assert torch.equal(
-            ema_callback.collected_state_dict[k], model.state_dict()[k]
-        )
+
+    diffs = sum(
+        not torch.equal(collected_state[p], ema_callback.ema.state_dict_ema[p])
+        for p in collected_state
+    )
+    assert diffs > 0, "Parameters did not swap after on_validation_end!"
 
 
-def test_ema_swapping_across_epochs(
+def test_ema_swapping_across_training(
     model: LightningModule, ema_callback: EMACallback
 ):
     class PreCheckCallback(pl.Callback):
@@ -150,30 +167,31 @@ def test_ema_swapping_across_epochs(
         It should revert to training weights on training epoch start.
         """
 
+        def on_train_epoch_start(self, trainer, pl_module):
+            original_weights = pl_module.training_weights_on_train_epoch_start
+            diffs = sum(
+                not torch.equal(pl_module.state_dict()[k], original_weights[k])
+                for k in pl_module.state_dict()
+            )
+            assert diffs == 0, "Parameters changed after on_train_epoch_start!"
+
         def on_validation_epoch_start(self, trainer, pl_module):
             original_weights = pl_module.training_weights_on_val_start
-            for k, v in pl_module.state_dict().items():
-                # Should not match training weights because EMA has been swapped in
-                assert not torch.equal(v, original_weights[k]), (
-                    f"Param {k} still matches original weights - no EMA swap!"
-                )
+            diffs = sum(
+                not torch.equal(pl_module.state_dict()[k], original_weights[k])
+                for k in pl_module.state_dict()
+            )
+            assert diffs > 0, (
+                "Parameters did not swap after on_validation_epoch_start!"
+            )
 
         def on_save_checkpoint(self, trainer, pl_module, checkpoint):
-            # checkpoint["state_dict"] is the EMA weights
-            original_weights_ckpt = pl_module.training_weights_on_save_ckpt
-            for k, v in checkpoint["state_dict"].items():
-                # Should differ from the training weights we captured
-                assert not torch.equal(v, original_weights_ckpt[k]), (
-                    f"Checkpoint param {k} matches original weights - no EMA in checkpoint!"
-                )
-
-        def on_train_epoch_start(self, trainer, pl_module):
-            # Should be using original weights
-            original_weights = pl_module.training_weights_on_train_epoch_start
-            for k, v in pl_module.state_dict().items():
-                assert torch.equal(v, original_weights[k]), (
-                    f"Param {k} doesn't match original weights - EMA not swapped out!, epoch {trainer.current_epoch}"
-                )
+            original_weights = pl_module.training_weights_on_save_ckpt
+            diffs = sum(
+                not torch.equal(pl_module.state_dict()[k], original_weights[k])
+                for k in pl_module.state_dict()
+            )
+            assert diffs == 0, "Parameters changed after on_save_checkpoint!"
 
     x_train = torch.randn(50, 2)
     y_train = torch.randn(50, 2)
@@ -186,16 +204,37 @@ def test_ema_swapping_across_epochs(
     pre_callback = PreCheckCallback()
     post_callback = PostCheckCallback()
 
+    # Simulate luxonis-train 2 ModelCheckpoint callbacks
+    checkpoint_min = ModelCheckpoint(
+        monitor="val_loss",
+        mode="min",
+        filename="min-loss",
+        save_top_k=1,
+    )
+    checkpoint_best = ModelCheckpoint(
+        monitor="val_metric",
+        mode="max",
+        filename="best-metric",
+        save_top_k=1,
+    )
+
     trainer = Trainer(
-        max_epochs=3,
+        max_epochs=4,
+        check_val_every_n_epoch=2,
         callbacks=[
             pre_callback,
             ema_callback,
             post_callback,
-        ],  # The order matters: pre -> EMA -> post
+            checkpoint_min,
+            checkpoint_best,
+        ],
         limit_val_batches=1,
+        num_sanity_val_steps=0,
+        default_root_dir="test_ema_swapping_logs",
     )
 
     trainer.fit(
         model, train_dataloaders=train_loader, val_dataloaders=val_loader
     )
+
+    shutil.rmtree("test_ema_swapping_logs", ignore_errors=True)

--- a/tests/unittests/test_strategies/test_triple_lr_sgd.py
+++ b/tests/unittests/test_strategies/test_triple_lr_sgd.py
@@ -1,0 +1,70 @@
+import pytorch_lightning as pl
+import torch
+
+from luxonis_train.strategies.triple_lr_sgd import TripleLRSGDStrategy
+
+
+def test_triple_lr_sgd():
+    class DummyModel(pl.LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.core = type("", (), {"loaders": {"train": range(10)}})()
+            self.cfg = type(
+                "",
+                (),
+                {"trainer": type("", (), {"batch_size": 1, "epochs": 50})()},
+            )()
+            self.linear = torch.nn.Linear(2, 1)
+            self.lr_list = [[], [], []]
+
+        def forward(self, x):
+            return self.linear(x)
+
+        def training_step(self, batch, batch_idx):
+            x = batch
+            y = self.forward(x)
+            loss = torch.nn.functional.mse_loss(y, torch.zeros_like(y))
+            return loss
+
+        def configure_optimizers(self):
+            self.strategy = TripleLRSGDStrategy(model)
+            return self.strategy.configure_optimizers()
+
+        def on_before_optimizer_step(self, optimizer):
+            for i, param_group in enumerate(optimizer.param_groups):
+                self.lr_list[i].append(param_group["lr"])
+
+        def on_after_backward(self):
+            self.strategy.update_parameters()
+
+    model = DummyModel()
+
+    dataset = torch.randn(model.core.loaders["train"].__len__(), 2)
+    dataloader = torch.utils.data.DataLoader(dataset, batch_size=1)
+    trainer = pl.Trainer(max_epochs=model.cfg.trainer.epochs)
+    trainer.fit(model, dataloader)
+
+    cases = [
+        (0, 0, 0.0, None),
+        (1, 0, 0.0, None),
+        (2, 0, 0.1, None),
+        (0, 100, 0.018, 3e-4),
+        (1, 100, 0.018, 3e-4),
+        (2, 100, 0.018, 3e-4),
+        (0, -1, 0.0002, 5e-5),
+        (1, -1, 0.0002, 5e-5),
+        (2, -1, 0.0002, 5e-5),
+        (0, 50, 0.0098, 1e-4),
+        (1, 50, 0.0098, 1e-4),
+        (2, 50, 0.0597, 1e-4),
+        (0, 150, 0.0159, 3e-4),
+        (1, 150, 0.0159, 3e-4),
+        (2, 150, 0.0159, 3e-4),
+    ]
+
+    for group_idx, step, expected, tol in cases:
+        value = model.lr_list[group_idx][step]
+        if tol is None:
+            assert value == expected
+        else:
+            assert abs(value - expected) < tol


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

This PR fixes the following issues:

- **Archive Command on Windows:**
  - Resolved issues with the archive command failing on Windows.

- **Accumulator Loss Reset:**
  - Fixed a bug where the accumulator was not being reset properly.
  - Previously, the train accumulator was used for validation and testing, leading to incorrect loss values being logged, appearing identical to the train values.

- **`current_epoch` for Nodes:**
  - Corrected an issue where `current_epoch` was always set to `0` for nodes.

- **Bug in EMA (Exponential Moving Average):**
  - Fixed improper loading of weights in EMA.
  - This issue caused incorrect training behavior and resulted in slower training performance.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->

This PR fixes the EMA tests and adds a unit test for the training strategy.