### PR TITLE
Fix for registering predefined models in Config

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -233,7 +233,6 @@ Here you can change everything related to actual training of the model.
 | `strategy`                | `Literal["auto", "ddp"]`                       | `"auto"`      | What strategy to use for training                                                                                                                |
 | `n_sanity_val_steps`      | `int`                                          | `2`           | Number of sanity validation steps performed before training                                                                                      |
 | `profiler`                | `Literal["simple", "advanced"] \| None`        | `None`        | PL profiler for GPU/CPU/RAM utilization analysis                                                                                                 |
-| `verbose`                 | `bool`                                         | `True`        | Print all intermediate results to console                                                                                                        |
 | `pin_memory`              | `bool`                                         | `True`        | Whether to pin memory in the `DataLoader`                                                                                                        |
 | `save_top_k`              | `-1 \| NonNegativeInt`                         | `3`           | Save top K checkpoints based on validation loss when training                                                                                    |
 | `n_validation_batches`    | `PositiveInt \| None`                          | `None`        | Limits the number of validation/test batches and makes the val/test loaders deterministic                                                        |
@@ -346,7 +345,6 @@ trainer:
         patience: 3
         monitor: "val/loss"
         mode: "min"
-        verbose: true
     - name: "ExportOnTrainEnd"
     - name: "TestOnTrainEnd"
 ```

--- a/luxonis_train/config/__init__.py
+++ b/luxonis_train/config/__init__.py
@@ -7,6 +7,7 @@ from .config import (
     NodeConfig,
     TrainerConfig,
 )
+from .predefined_models import *  # so predefined models get registered
 
 __all__ = [
     "AttachedModuleConfig",

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -440,6 +440,14 @@ class TrainerConfig(BaseModelExtraForbid):
 
     training_strategy: ConfigItem | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def deprecate_params(cls, data: Params) -> Params:
+        if "verbose" in data:
+            logger.warning("`trainer.verbose` is deprecated and won't be used")
+            data.pop("verbose")
+        return data
+
     @model_validator(mode="after")
     def validate_scheduler(self) -> Self:
         if self.scheduler.name == "CosineAnnealingLR":

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -440,14 +440,6 @@ class TrainerConfig(BaseModelExtraForbid):
 
     training_strategy: ConfigItem | None = None
 
-    @model_validator(mode="before")
-    @classmethod
-    def deprecate_params(cls, data: Params) -> Params:
-        if "verbose" in data:
-            logger.warning("`trainer.verbose` is deprecated and won't be used")
-            data.pop("verbose")
-        return data
-
     @model_validator(mode="after")
     def validate_scheduler(self) -> Self:
         if self.scheduler.name == "CosineAnnealingLR":


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Fixed loading predefined models into the Config
- Added `trainer.verbose` back with a deprecated warning

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable