### PR TITLE
Make tests.yaml a reusable workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,12 +5,14 @@ on:
     inputs:
       ml_ref:
         description: 'luxonis-ml version (branch/tag/SHA)'
-        required: true
+        required: false
         default: 'main'
-      train_ref_mode:
-        description: 'Run luxonis-train on "main" or "latest-release"'
+  workflow_call:
+    inputs:
+      ml_ref:
+        description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
-        default: 'main'
+        type: string
 
 permissions:
   pull-requests: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,18 @@
 name: Run tests
 
 on:
- workflow_dispatch:
+  workflow_dispatch:
+    inputs:
+      ml_ref:
+        description: 'luxonis-ml version (branch/tag/SHA)'
+        required: false
+        default: 'main'
+  workflow_call:
+    inputs:
+      ml_ref:
+        description: 'luxonis-ml version (branch/tag/SHA)'
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
@@ -32,8 +43,11 @@ jobs:
     - name: Install dependencies
       run: pip install -e .[dev]
 
-    - name: Install latest luxonis-ml
-      run: pip install luxonis-ml[all]@git+https://github.com/luxonis/luxonis-ml.git@main --upgrade --force-reinstall
+    - name: Install specified luxonis-ml
+      run: |
+        pip uninstall luxonis-ml -y || true
+        pip install "luxonis-ml[all] @ git+https://github.com/luxonis/luxonis-ml.git@${{ inputs.ml_ref || github.event.inputs.ml_ref }}" \
+          --upgrade --force-reinstall
 
     - name: Authenticate to Google Cloud
       id: google-auth

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,14 +5,12 @@ on:
     inputs:
       ml_ref:
         description: 'luxonis-ml version (branch/tag/SHA)'
-        required: false
-        default: 'main'
-  workflow_call:
-    inputs:
-      ml_ref:
-        description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
-        type: string
+        default: 'main'
+      train_ref_mode:
+        description: 'Run luxonis-train on "main" or "latest-release"'
+        required: true
+        default: 'main'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

- **`workflow_dispatch`**: keeps the “Run workflow” button and prompts for `ml_ref` (default `main`).
- **`workflow_call`**: makes the workflow reusable so **luxonis-ml** can invoke it in the BOM test run.



## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable