### PR TITLE
Faster Loader

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -122,6 +122,7 @@ class LuxonisModel:
         self.loaders: dict[View, BaseLoaderTorch] = {}
         loader_name = self.cfg.loader.name
         Loader = LOADERS.get(loader_name)
+        model_tasks = sorted({node.task_name for node in self.cfg.model.nodes})
         for view in ("train", "val", "test"):
             if (
                 view != "train"
@@ -142,6 +143,7 @@ class LuxonisModel:
                 augmentation_config=self.cfg_preprocessing.get_active_augmentations(),
                 color_space=self.cfg_preprocessing.color_space,
                 keep_aspect_ratio=self.cfg_preprocessing.keep_aspect_ratio,
+                filter_task_names=model_tasks,
                 **self.cfg.loader.params,  # type: ignore
             )
 

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -122,7 +122,12 @@ class LuxonisModel:
         self.loaders: dict[View, BaseLoaderTorch] = {}
         loader_name = self.cfg.loader.name
         Loader = LOADERS.get(loader_name)
-        model_tasks = sorted({node.task_name for node in self.cfg.model.nodes})
+        if issubclass(Loader, LuxonisLoaderTorch):
+            model_tasks = sorted(
+                {node.task_name for node in self.cfg.model.nodes}
+            )
+            self.cfg.loader.params["filter_task_names"] = model_tasks
+
         for view in ("train", "val", "test"):
             if (
                 view != "train"
@@ -143,7 +148,6 @@ class LuxonisModel:
                 augmentation_config=self.cfg_preprocessing.get_active_augmentations(),
                 color_space=self.cfg_preprocessing.color_space,
                 keep_aspect_ratio=self.cfg_preprocessing.keep_aspect_ratio,
-                filter_task_names=model_tasks,
                 **self.cfg.loader.params,  # type: ignore
             )
 

--- a/luxonis_train/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/loaders/luxonis_loader_torch.py
@@ -25,6 +25,7 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         bucket_storage: Literal["local", "s3", "gcs", "azure"] = "local",
         update_mode: Literal["always", "if_empty"] = "always",
         delete_existing: bool = True,
+        filter_task_names: list[str] | None = None,
         **kwargs,
     ):
         """Torch-compatible loader for Luxonis datasets.
@@ -55,6 +56,12 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         @type bucket_storage: Literal["local", "s3", "gcs", "azure"]
         @param bucket_storage: Type of the bucket storage. Defaults to
             'local'.
+        @type update_mode: Literal["always", "if_empty"]
+        @param update_mode: Update mode for the dataset. Only applicable
+            for remote datasets. If set to 'always', the dataset will be
+            updated every time the loader is created. If set to 'if_empty',
+            the dataset will only be updated if it is empty. Defaults to
+            'always'.
         @type delete_existing: bool
         @param delete_existing: Only relevant when C{dataset_dir} is
             provided. By default, the dataset is parsed again every time
@@ -62,6 +69,11 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
             changed. If C{delete_existing} is set to C{False} and a
             dataset of the same name already exists, the existing
             dataset will be used instead of re-parsing the data.
+        @type filter_task_names: list[str] | None
+        @param filter_task_names: List of task names to filter the
+            dataset by. If provided, only the tasks with the specified
+            names will be loaded. If not provided, all tasks will be
+            loaded.
         """
         super().__init__(**kwargs)
         if dataset_dir is not None:
@@ -91,6 +103,7 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
             keep_aspect_ratio=self.keep_aspect_ratio,
             color_space=self.color_space,
             update_mode=update_mode,
+            filter_task_names=filter_task_names,
         )
 
     @override


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Currently, we load the entire dataset, which is not optimal. Instead, we should only load the data we actually need. To address this, we now filter the tasks (`task_names`) during data loading to avoid unnecessary annotations. This is done by identifying the `task_names` required by the model and using only those.

> **Note:** Please ensure that the [Luxonis-ml PR #300](https://github.com/luxonis/luxonis-ml/pull/300) is merged first, as this change depends on it.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable