### PR TITLE
Feature: Disable `rich` logging

### DIFF
--- a/luxonis_train/callbacks/__init__.py
+++ b/luxonis_train/callbacks/__init__.py
@@ -16,13 +16,13 @@ from .ema import EMACallback
 from .export_on_train_end import ExportOnTrainEnd
 from .gpu_stats_monitor import GPUStatsMonitor
 from .gradcam_visualizer import GradCamCallback
+from .luxonis_model_summary import LuxonisModelSummary
 from .luxonis_progress_bar import (
     BaseLuxonisProgressBar,
     LuxonisRichProgressBar,
     LuxonisTQDMProgressBar,
 )
 from .metadata_logger import MetadataLogger
-from .rich_model_summary import LuxonisRichModelSummary
 from .test_on_train_end import TestOnTrainEnd
 from .training_manager import TrainingManager
 from .upload_checkpoint import UploadCheckpoint
@@ -30,7 +30,7 @@ from .upload_checkpoint import UploadCheckpoint
 CALLBACKS.register(module=EarlyStopping)
 CALLBACKS.register(module=LearningRateMonitor)
 CALLBACKS.register(module=ModelCheckpoint)
-CALLBACKS.register(module=LuxonisRichModelSummary)
+CALLBACKS.register(module=LuxonisModelSummary)
 CALLBACKS.register(module=DeviceStatsMonitor)
 CALLBACKS.register(module=GradientAccumulationScheduler)
 CALLBACKS.register(module=StochasticWeightAveraging)
@@ -48,7 +48,7 @@ __all__ = [
     "ExportOnTrainEnd",
     "GPUStatsMonitor",
     "GradCamCallback",
-    "LuxonisRichModelSummary",
+    "LuxonisModelSummary",
     "LuxonisRichProgressBar",
     "LuxonisTQDMProgressBar",
     "MetadataLogger",

--- a/luxonis_train/callbacks/luxonis_model_summary.py
+++ b/luxonis_train/callbacks/luxonis_model_summary.py
@@ -9,7 +9,7 @@ from tabulate import tabulate
 from typing_extensions import override
 
 
-class LuxonisRichModelSummary(RichModelSummary):
+class LuxonisModelSummary(RichModelSummary):
     def __init__(self, rich: bool = True, **kwargs):
         super().__init__(**kwargs)
 

--- a/luxonis_train/callbacks/luxonis_progress_bar.py
+++ b/luxonis_train/callbacks/luxonis_progress_bar.py
@@ -5,7 +5,6 @@ from collections.abc import Mapping
 from io import StringIO
 
 import lightning.pytorch as pl
-import tabulate
 from lightning.pytorch.callbacks import (
     ProgressBar,
     RichProgressBar,
@@ -14,6 +13,7 @@ from lightning.pytorch.callbacks import (
 from loguru import logger
 from rich.console import Console
 from rich.table import Table
+from tabulate import tabulate
 from typing_extensions import override
 
 import luxonis_train as lxt
@@ -119,7 +119,7 @@ class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
             C{"Value"}.
         """
         self._rule(title)
-        formatted = tabulate.tabulate(
+        formatted = tabulate(
             table.items(),
             headers=[key_name, value_name],
             tablefmt="fancy_grid",

--- a/luxonis_train/callbacks/luxonis_progress_bar.py
+++ b/luxonis_train/callbacks/luxonis_progress_bar.py
@@ -125,7 +125,7 @@ class LuxonisTQDMProgressBar(TQDMProgressBar, BaseLuxonisProgressBar):
             tablefmt="fancy_grid",
             numalign="right",
         )
-        logger.info(f"\n{formatted}")
+        logger.info(f"\n{formatted}\n")
 
     def on_train_epoch_start(self, trainer, pl_module):
         super().on_train_epoch_start(trainer, pl_module)

--- a/luxonis_train/callbacks/rich_model_summary.py
+++ b/luxonis_train/callbacks/rich_model_summary.py
@@ -5,13 +5,15 @@ from lightning.pytorch.callbacks import RichModelSummary
 from lightning.pytorch.utilities.model_summary import get_human_readable_count
 from loguru import logger
 from rich.console import Console
+from tabulate import tabulate
 from typing_extensions import override
 
 
 class LuxonisRichModelSummary(RichModelSummary):
-    def __init__(self, **kwargs):
+    def __init__(self, rich: bool = True, **kwargs):
         super().__init__(**kwargs)
 
+        self.rich = rich
         self._log_buffer = StringIO()
         self._log_console = Console(
             file=self._log_buffer, force_terminal=False
@@ -19,6 +21,16 @@ class LuxonisRichModelSummary(RichModelSummary):
 
     @override
     def summarize(
+        self,
+        *args,
+        **kwargs,
+    ) -> None:
+        if self.rich:
+            self._rich_summarize(*args, **kwargs)
+        else:
+            self._regular_summarize(*args, **kwargs)
+
+    def _rich_summarize(
         self,
         summary_data: list[tuple[str, list[str]]],
         total_parameters: int,
@@ -89,3 +101,37 @@ class LuxonisRichModelSummary(RichModelSummary):
         logger.bind(file_only=True).info("\n" + self._log_buffer.getvalue())
         self._log_buffer.seek(0)
         self._log_buffer.truncate(0)
+
+    def _regular_summarize(
+        self,
+        summary_data: list[tuple[str, list[str]]],
+        total_parameters: int,
+        trainable_parameters: int,
+        model_size: float,
+        total_training_modes: dict[str, int],
+        **_,
+    ) -> None:
+        rows = list(zip(*(arr[1] for arr in summary_data)))
+        table = tabulate(
+            rows,
+            headers=[" ", "Name", "Type", "Params", "Mode"],
+            tablefmt="fancy_grid",
+        )
+        logger.info(f"\n{table}\n")
+
+        parameters = []
+        for param in [
+            trainable_parameters,
+            total_parameters - trainable_parameters,
+            total_parameters,
+            model_size,
+        ]:
+            parameters.append(
+                "{:<{}}".format(get_human_readable_count(int(param)), 10)
+            )
+        logger.info(f"Trainable params: {parameters[0]}")
+        logger.info(f"Non-trainable params: {parameters[1]}")
+        logger.info(f"Total params: {parameters[2]}")
+        logger.info(f"Total estimated model params size (MB): {parameters[3]}")
+        logger.info(f"Modules in train mode: {total_training_modes['train']}")
+        logger.info(f"Modules in eval mode: {total_training_modes['eval']}")

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -119,7 +119,7 @@ class LuxonisModel:
         self.log_file = self.run_save_dir / "luxonis_train.log"
         self.error_message = None
 
-        setup_logging(file=self.log_file)
+        setup_logging(file=self.log_file, use_rich=self.cfg.rich_logging)
 
         # NOTE: overriding logger in pl so it uses our logger to log device info
         rank_zero_module.log = logger
@@ -132,7 +132,7 @@ class LuxonisModel:
             logger=self.tracker,
             callbacks=(
                 LuxonisRichProgressBar()
-                if self.cfg.trainer.use_rich_progress_bar
+                if self.cfg.rich_logging
                 else LuxonisTQDMProgressBar()
             ),
             precision=self.cfg.trainer.precision,
@@ -728,7 +728,7 @@ class LuxonisModel:
             callbacks = [
                 (
                     LuxonisRichProgressBar()
-                    if cfg.trainer.use_rich_progress_bar
+                    if cfg.rich_logging
                     else LuxonisTQDMProgressBar()
                 )
             ]

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -22,7 +22,7 @@ from torch.optim.lr_scheduler import (
 from torch.optim.optimizer import Optimizer
 
 from luxonis_train.attached_modules import BaseLoss, BaseMetric, BaseVisualizer
-from luxonis_train.callbacks import LuxonisRichModelSummary, TrainingManager
+from luxonis_train.callbacks import LuxonisModelSummary, TrainingManager
 from luxonis_train.config import AttachedModuleConfig, Config
 from luxonis_train.nodes import BaseHead, BaseNode
 from luxonis_train.registry import (
@@ -341,7 +341,7 @@ def build_callbacks(
 
     callbacks: list[pl.Callback] = [
         TrainingManager(),
-        LuxonisRichModelSummary(max_depth=2, rich=cfg.rich_logging),
+        LuxonisModelSummary(max_depth=2, rich=cfg.rich_logging),
         ModelCheckpoint(
             dirpath=save_dir / "min_val_loss",
             filename=f"{model_name}_loss={{val/loss:.4f}}_{{epoch:02d}}",

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -341,7 +341,7 @@ def build_callbacks(
 
     callbacks: list[pl.Callback] = [
         TrainingManager(),
-        LuxonisRichModelSummary(max_depth=2),
+        LuxonisRichModelSummary(max_depth=2, rich=cfg.rich_logging),
         ModelCheckpoint(
             dirpath=save_dir / "min_val_loss",
             filename=f"{model_name}_loss={{val/loss:.4f}}_{{epoch:02d}}",

--- a/luxonis_train/utils/logging.py
+++ b/luxonis_train/utils/logging.py
@@ -6,5 +6,11 @@ from luxonis_ml.typing import PathType
 from luxonis_ml.utils import setup_logging as ml_setup_logging
 
 
-def setup_logging(*, file: PathType | None = None) -> None:
-    ml_setup_logging(file=file, tracebacks_suppress=[pl, torch, pydantic, np])
+def setup_logging(
+    *, file: PathType | None = None, use_rich: bool = True
+) -> None:
+    ml_setup_logging(
+        file=file,
+        use_rich=use_rich,
+        tracebacks_suppress=[pl, torch, pydantic, np],
+    )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adds an option to disable rich logging using config's top-level `rich_logging` field.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable