### PR TITLE
Fix/export config

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -432,7 +432,7 @@ class LuxonisModel:
 
         inputs = []
         outputs = []
-        inputs_dict = get_inputs(path)
+        inputs_dict = get_inputs(self._exported_models["onnx"])
         for input_name, metadata in inputs_dict.items():
             inputs.append(
                 {
@@ -441,7 +441,7 @@ class LuxonisModel:
                 }
             )
 
-        outputs_dict = get_outputs(path)
+        outputs_dict = get_outputs(self._exported_models["onnx"])
         for output_name, metadata in outputs_dict.items():
             outputs.append(
                 {

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -378,7 +378,7 @@ class LuxonisModel:
         try_onnx_simplify(onnx_save_path)
         self._exported_models["onnx"] = Path(onnx_save_path)
 
-        scale, mean, color_space = get_preprocessing(
+        mean, scale, color_space = get_preprocessing(
             self.cfg_preprocessing, "Model export"
         )
         scale_values = self.cfg.exporter.scale_values or scale

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -36,6 +36,11 @@ from luxonis_train.utils import (
     setup_logging,
 )
 
+from .utils.archive_utils import (
+    get_head_configs,
+    get_inputs,
+    get_outputs,
+)
 from .utils.export_utils import (
     blobconverter_export,
     get_preprocessing,
@@ -412,6 +417,12 @@ class LuxonisModel:
                     "Ensure `blobconverter` is installed in your environment."
                 )
 
+        for path in self._exported_models.values():
+            if self.cfg.exporter.upload_to_run:
+                self.tracker.upload_artifact(path, typ="export")
+            if self.cfg.exporter.upload_url is not None:  # pragma: no cover
+                LuxonisFileSystem.upload(path, self.cfg.exporter.upload_url)
+
         if len(self.input_shapes) > 1:
             logger.error(
                 "Generating modelconverter config for a model "
@@ -419,20 +430,33 @@ class LuxonisModel:
             )
             return
 
+        inputs = []
+        outputs = []
+        inputs_dict = get_inputs(path)
+        for input_name, metadata in inputs_dict.items():
+            inputs.append(
+                {
+                    "name": input_name,
+                    "shape": metadata["shape"],
+                }
+            )
+
+        outputs_dict = get_outputs(path)
+        for output_name, metadata in outputs_dict.items():
+            outputs.append(
+                {
+                    "name": output_name,
+                    "shape": metadata["shape"],
+                }
+            )
         modelconverter_config = {
             "input_model": onnx_save_path,
             "scale_values": scale_values,
             "mean_values": mean_values,
-            "reverse_input_channels": reverse_input_channels,
-            "shape": [1, *next(iter(self.input_shapes.values()))],
-            "outputs": [{"name": name} for name in output_names],
+            "encoding": {"from": color_space, "to": "BGR"},
+            "inputs": inputs,
+            "outputs": outputs,
         }
-
-        for path in self._exported_models.values():
-            if self.cfg.exporter.upload_to_run:
-                self.tracker.upload_artifact(path, typ="export")
-            if self.cfg.exporter.upload_url is not None:  # pragma: no cover
-                LuxonisFileSystem.upload(path, self.cfg.exporter.upload_url)
 
         with open(export_path.with_suffix(".yaml"), "w") as f:
             yaml.safe_dump(modelconverter_config, f)
@@ -779,12 +803,6 @@ class LuxonisModel:
             return self._archive(path)
 
     def _archive(self, path: PathType | None = None) -> Path:
-        from .utils.archive_utils import (
-            get_head_configs,
-            get_inputs,
-            get_outputs,
-        )
-
         archive_name = self.cfg.archiver.name or self.cfg.model.name
         archive_save_directory = Path(self.run_save_dir, "archive")
         archive_save_directory.mkdir(parents=True, exist_ok=True)
@@ -806,11 +824,13 @@ class LuxonisModel:
         mean, scale, color_space = get_preprocessing(
             self.cfg_preprocessing, "Exporting to NN Archive"
         )
+        scale_values = self.cfg.exporter.scale_values or scale
+        mean_values = self.cfg.exporter.mean_values or mean
 
         # TODO: keep preprocessing same for each input?
         preprocessing = {
-            "mean": mean,
-            "scale": scale,
+            "mean": mean_values,
+            "scale": scale_values,
             "dai_type": f"{color_space}888p",
         }
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Fixed a bug regarding mixed mean and scale values during export - this bug only affected blobconverter conversion
- Added a check in archive() to also check exporter params for specific mean and scale values (which would be already used for exporting)
- Updated the export .yaml config to be (almost) valid modelconverter config
  - *Almost because one would have to change the path to the model to be e.g. `models/...` relative to the shared_with_container folder. 
  - We could reorganize the output folder structure so that all would be in correct subfolders inside `shared_with_container` but IMO this makes it a bit strange from UX POV since most people should use HubAI to convert or modelconverter hub API where this specific folder structure is not required.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable