### PR TITLE
Fix failing docstrings

### DIFF
--- a/luxonis_train/attached_modules/base_attached_module.py
+++ b/luxonis_train/attached_modules/base_attached_module.py
@@ -38,8 +38,6 @@ class BaseAttachedModule(
           Used to determine which labels to extract from the dataset and to validate
           compatibility with the node based on the node's tasks.
 
-    @type node: BaseNode
-    @param node: Reference to the node that this module is attached to.
 
     @type supported_tasks: list[Task] | None
     @ivar supported_tasks: List of task types that the module supports.
@@ -51,6 +49,13 @@ class BaseAttachedModule(
     supported_tasks: Sequence[Task] | None = None
 
     def __init__(self, *, node: BaseNode | None = None, **kwargs):
+        """Constructor for teh C{BaseAttachedModule}
+
+        @type node: BaseNode
+        @param node: Reference to the node that this module is attached
+            to.
+        @param kwargs: Additional keyword arguments.
+        """
         super().__init__(**kwargs)
         self._node = node
 

--- a/luxonis_train/attached_modules/metrics/base_metric.py
+++ b/luxonis_train/attached_modules/metrics/base_metric.py
@@ -49,19 +49,13 @@ class MetricState:
             false_positives: Annotated[Tensor, MetricState(default=0)]
             total: Annotated[Tensor, MetricState(default=0)]
 
-
-    @type name: str
-    @param name: The name of the state variable. The variable will then
+    @keyword name: The name of the state variable. The variable will then
         be accessible at C{self.name}.
-    @type default: Tensor | Number | list
-    @param default: Default value of the state; can either be a
+    @keyword default: Default value of the state; can either be a
         C{Tensor} or an empty list. The state will be reset to this
         value when C{self.reset()} is called. If the default value is a
         float, it will be converted to a C{Tensor}.
-    @type dist_reduce_fx: Literal["sum", "mean", "cat", "min", "max"] |
-        Callable[[Tensor], Tensor] | Callable[[list[Tensor]], Tensor] |
-        | EllipsisType | None
-    @param dist_reduce_fx: Function to reduce state across multiple
+    @keyword dist_reduce_fx: Function to reduce state across multiple
         processes in distributed mode. If value is C{"sum"}, C{"mean"},
         C{"cat"}, C{"min"} or C{"max"} we will use C{torch.sum},
         C{torch.mean}, C{torch.cat}, C{torch.min} and C{torch.max}
@@ -71,8 +65,7 @@ class MetricState:
         parameter.
         If not specified, the default is C{"sum"} if the default value
         is a tensor, and C{"cat"} if the default value is a list.
-    @type persistent: bool
-    @param persistent: whether the state will be saved as part of the
+    @keyword persistent: Whether the state will be saved as part of the
         modules C{state_dict}. Default is C{False}.
     """
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
These two particular docstrings were failing when trying to build html docs. The `kind` attribute of the `Documentable` instance was `None` because the docstring didn't match with what epytext expected for the class.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable