### PR TITLE
Feature: Debug Mode (Loader)

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -28,11 +28,13 @@ management_group = Group.create_ordered("Management")
 annotation_group = Group.create_ordered("Annotation")
 
 
-def create_model(config: str | None, opts: list[str] | None) -> "LuxonisModel":
+def create_model(
+    config: str | None, opts: list[str] | None, debug_mode: bool = False
+) -> "LuxonisModel":
     importlib.reload(sys.modules["luxonis_train"])
     from luxonis_train import LuxonisModel
 
-    return LuxonisModel(config, opts)
+    return LuxonisModel(config, opts, debug_mode=debug_mode)
 
 
 @app.command(group=training_group, sort_key=1)
@@ -42,6 +44,7 @@ def train(
     *,
     config: str | None = None,
     weights: str | None = None,
+    debug: bool = False,
 ):
     """Start the training process.
 
@@ -51,8 +54,12 @@ def train(
     @param weights: Path to the model weights.
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
+    @type debug: bool
+    @param debug: If True, the training will run in debug mode which
+        suppresses some exceptions to allow training without a fully
+        defined model.
     """
-    create_model(config, opts).train(weights=weights)
+    create_model(config, opts, debug).train(weights=weights)
 
 
 @app.command(group=training_group, sort_key=2)
@@ -136,6 +143,7 @@ def test(
     config: str | None = None,
     view: Literal["train", "val", "test"] = "val",
     weights: str | None = None,
+    debug: bool = False,
 ):
     """Evaluate a trained model.
 
@@ -149,8 +157,12 @@ def test(
     @param weights: Path to the model weights.
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
+    @type debug: bool
+    @param debug: If True, the training will run in debug mode which
+        suppresses some exceptions to allow training without a fully
+        defined model.
     """
-    create_model(config, opts).test(view=view, weights=weights)
+    create_model(config, opts, debug).test(view=view, weights=weights)
 
 
 @app.command(group=evaluation_group, sort_key=2)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -30,7 +30,7 @@ from luxonis_train.config import Config
 from luxonis_train.lightning import LuxonisLightningModule
 from luxonis_train.loaders import (
     BaseLoaderTorch,
-    DummyLoader,
+    DebugLoader,
     LuxonisLoaderTorch,
 )
 from luxonis_train.registry import LOADERS
@@ -181,7 +181,7 @@ class LuxonisModel:
                     f"Failed to initialize loader '{loader_name}' "
                     f"for view '{view}'. Using `DummyLoader` instead."
                 )
-                self.loaders[view] = DummyLoader(
+                self.loaders[view] = DebugLoader(
                     cfg=self.cfg,
                     view={
                         "train": self.cfg.loader.train_view,

--- a/luxonis_train/loaders/__init__.py
+++ b/luxonis_train/loaders/__init__.py
@@ -1,11 +1,11 @@
 from .base_loader import BaseLoaderTorch, LuxonisLoaderTorchOutput
-from .dummy_loader import DummyLoader
+from .debug_loader import DebugLoader
 from .luxonis_loader_torch import LuxonisLoaderTorch
 from .luxonis_perlin_loader_torch import LuxonisLoaderPerlinNoise
 
 __all__ = [
     "BaseLoaderTorch",
-    "DummyLoader",
+    "DebugLoader",
     "LuxonisLoaderPerlinNoise",
     "LuxonisLoaderTorch",
     "LuxonisLoaderTorchOutput",

--- a/luxonis_train/loaders/__init__.py
+++ b/luxonis_train/loaders/__init__.py
@@ -1,9 +1,11 @@
 from .base_loader import BaseLoaderTorch, LuxonisLoaderTorchOutput
+from .dummy_loader import DummyLoader
 from .luxonis_loader_torch import LuxonisLoaderTorch
 from .luxonis_perlin_loader_torch import LuxonisLoaderPerlinNoise
 
 __all__ = [
     "BaseLoaderTorch",
+    "DummyLoader",
     "LuxonisLoaderPerlinNoise",
     "LuxonisLoaderTorch",
     "LuxonisLoaderTorchOutput",

--- a/luxonis_train/loaders/debug_loader.py
+++ b/luxonis_train/loaders/debug_loader.py
@@ -13,7 +13,7 @@ from luxonis_train.typing import Labels
 from .base_loader import BaseLoaderTorch
 
 
-class DummyLoader(BaseLoaderTorch):
+class DebugLoader(BaseLoaderTorch):
     """A dummy data loader for testing purposes.
 
     It serves as a placeholder in place of C{LuxonisLoaderTorch} when no

--- a/luxonis_train/loaders/dummy_loader.py
+++ b/luxonis_train/loaders/dummy_loader.py
@@ -1,0 +1,111 @@
+from collections import defaultdict
+from typing import Literal
+
+import torch
+from torch import Size, Tensor
+from typing_extensions import override
+
+from luxonis_train.config import Config
+from luxonis_train.registry import NODES
+from luxonis_train.tasks import Metadata
+from luxonis_train.typing import Labels
+
+from .base_loader import BaseLoaderTorch
+
+
+class DummyLoader(BaseLoaderTorch):
+    """A dummy data loader for testing purposes.
+
+    It serves as a placeholder in place of C{LuxonisLoaderTorch} when no
+    real data is available.
+
+    It can be extended to be used instead of custom loaders as well by
+    overriding the C{get_label_shapes} method.
+    """
+
+    def __init__(
+        self,
+        cfg: Config,
+        view: list[str],
+        height: int | None = None,
+        width: int | None = None,
+        image_source: str = "image",
+        color_space: Literal["RGB", "BGR", "GRAY"] = "RGB",
+    ):
+        super().__init__(
+            view=view,
+            height=height,
+            width=width,
+            image_source=image_source,
+            color_space=color_space,
+        )
+        self.labels: dict[str, set[str | Metadata]] = defaultdict(set)
+        for node in cfg.model.nodes:
+            Node = NODES.get(node.name)
+            if Node.task is not None:
+                for label in Node.task.required_labels:
+                    self.labels[f"{node.task_name}"].add(label)
+        self.n_channels = 1 if color_space == "GRAY" else 3
+
+    @property
+    @override
+    def input_shapes(self) -> dict[str, Size]:
+        return {
+            self.image_source: Size(
+                [
+                    self.n_channels,
+                    self.height,
+                    self.width,
+                ]
+            )
+        }
+
+    @override
+    def __len__(self) -> int:
+        return 10
+
+    @override
+    def get(self, idx: int) -> tuple[Tensor | dict[str, Tensor], Labels]:
+        img = torch.zeros(self.n_channels, self.height, self.width)
+        label_shapes = self.get_label_shapes(self.labels)
+        labels = {
+            f"{task_name}/{task_type}": torch.zeros(
+                label_shapes[f"{task_name}/{task_type}"]
+            )
+            for task_name, task_types in self.labels.items()
+            for task_type in task_types
+        }
+        return img, labels
+
+    @override
+    def get_classes(self) -> dict[str, dict[str, int]]:
+        return {task_name: {"x": 0} for task_name in self.labels}
+
+    @override
+    def get_n_keypoints(self) -> dict[str, int] | None:
+        return dict.fromkeys(self.labels, 3)
+
+    def get_label_shapes(
+        self, labels: dict[str, set[str | Metadata]]
+    ) -> dict[str, tuple[int, ...]]:
+        """Creates a dictionary with shape information for each label
+        based on the task type.
+
+        Handles all LDF-native labels by default, but needs to be
+        extended for custom loaders.
+        """
+        shapes = {}
+        for task_name, task_types in labels.items():
+            for task_type in task_types:
+                name = f"{task_name}/{task_type}"
+                match task_type:
+                    case "boundingbox":
+                        shapes[name] = (1, 5)
+                    case "keypoints":
+                        shapes[name] = (1, 9)
+                    case "segmentation" | "instance_segmentation":
+                        shapes[name] = (1, self.height, self.width)
+                    case _:
+                        shapes[name] = (1,)
+
+        return shapes

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -531,3 +531,19 @@ def test_annotate_from_directory(
         team_id="test_team",
     )
     assert isinstance(annotated_dataset, LuxonisDataset)
+
+
+def test_debug_mode(opts: Params, subtests: SubTests):
+    config_file = "configs/detection_light_model.yaml"
+    opts = opts | {
+        "loader.params.dataset_name": "invalid_dataset_name",
+        "trainer.epochs": 1,
+        "trainer.batch_size": 1,
+    }
+    model = LuxonisModel(config_file, opts, debug_mode=True)
+
+    with subtests.test("train"):
+        model.train()
+
+    with subtests.test("test"):
+        model.test()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it easier to create and test models before the entire pipeline is defined. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Adds new argument `debug_mode` to `lxt.Core` that sets the model to a debug mode
  - Corresponding CLI flag (`--debug`) added to `test` and `train` commands
- Added new dummy `DebugLoader` that is used instead of `LuxonisLoaderTorch` in case we fail to load the specified dataset (and `debug_mode` is set to `True`)
  - Yields empty images and labels. Compatible with all LDF label types, but can be extended so it can replace custom loaders as well   

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable