### PR TITLE
Fix Export Save Path

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,9 +35,6 @@ jobs:
     - name: Install latest luxonis-ml
       run: pip install luxonis-ml[all]@git+https://github.com/luxonis/luxonis-ml.git@main --upgrade --force-reinstall
 
-    - name: Force correct torchmetrics version
-      run: pip install --force-reinstall torchmetrics==1.16.3
-
     - name: Authenticate to Google Cloud
       id: google-auth
       uses: google-github-actions/auth@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,9 @@ jobs:
     - name: Install latest luxonis-ml
       run: pip install luxonis-ml[all]@git+https://github.com/luxonis/luxonis-ml.git@main --upgrade --force-reinstall
 
+    - name: Force correct torchmetrics version
+      run: pip install --force-reinstall torchmetrics==1.16.3
+
     - name: Authenticate to Google Cloud
       id: google-auth
       uses: google-github-actions/auth@v2

--- a/configs/README.md
+++ b/configs/README.md
@@ -212,32 +212,37 @@ loader:
 
 Here you can change everything related to actual training of the model.
 
-| Key                       | Type                                           | Default value | Description                                                                                                                                      |
-| ------------------------- | ---------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `seed`                    | `int`                                          | `None`        | Seed for reproducibility                                                                                                                         |
-| `deterministic`           | `bool \| "warn" \| None`                       | `None`        | Whether PyTorch should use deterministic backend                                                                                                 |
-| `batch_size`              | `int`                                          | `32`          | Batch size used for training                                                                                                                     |
-| `accumulate_grad_batches` | `int`                                          | `1`           | Number of batches for gradient accumulation                                                                                                      |
-| `precision`               | `Literal["16-mixed", "32"]`                    | `32`          | Controls training precision. `"16-mixed"` can **significantly speed up training** on supported GPUs.                                             |
-| `gradient_clip_val`       | `NonNegativeFloat \| None`                     | `None`        | Value for gradient clipping. If `None`, gradient clipping is disabled. Clipping can help prevent exploding gradients.                            |
-| `gradient_clip_algorithm` | `Literal["norm", "value"] \| None`             | `None`        | Algorithm to use for gradient clipping. Options are `"norm"` (clip by norm) or `"value"` (clip element-wise).                                    |
-| `use_weighted_sampler`    | `bool`                                         | `False`       | Whether to use `WeightedRandomSampler` for training, only works with classification tasks                                                        |
-| `epochs`                  | `int`                                          | `100`         | Number of training epochs                                                                                                                        |
-| `n_workers`               | `int`                                          | `4`           | Number of workers for data loading                                                                                                               |
-| `validation_interval`     | `int`                                          | `5`           | Frequency at which metrics and visualizations are computed on validation data                                                                    |
-| `n_log_images`            | `int`                                          | `4`           | Maximum number of images to visualize and log                                                                                                    |
-| `skip_last_batch`         | `bool`                                         | `True`        | Whether to skip last batch while training                                                                                                        |
-| `accelerator`             | `Literal["auto", "cpu", "gpu"]`                | `"auto"`      | What accelerator to use for training                                                                                                             |
-| `devices`                 | `int \| list[int] \| str`                      | `"auto"`      | Either specify how many devices to use (int), list specific devices, or use "auto" for automatic configuration based on the selected accelerator |
-| `matmul_precision`        | `Literal["medium", "high", "highest"] \| None` | `None`        | Sets the internal precision of float32 matrix multiplications                                                                                    |
-| `strategy`                | `Literal["auto", "ddp"]`                       | `"auto"`      | What strategy to use for training                                                                                                                |
-| `n_sanity_val_steps`      | `int`                                          | `2`           | Number of sanity validation steps performed before training                                                                                      |
-| `profiler`                | `Literal["simple", "advanced"] \| None`        | `None`        | PL profiler for GPU/CPU/RAM utilization analysis                                                                                                 |
-| `pin_memory`              | `bool`                                         | `True`        | Whether to pin memory in the `DataLoader`                                                                                                        |
-| `save_top_k`              | `-1 \| NonNegativeInt`                         | `3`           | Save top K checkpoints based on validation loss when training                                                                                    |
-| `n_validation_batches`    | `PositiveInt \| None`                          | `None`        | Limits the number of validation/test batches and makes the val/test loaders deterministic                                                        |
-| `smart_cfg_auto_populate` | `bool`                                         | `True`        | Automatically populate sensible default values for missing config fields and log warnings. See [Trainer Tips](#trainer-tips) for more details    |
-| `resume_training`         | `bool`                                         | `False`       | Whether to resume training from a checkpoint. See [Trainer Tips](#trainer-tips) for more details                                                 |
+| Key                       | Type                                           | Default value                          | Description                                                                                                                                      |
+| ------------------------- | ---------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `seed`                    | `int`                                          | `None`                                 | Seed for reproducibility                                                                                                                         |
+| `deterministic`           | `bool \| "warn" \| None`                       | `None`                                 | Whether PyTorch should use deterministic backend                                                                                                 |
+| `batch_size`              | `int`                                          | `32`                                   | Batch size used for training                                                                                                                     |
+| `accumulate_grad_batches` | `int`                                          | `1`                                    | Number of batches for gradient accumulation                                                                                                      |
+| `precision`               | `Literal["16-mixed", "32"]`                    | `32`                                   | Controls training precision. `"16-mixed"` can **significantly speed up training** on supported GPUs.                                             |
+| `gradient_clip_val`       | `NonNegativeFloat \| None`                     | `None`                                 | Value for gradient clipping. If `None`, gradient clipping is disabled. Clipping can help prevent exploding gradients.                            |
+| `gradient_clip_algorithm` | `Literal["norm", "value"] \| None`             | `None`                                 | Algorithm to use for gradient clipping. Options are `"norm"` (clip by norm) or `"value"` (clip element-wise).                                    |
+| `use_weighted_sampler`    | `bool`                                         | `False`                                | Whether to use `WeightedRandomSampler` for training, only works with classification tasks                                                        |
+| `epochs`                  | `int`                                          | `100`                                  | Number of training epochs                                                                                                                        |
+| `n_workers`               | `int`                                          | `4`                                    | Number of workers for data loading                                                                                                               |
+| `validation_interval`     | `int`                                          | `5`                                    | Frequency at which metrics and visualizations are computed on validation data                                                                    |
+| `n_log_images`            | `int`                                          | `4`                                    | Maximum number of images to visualize and log                                                                                                    |
+| `skip_last_batch`         | `bool`                                         | `True`                                 | Whether to skip last batch while training                                                                                                        |
+| `accelerator`             | `Literal["auto", "cpu", "gpu"]`                | `"auto"`                               | What accelerator to use for training                                                                                                             |
+| `devices`                 | `int \| list[int] \| str`                      | `"auto"`                               | Either specify how many devices to use (int), list specific devices, or use "auto" for automatic configuration based on the selected accelerator |
+| `matmul_precision`        | `Literal["medium", "high", "highest"] \| None` | `None`                                 | Sets the internal precision of float32 matrix multiplications                                                                                    |
+| `strategy`                | `Literal["auto", "ddp"]`                       | `"auto"`                               | What strategy to use for training                                                                                                                |
+| `n_sanity_val_steps`      | `int`                                          | `2`                                    | Number of sanity validation steps performed before training                                                                                      |
+| `profiler`                | `Literal["simple", "advanced"] \| None`        | `None`                                 | PL profiler for GPU/CPU/RAM utilization analysis                                                                                                 |
+| `pin_memory`              | `bool`                                         | `True`                                 | Whether to pin memory in the `DataLoader`                                                                                                        |
+| `save_top_k`              | `-1 \| NonNegativeInt`                         | `3`                                    | Save top K checkpoints based on validation loss when training                                                                                    |
+| `n_validation_batches`    | `PositiveInt \| None`                          | `None`                                 | Limits the number of validation/test batches and makes the val/test loaders deterministic                                                        |
+| `smart_cfg_auto_populate` | `bool`                                         | `True`                                 | Automatically populate sensible default values for missing config fields and log warnings. See [Trainer Tips](#trainer-tips) for more details    |
+| `resume_training`         | `bool`                                         | `False`                                | Whether to resume training from a checkpoint. See [Trainer Tips](#trainer-tips) for more details                                                 |
+| `preprocessing`           | `dict`                                         | `{}`                                   | Configuration for image preprocessing and augmentations. [See preprocessing](#preprocessing) for more details                                    |
+| `callbacks`               | `list`                                         | `[]`                                   | List of callback configurations to use during training. See [Callbacks](#callbacks) section for details and examples                             |
+| `optimizer`               | `dict`                                         | `{"name": "Adam", "params": {}}`       | What optimizer to use for training. See [Optimizer](#optimizer) section for details and examples                                                 |
+| `scheduler`               | `dict`                                         | `{"name": "ConstantLR", "params": {}}` | What scheduler to use for training. See [Scheduler](#scheduler) section for details and examples                                                 |
+| `training_strategy`       | `dict`                                         | `{}`                                   | Defines the training strategy to be used. See [Training Strategy](#training-strategy) section for details and examples                           |
 
 ```yaml
 
@@ -397,10 +402,10 @@ trainer:
 Defines the training strategy to be used.
 More information on training strategies and a list of available ones can be found [here](../luxonis_train/strategies/README.md).
 
-| Key      | Type   | Default value           | Description                   |
-| -------- | ------ | ----------------------- | ----------------------------- |
-| `name`   | `str`  | `"TripleLRSGDStrategy"` | Name of the training strategy |
-| `params` | `dict` | `{}`                    | Parameters of the optimizer   |
+| Key      | Type   | Default value | Description                   |
+| -------- | ------ | ------------- | ----------------------------- |
+| `name`   | `str`  | -             | Name of the training strategy |
+| `params` | `dict` | `{}`          | Parameters of the optimizer   |
 
 **Example:**
 
@@ -486,6 +491,8 @@ Here you can define configuration for exporting.
 | `upload_to_run`          | `bool`                            | `True`        | Whether to upload the exported files to tracked run as artifact                                |
 | `upload_url`             | `str \| None`                     | `None`        | Exported model will be uploaded to this URL if specified                                       |
 | `output_names`           | `list[str] \| None`               | `None`        | Optional list of output names to override the default ones (deprecated)                        |
+| `onnx`                   | `dict`                            | `{}`          | Options specific for ONNX export. See [ONNX](#onnx) section for details                        |
+| `blobconverter`          | `dict`                            | `{}`          | Options for converting to BLOB format. See [Blob](#blob) section for details                   |
 
 ### `ONNX`
 
@@ -496,7 +503,7 @@ Option specific for `ONNX` export.
 | `opset_version` | `int`                    | `12`          | Which `ONNX` opset version to use |
 | `dynamic_axes`  | `dict[str, Any] \| None` | `None`        | Whether to specify dynamic axes   |
 
-### Blob
+### `Blob`
 
 | Key       | Type                                                             | Default value | Description                              |
 | --------- | ---------------------------------------------------------------- | ------------- | ---------------------------------------- |

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -206,7 +206,7 @@ def export(
     @param config: Path to the configuration file or a name of a
         predefined model.
     @type save_path: str
-    @param save_path: Path to save the exported model.
+    @param save_path: Path (absolute or relative, e.g., `model.onnx` or `/path/to/model.onnx`) to save the exported ONNX model. Must end with `.onnx`.
     @type weights: str
     @param weights: Path to the model weights.
     @type opts: list[str]

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -206,15 +206,15 @@ def export(
     @param config: Path to the configuration file or a name of a
         predefined model.
     @type save_path: str
-    @param save_path: Path (absolute or relative, e.g., `model.onnx` or `/path/to/model.onnx`) to save the exported ONNX model. Must end with `.onnx`.
+    @param save_path: Directory where to save all exported model files.
+        If not specified, files will be saved to the 'export' directory
+        in the run save directory.
     @type weights: str
     @param weights: Path to the model weights.
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the
     """
-    create_model(config, opts).export(
-        onnx_save_path=save_path, weights=weights
-    )
+    create_model(config, opts).export(save_path=save_path, weights=weights)
 
 
 @app.command(group=export_group, sort_key=2)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -323,16 +323,16 @@ class LuxonisModel:
 
     def export(
         self,
-        onnx_save_path: PathType | None = None,
+        save_path: PathType | None = None,
         weights: PathType | None = None,
         ignore_missing_weights: bool = False,
     ) -> None:
         """Runs export.
 
-        @type onnx_save_path: PathType | None
-        @param onnx_save_path: Path to where the exported ONNX model will be saved.
-            If not specified, model will be saved to the export directory
-            with the name specified in config file.
+        @type save_path: PathType | None
+        @param save_path: Directory where to save all exported model files.
+        If not specified, files will be saved to the "export" directory
+        in the run save directory.
         @type weights: PathType | None
         @param weights: Path to the checkpoint from which to load weights.
             If not specified, the value of `model.weights` from the
@@ -352,15 +352,17 @@ class LuxonisModel:
                 "No model weights specified. Exporting model without weights."
             )
 
-        export_save_dir = Path(self.run_save_dir, "export")
+        export_save_dir = (
+            Path(save_path)
+            if save_path is not None
+            else Path(self.run_save_dir, "export")
+        )
         export_save_dir.mkdir(parents=True, exist_ok=True)
 
         export_path = export_save_dir / (
             self.cfg.exporter.name or self.cfg.model.name
         )
-        onnx_save_path = str(
-            onnx_save_path or export_path.with_suffix(".onnx")
-        )
+        onnx_save_path = str(export_path.with_suffix(".onnx"))
 
         with replace_weights(self.lightning_module, weights):
             output_names = self.lightning_module.export_onnx(

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ grad-cam>=1.5.4
 pytorch_metric_learning>=2.7.0
 scikit-learn>=1.5.0
 seaborn>=0.13.2
-torchmetrics<=1.16.3
+torchmetrics<=1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ grad-cam>=1.5.4
 pytorch_metric_learning>=2.7.0
 scikit-learn>=1.5.0
 seaborn>=0.13.2
-torchmetrics=<1.16.3
+torchmetrics<=1.16.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ grad-cam>=1.5.4
 pytorch_metric_learning>=2.7.0
 scikit-learn>=1.5.0
 seaborn>=0.13.2
+torchmetrics=<1.16.3

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -15,7 +15,7 @@ from luxonis_train.__main__ import (
 )
 from luxonis_train.__main__ import test as _test
 
-ONNX_PATH = Path("tests/integration/model.onnx")
+ONNX_PATH = Path("tests/integration/client_commands_test_model.onnx")
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -40,7 +40,7 @@ def prepare():
             export,
             {
                 "config": "tests/configs/config_simple.yaml",
-                "save_path": ONNX_PATH,
+                "save_path": ONNX_PATH.parent,
             },
         ),
         (

--- a/tests/integration/test_remove_on_export.py
+++ b/tests/integration/test_remove_on_export.py
@@ -7,7 +7,7 @@ from luxonis_ml.typing import Params
 
 from luxonis_train.core import LuxonisModel
 
-ONNX_PATH = Path("tests/integration/_ddrnet_model.onnx")
+ONNX_PATH = Path("tests/integration/ddrnet_segmentation.onnx")
 
 
 @pytest.fixture(autouse=True)
@@ -27,7 +27,7 @@ def test_train_only_heads(coco_dataset: LuxonisDataset):
     name_to_check = "aux_segmentation_head"
     is_in_results = any(name_to_check in key for key in results)
 
-    model.export(str(ONNX_PATH))
+    model.export(str(ONNX_PATH.parent))
 
     sess = rt.InferenceSession(str(ONNX_PATH))
     onnx_output_names = [output.name for output in sess.get_outputs()]

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -17,7 +17,7 @@ from luxonis_train.core import LuxonisModel
 from .multi_input_modules import *
 
 INFER_PATH = Path("tests/integration/infer-save-directory")
-ONNX_PATH = Path("tests/integration/_model.onnx")
+ONNX_PATH = Path("tests/integration/example_multi_input.onnx")
 STUDY_PATH = Path("study_local.db")
 
 
@@ -114,7 +114,7 @@ def test_multi_input(opts: Params, infer_path: Path):
     model.test(view="val")
 
     assert not ONNX_PATH.exists()
-    model.export(str(ONNX_PATH))
+    model.export(str(ONNX_PATH.parent))
     assert ONNX_PATH.exists()
 
     assert len(list(infer_path.iterdir())) == 0


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

- The `exporter_save_path` defines the directory where export files will be saved. If not provided, it defaults to `"exporter"` as before.

- Additionally, some inconsistencies in the documentation were identified and fixed.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable