### PR TITLE
Test Fallback to bf16 on CPU

### DIFF
--- a/luxonis_train/attached_modules/visualizers/classification_visualizer.py
+++ b/luxonis_train/attached_modules/visualizers/classification_visualizer.py
@@ -45,6 +45,7 @@ class ClassificationVisualizer(BaseVisualizer):
     def _generate_plot(
         self, prediction: Tensor, width: int, height: int
     ) -> Tensor:
+        prediction = prediction.to(torch.float32)
         if self.multilabel:
             pred = prediction.sigmoid().detach().cpu().numpy()
         else:

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -463,3 +463,28 @@ def test_weight_loading(coco_dataset: LuxonisDataset):
     model.train()
     weights = model.get_min_loss_checkpoint_path()
     model.test(weights=weights)
+
+
+def test_precision_fallback_to_bf16_on_cpu(coco_dataset: LuxonisDataset):
+    config_files = [
+        "configs/segmentation_light_model.yaml",
+        "configs/detection_light_model.yaml",
+        "configs/keypoint_bbox_light_model.yaml",
+        "configs/instance_segmentation_light_model.yaml",
+    ]
+    opts = {
+        "loader.params.dataset_name": coco_dataset.dataset_name,
+        "trainer.epochs": 1,
+        "trainer.n_validation_batches": 1,
+        "trainer.batch_size": 1,
+        "loader.train_view": "val",
+        "loader.val_view": "val",
+        "loader.test_view": "val",
+        "trainer.precision": "16-mixed",
+        "trainer.accelerator": "cpu",
+        "trainer.callbacks": [],
+    }
+
+    for config_file in config_files:
+        model = LuxonisModel(config_file, opts)
+        model.test()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

`luxonis-ml` BOM tests fail because they use bf16—tensors need to be cast to float32 first.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable