### PR TITLE
Align with Luxonis-ML Push/Pull/Clone/Merge

### DIFF
--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -200,7 +200,7 @@ def infer_from_directory(
             yield {"file": img_path}
 
     dataset_name = "infer_from_directory"
-    dataset = LuxonisDataset(dataset_name=dataset_name, delete_existing=True)
+    dataset = LuxonisDataset(dataset_name=dataset_name, delete_local=True)
     dataset.add(generator())
     dataset.make_splits(
         {"train": 0.0, "val": 0.0, "test": 1.0}, replace_old_splits=True

--- a/luxonis_train/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/loaders/luxonis_loader_torch.py
@@ -175,5 +175,5 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
             dataset_name=dataset_name,
             dataset_type=dataset_type,
             save_dir="data",
-            delete_existing=True,
+            delete_local=True,
         ).parse()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,7 +53,7 @@ def parking_lot_dataset() -> LuxonisDataset:
     parser = LuxonisParser(
         url,
         dataset_name="D1_ParkingLot",
-        delete_existing=True,
+        delete_local=True,
         save_dir=WORK_DIR,
     )
     return parser.parse(random_split=True)
@@ -80,7 +80,7 @@ def embedding_dataset() -> LuxonisDataset:
                 },
             }
 
-    dataset = LuxonisDataset("embedding_test", delete_existing=True)
+    dataset = LuxonisDataset("embedding_test", delete_local=True)
     dataset.add(generator())
     dataset.make_splits()
     return dataset
@@ -115,7 +115,7 @@ def toy_ocr_dataset() -> LuxonisDataset:
                 },
             }
 
-    dataset = LuxonisDataset("toy_ocr", delete_existing=True)
+    dataset = LuxonisDataset("toy_ocr", delete_local=True)
     dataset.add(generator())
 
     dataset.make_splits()
@@ -135,14 +135,14 @@ def coco_dataset() -> LuxonisDataset:
         gdown.download(url, str(output_zip), quiet=False)
 
     parser = LuxonisParser(
-        str(output_zip), dataset_name=dataset_name, delete_existing=True
+        str(output_zip), dataset_name=dataset_name, delete_local=True
     )
     return parser.parse(random_split=True)
 
 
 @pytest.fixture(scope="session")
 def cifar10_dataset() -> LuxonisDataset:
-    dataset = LuxonisDataset("cifar10_test", delete_existing=True)
+    dataset = LuxonisDataset("cifar10_test", delete_local=True)
     output_folder = WORK_DIR / "cifar10"
     output_folder.mkdir(parents=True, exist_ok=True)
     cifar10_torch = torchvision.datasets.CIFAR10(
@@ -181,7 +181,7 @@ def cifar10_dataset() -> LuxonisDataset:
 
 @pytest.fixture(scope="session")
 def mnist_dataset() -> LuxonisDataset:
-    dataset = LuxonisDataset("mnist_test", delete_existing=True)
+    dataset = LuxonisDataset("mnist_test", delete_local=True)
     output_folder = WORK_DIR / "mnist"
     output_folder.mkdir(parents=True, exist_ok=True)
     mnist_torch = torchvision.datasets.MNIST(
@@ -279,7 +279,7 @@ def anomaly_detection_dataset() -> LuxonisDataset:
     train_paths = paths_total[:5]
     test_paths = paths_total[5:]
 
-    dataset = LuxonisDataset("dummy_mvtec", delete_existing=True)
+    dataset = LuxonisDataset("dummy_mvtec", delete_local=True)
     dataset.add(dummy_generator(train_paths, test_paths))
     definitions = {
         "train": train_paths,

--- a/tests/integration/test_mlflow_logging.py
+++ b/tests/integration/test_mlflow_logging.py
@@ -137,7 +137,7 @@ def test_mlflow_logging(temp_dir, setup_mlflow, set_env_vars):
                         "annotation": {"class": f"xor_{y_value}"},
                     }
 
-        dataset = LuxonisDataset("xor_dataset", delete_existing=True)
+        dataset = LuxonisDataset("xor_dataset", delete_local=True)
         dataset.add(generator(temp_dir))
         dataset.make_splits((1, 0, 0))
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Align luxonis-train with [luxonis-ml push/pull/clone/merge PR](https://github.com/luxonis/luxonis-ml/pull/298). We should first merge the luxonis-ml changes, and then immediately merge luxonis-train. If we merge luxonis-ml first without updating luxonis-train, only the parsers will not work. Otherwise, everything should function as before.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable