### PR TITLE
Fix Saving Config

### DIFF
--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -340,7 +340,7 @@ class LoaderConfig(ConfigItem):
                 f"Dataset type '{dataset_type}' not supported."
                 f"Supported types are: {', '.join(DatasetType.__members__)}."
             )
-        self.params["dataset_type"] = DatasetType(dataset_type.lower())
+        self.params["dataset_type"] = dataset_type.lower()
         return self
 
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Fixed issue where config saving failed due to `dataset_type` being stored as an enum in the loader config.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable