### PR TITLE
Fix mAP per class metrics processing

### DIFF
--- a/luxonis_train/attached_modules/metrics/mean_average_precision/utils.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision/utils.py
@@ -41,10 +41,9 @@ def process_class_metrics(
     for metric_name in per_class_metrics:
         metric = metrics.pop(metric_name)
 
-        if metric.ndim > 1:
-            for i, class_id in enumerate(classes):
-                class_name = class_names[int(class_id)].replace(" ", "_")
-                metrics[f"{metric_name}_{class_name}"] = metric[i]
+        for i, class_id in enumerate(classes):
+            class_name = class_names[int(class_id)].replace(" ", "_")
+            metrics[f"{metric_name}_{class_name}"] = metric[i]
 
     return metrics
 

--- a/luxonis_train/attached_modules/metrics/mean_average_precision/utils.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision/utils.py
@@ -41,9 +41,10 @@ def process_class_metrics(
     for metric_name in per_class_metrics:
         metric = metrics.pop(metric_name)
 
-        for i, class_id in enumerate(classes):
-            class_name = class_names[int(class_id)].replace(" ", "_")
-            metrics[f"{metric_name}_{class_name}"] = metric[i]
+        if metric.shape[0] > 1:
+            for i, class_id in enumerate(classes):
+                class_name = class_names[int(class_id)].replace(" ", "_")
+                metrics[f"{metric_name}_{class_name}"] = metric[i]
 
     return metrics
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Remove `metric.ndim > 1` check which prevents saving of per-class metrics.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable