### PR TITLE
Improved logging to the file

### DIFF
--- a/luxonis_train/callbacks/__init__.py
+++ b/luxonis_train/callbacks/__init__.py
@@ -5,7 +5,6 @@ from lightning.pytorch.callbacks import (
     LearningRateMonitor,
     ModelCheckpoint,
     ModelPruning,
-    RichModelSummary,
     StochasticWeightAveraging,
     Timer,
 )
@@ -23,6 +22,7 @@ from .luxonis_progress_bar import (
     LuxonisTQDMProgressBar,
 )
 from .metadata_logger import MetadataLogger
+from .rich_model_summary import LuxonisRichModelSummary
 from .test_on_train_end import TestOnTrainEnd
 from .training_manager import TrainingManager
 from .upload_checkpoint import UploadCheckpoint
@@ -30,7 +30,7 @@ from .upload_checkpoint import UploadCheckpoint
 CALLBACKS.register(module=EarlyStopping)
 CALLBACKS.register(module=LearningRateMonitor)
 CALLBACKS.register(module=ModelCheckpoint)
-CALLBACKS.register(module=RichModelSummary)
+CALLBACKS.register(module=LuxonisRichModelSummary)
 CALLBACKS.register(module=DeviceStatsMonitor)
 CALLBACKS.register(module=GradientAccumulationScheduler)
 CALLBACKS.register(module=StochasticWeightAveraging)
@@ -48,6 +48,7 @@ __all__ = [
     "ExportOnTrainEnd",
     "GPUStatsMonitor",
     "GradCamCallback",
+    "LuxonisRichModelSummary",
     "LuxonisRichProgressBar",
     "LuxonisTQDMProgressBar",
     "MetadataLogger",

--- a/luxonis_train/callbacks/luxonis_progress_bar.py
+++ b/luxonis_train/callbacks/luxonis_progress_bar.py
@@ -52,6 +52,32 @@ class BaseLuxonisProgressBar(ABC, ProgressBar):
         """
         ...
 
+    def on_train_epoch_start(
+        self, trainer: pl.Trainer, pl_module: "lxt.LuxonisLightningModule"
+    ):
+        super().on_train_epoch_start(trainer, pl_module)
+        self._epoch_start_time = time.time()
+
+    def on_train_epoch_end(
+        self, trainer: pl.Trainer, pl_module: "lxt.LuxonisLightningModule"
+    ):
+        super().on_train_epoch_end(trainer, pl_module)
+        # Get duration
+        duration = (
+            time.time() - self._epoch_start_time
+            if self._epoch_start_time
+            else 0.0
+        )
+        # Get last loss
+        metrics = trainer.callback_metrics
+        loss = metrics.get("train/loss")
+        loss_str = f"{loss:.4f}" if loss else "N/A"
+
+        # Log only to file
+        logger.bind(file_only=True).info(
+            f"[Epoch {trainer.current_epoch}/{trainer.max_epochs}] Duration: {duration:.2f}s | Train Loss: {loss_str}"
+        )
+
 
 @CALLBACKS.register()
 class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
@@ -108,28 +134,6 @@ class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
             numalign="right",
         )
         logger.info(f"\n{formatted}")
-
-    def on_train_epoch_start(self, trainer, pl_module):
-        super().on_train_epoch_start(trainer, pl_module)
-        self._epoch_start_time = time.time()
-
-    def on_train_epoch_end(self, trainer, pl_module):
-        super().on_train_epoch_end(trainer, pl_module)
-        # Get duration
-        duration = (
-            time.time() - self._epoch_start_time
-            if self._epoch_start_time
-            else 0.0
-        )
-        # Get last loss
-        metrics = trainer.callback_metrics
-        loss = metrics.get("train/loss")
-        loss_str = f"{loss:.4f}" if loss else "N/A"
-
-        # Log only to file
-        logger.bind(file_only=True).info(
-            f"[Epoch {trainer.current_epoch}/{trainer.max_epochs}] Duration: {duration:.2f}s | Train Loss: {loss_str}"
-        )
 
 
 @CALLBACKS.register()
@@ -215,25 +219,3 @@ class LuxonisRichProgressBar(RichProgressBar, BaseLuxonisProgressBar):
         for name, value in table.items():
             rich_table.add_row(name, f"{value:.5f}")
         console.print(rich_table)
-
-    def on_train_epoch_start(self, trainer, pl_module):
-        super().on_train_epoch_start(trainer, pl_module)
-        self._epoch_start_time = time.time()
-
-    def on_train_epoch_end(self, trainer, pl_module):
-        super().on_train_epoch_end(trainer, pl_module)
-        # Get duration
-        duration = (
-            time.time() - self._epoch_start_time
-            if self._epoch_start_time
-            else 0.0
-        )
-        # Get last loss
-        metrics = trainer.callback_metrics
-        loss = metrics.get("train/loss")
-        loss_str = f"{loss:.4f}" if loss else "N/A"
-
-        # Log only to file
-        logger.bind(file_only=True).info(
-            f"[Epoch {trainer.current_epoch}/{trainer.max_epochs}] Duration: {duration:.2f}s | Train Loss: {loss_str}"
-        )

--- a/luxonis_train/callbacks/rich_model_summary.py
+++ b/luxonis_train/callbacks/rich_model_summary.py
@@ -1,0 +1,97 @@
+from io import StringIO
+from typing import Any
+
+from lightning.pytorch.callbacks import (
+    GradientAccumulationScheduler,
+    ModelCheckpoint,
+    ModelSummary,
+    RichModelSummary,
+)
+from lightning.pytorch.callbacks.progress.rich_progress import _RICH_AVAILABLE
+from lightning.pytorch.utilities.model_summary import get_human_readable_count
+from loguru import logger
+from rich.console import Console
+from typing_extensions import override
+
+
+class LuxonisRichModelSummary(RichModelSummary):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self._log_buffer = StringIO()
+        self._log_console = Console(
+            file=self._log_buffer, force_terminal=False
+        )
+
+    @override
+    def summarize(
+        self,
+        summary_data: list[tuple[str, list[str]]],
+        total_parameters: int,
+        trainable_parameters: int,
+        model_size: float,
+        total_training_modes: dict[str, int],
+        **summarize_kwargs: Any,
+    ) -> None:
+        from rich import get_console
+        from rich.table import Table
+
+        console = get_console()
+
+        header_style: str = summarize_kwargs.get(
+            "header_style", "bold magenta"
+        )
+        table = Table(header_style=header_style)
+        table.add_column(" ", style="dim")
+        table.add_column("Name", justify="left", no_wrap=True)
+        table.add_column("Type")
+        table.add_column("Params", justify="right")
+        table.add_column("Mode")
+
+        column_names = list(zip(*summary_data))[0]
+
+        for column_name in ["In sizes", "Out sizes"]:
+            if column_name in column_names:
+                table.add_column(column_name, justify="right", style="white")
+
+        rows = list(zip(*(arr[1] for arr in summary_data)))
+        for row in rows:
+            table.add_row(*row)
+
+        console.print(table)
+        self._log_console.print(table)
+
+        parameters = []
+        for param in [
+            trainable_parameters,
+            total_parameters - trainable_parameters,
+            total_parameters,
+            model_size,
+        ]:
+            parameters.append(
+                "{:<{}}".format(get_human_readable_count(int(param)), 10)
+            )
+
+        grid = Table.grid(expand=True)
+        grid.add_column()
+        grid.add_column()
+
+        grid.add_row(f"[bold]Trainable params[/]: {parameters[0]}")
+        grid.add_row(f"[bold]Non-trainable params[/]: {parameters[1]}")
+        grid.add_row(f"[bold]Total params[/]: {parameters[2]}")
+        grid.add_row(
+            f"[bold]Total estimated model params size (MB)[/]: {parameters[3]}"
+        )
+        grid.add_row(
+            f"[bold]Modules in train mode[/]: {total_training_modes['train']}"
+        )
+        grid.add_row(
+            f"[bold]Modules in eval mode[/]: {total_training_modes['eval']}"
+        )
+
+        console.print(grid)
+        self._log_console.print(grid)
+
+        logger.bind(file_only=True).info("\n" + self._log_buffer.getvalue())
+        self._log_buffer.seek(0)
+        self._log_buffer.truncate(0)

--- a/luxonis_train/callbacks/rich_model_summary.py
+++ b/luxonis_train/callbacks/rich_model_summary.py
@@ -1,13 +1,7 @@
 from io import StringIO
 from typing import Any
 
-from lightning.pytorch.callbacks import (
-    GradientAccumulationScheduler,
-    ModelCheckpoint,
-    ModelSummary,
-    RichModelSummary,
-)
-from lightning.pytorch.callbacks.progress.rich_progress import _RICH_AVAILABLE
+from lightning.pytorch.callbacks import RichModelSummary
 from lightning.pytorch.utilities.model_summary import get_human_readable_count
 from loguru import logger
 from rich.console import Console

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -8,7 +8,6 @@ import torch
 from lightning.pytorch.callbacks import (
     GradientAccumulationScheduler,
     ModelCheckpoint,
-    RichModelSummary,
 )
 from loguru import logger
 from luxonis_ml.typing import ConfigItem, Kwargs, check_type
@@ -23,7 +22,7 @@ from torch.optim.lr_scheduler import (
 from torch.optim.optimizer import Optimizer
 
 from luxonis_train.attached_modules import BaseLoss, BaseMetric, BaseVisualizer
-from luxonis_train.callbacks import TrainingManager
+from luxonis_train.callbacks import LuxonisRichModelSummary, TrainingManager
 from luxonis_train.config import AttachedModuleConfig, Config
 from luxonis_train.nodes import BaseHead, BaseNode
 from luxonis_train.registry import (
@@ -342,7 +341,7 @@ def build_callbacks(
 
     callbacks: list[pl.Callback] = [
         TrainingManager(),
-        RichModelSummary(max_depth=2),
+        LuxonisRichModelSummary(max_depth=2),
         ModelCheckpoint(
             dirpath=save_dir / "min_val_loss",
             filename=f"{model_name}_loss={{val/loss:.4f}}_{{epoch:02d}}",


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Improved logging to the .log file by adding also metric table and information about the epochs which was previously only logged to the terminal.
Example from the log file:
```
025-06-18 00:36:02 [INFO] [Epoch 2/300] Duration: 0.45s | Train Loss: 27.5373
2025-06-18 00:36:03 [INFO] [Epoch 3/300] Duration: 0.45s | Train Loss: 27.2386
2025-06-18 00:36:03 [INFO] [Epoch 4/300] Duration: 0.46s | Train Loss: 27.2374
2025-06-18 00:36:03 [INFO] [Epoch 5/300] Duration: 0.43s | Train Loss: 27.2605
2025-06-18 00:36:04 [INFO] [Epoch 6/300] Duration: 0.47s | Train Loss: 25.8136
2025-06-18 00:36:04 [INFO] [Epoch 7/300] Duration: 0.45s | Train Loss: 25.4809
2025-06-18 00:36:05 [INFO] [Epoch 8/300] Duration: 0.45s | Train Loss: 24.4299
2025-06-18 00:36:06 [INFO] Validation loss: 22.1112
2025-06-18 00:36:06 [INFO] 
──────────────────────────────────────────────────────────────────────── Validation ─────────────────────────────────────────────────────────────────────────
Loss: 22.111196517944336
Metrics:
         EfficientBBoxHead         
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Name                 ┃ Value    ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ MeanAveragePrecision │ 0.00000  │
│ map_50               │ 0.00000  │
│ map_75               │ 0.00000  │
│ map_small            │ -1.00000 │
│ map_medium           │ 0.00000  │
│ map_large            │ 0.00000  │
│ mar_1                │ 0.00000  │
│ mar_10               │ 0.00000  │
│ mar_100              │ 0.00000  │
│ mar_small            │ -1.00000 │
│ mar_medium           │ 0.00000  │
│ mar_large            │ 0.00000  │
│ f1_small             │ -1.00000 │
│ f1_medium            │ nan      │
│ f1_large             │ nan      │
│ mcc                  │ 0.00000  │
└──────────────────────┴──────────┘
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```

**NOTE**: Right now there is duplicated code for `on_train_epoch_start` and `on_train_epoch_end` under both progress bar callback implementations. If you have an idea how to merge this let me know/feel free to implement.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable
Relies on https://github.com/luxonis/luxonis-ml/pull/335 PR on LuxonisML

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable