### PR TITLE
Ensure Full Quota of Validation Visualizations Despite Class Imbalance

### DIFF
--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -634,6 +634,7 @@ class LuxonisLightningModule(pl.LightningModule):
         max_log_images = self.cfg.trainer.n_log_images
         input_image = inputs[self.image_source]
 
+        # Smart logging is decided based on only one task's classifications
         cls_key = next(
             (key for key in labels if "/classification" in key), None
         )

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -571,7 +571,7 @@ def log_balanced_class_images(
     nodes: Mapping[str, BaseNode],
     visualizations: dict[str, dict[str, Tensor]],
     labels: Labels,
-    cls_key: str,
+    cls_task_keys: list[str],
     class_log_counts: list[int],
     n_logged_images: int,
     max_log_images: int,
@@ -584,8 +584,9 @@ def log_balanced_class_images(
     batch_size = next(
         iter(next(iter(visualizations.values())).values())
     ).shape[0]
+    cls_tensor = torch.cat([labels[k] for k in cls_task_keys], dim=1)
     present_classes = [
-        (labels[cls_key][idx] > 0).nonzero(as_tuple=True)[0].tolist()
+        (cls_tensor[idx] > 0).nonzero(as_tuple=True)[0].tolist()
         for idx in range(batch_size)
     ]
     for idx, classes in enumerate(present_classes):

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -653,6 +653,23 @@ def compute_visualization_buffer(
     logged_idxs: dict[str, list[int]],
     max_log_images: int,
 ) -> dict[str, dict[str, Tensor]] | None:
+    """Build a buffer of leftover visualizations to fill up to
+    `max_log_images` frames.
+
+    @type seq_buffer: list[dict[str, dict[str, Tensor]]]
+    @param seq_buffer: Previously buffered visualizations; each item maps node names to
+                        dicts of viz names to Tensors of shape [N, …].
+    @type visualizations: dict[str, dict[str, Tensor]]
+    @param visualizations: Current batch’s visualizations with the same nested structure.
+    @type logged_idxs: dict[str, list[int]]
+    @param logged_idxs: Mapping from node names to lists of batch indices already logged
+                       by the smart (class-balanced) logger.
+    @type max_log_images: int
+    @param max_log_images: Total number of images we aim to log per epoch.
+    @return: A dict `{ node_name: { viz_name: Tensor[...] } }` containing up to the remaining
+             number of images needed to reach `max_log_images`, excluding any indices in
+             `logged_idxs`. Returns `None` if the buffer is already full or no leftovers exist.
+    """
     if seq_buffer:
         first_map = seq_buffer[0]
         first_tensor = next(iter(next(iter(first_map.values())).values()))

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -693,14 +693,9 @@ def compute_visualization_buffer(
                 continue
             slice_ = tensor[free_ix][:rem]
             node_buf[viz_name] = slice_
-            rem -= slice_.shape[0]
-            if rem <= 0:
-                break
 
         if node_buf:
             leftovers[node_name] = node_buf
-        if rem <= 0:
-            break
 
     return leftovers if leftovers else None
 

--- a/tests/integration/test_smart_logging.py
+++ b/tests/integration/test_smart_logging.py
@@ -114,7 +114,7 @@ def test_smart_vis_logging(work_dir: Path):
                     },
                 }
             if (
-                i == 0 or i > 5
+                i > 5
             ):  # luxonis-ml: background class will be assigned based on 0-th sample (self._load_data(0) in luxonis_loader.py)
                 mask = np.zeros((512, 512), dtype=np.uint8)
                 mask[0:10, 0:10] = np.random.randint(
@@ -128,6 +128,17 @@ def test_smart_vis_logging(work_dir: Path):
                         "segmentation": {"mask": mask},
                     },
                 }
+
+                background_mask = 1 - mask
+                yield {
+                    "file": str(path),
+                    "task_name": "objects",
+                    "annotation": {
+                        "class": "background",
+                        "segmentation": {"mask": background_mask},
+                    },
+                }
+
             if i in [0, 1]:
                 definitions["train"].append(str(path))
             else:

--- a/tests/integration/test_smart_logging.py
+++ b/tests/integration/test_smart_logging.py
@@ -81,7 +81,7 @@ CONFIG = {
     },
     "trainer": {
         "batch_size": 2,
-        "n_log_images": 8,
+        "n_log_images": 9,
     },
 }
 
@@ -118,6 +118,13 @@ def test_smart_vis_logging(work_dir: Path):
                 definitions["train"].append(str(path))
             else:
                 definitions["val"].append(str(path))
+            path = create_image(i, temp_dir)
+
+        path = create_image(11, temp_dir)
+        yield {
+            "file": str(path),
+        }
+        definitions["val"].append(str(path))
 
     dataset = LuxonisDataset("non_balanced", delete_local=True)
     dataset.add(generator())
@@ -139,11 +146,11 @@ def test_smart_vis_logging(work_dir: Path):
 
     expected_det = [
         f"test/visualizations/EfficientBBoxHead/BBoxVisualizer/{i}"
-        for i in range(8)
+        for i in range(9)
     ]
     expected_kpts = [
         f"test/visualizations/EfficientKeypointBBoxHead/KeypointVisualizer/{i}"
-        for i in range(8)
+        for i in range(9)
     ]
 
     expected = set(expected_det) | set(expected_kpts)

--- a/tests/integration/test_smart_logging.py
+++ b/tests/integration/test_smart_logging.py
@@ -96,29 +96,38 @@ def test_smart_vis_logging(work_dir: Path):
     def generator():
         for i in range(10):
             path = create_image(i, temp_dir)
-            yield {
-                "file": str(path),
-                "task_name": "animals",
-                "annotation": {
-                    "class": "cat" if i in [0, 1] else "dog",
-                    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.1, "h": 0.3},
-                    "keypoints": {
-                        "keypoints": [(0.5, 0.5, 1), (0.6, 0.6, 1)],
+            if i <= 5:
+                yield {
+                    "file": str(path),
+                    "task_name": "animals",
+                    "annotation": {
+                        "class": "cat" if i in [0, 1] else "dog",
+                        "boundingbox": {
+                            "x": 0.5,
+                            "y": 0.5,
+                            "w": 0.1,
+                            "h": 0.3,
+                        },
+                        "keypoints": {
+                            "keypoints": [(0.5, 0.5, 1), (0.6, 0.6, 1)],
+                        },
                     },
-                },
-            }
-            mask = np.zeros((512, 512), dtype=np.uint8)
-            mask[0:10, 0:10] = np.random.randint(
-                0, 2, (10, 10), dtype=np.uint8
-            )
-            yield {
-                "file": str(path),
-                "task_name": "objects",
-                "annotation": {
-                    "class": "house" if i % 2 == 0 else "car",
-                    "segmentation": {"mask": mask},
-                },
-            }
+                }
+            if (
+                i > 5
+            ):  # TODO: luxonis-ml bug, background class will not be assigned (self._load_data(0) in luxonis_loader.py)
+                mask = np.zeros((512, 512), dtype=np.uint8)
+                mask[0:10, 0:10] = np.random.randint(
+                    0, 2, (10, 10), dtype=np.uint8
+                )
+                yield {
+                    "file": str(path),
+                    "task_name": "objects",
+                    "annotation": {
+                        "class": "house" if i % 2 == 0 else "car",
+                        "segmentation": {"mask": mask},
+                    },
+                }
             if i in [0, 1]:
                 definitions["train"].append(str(path))
             else:
@@ -163,3 +172,10 @@ def test_smart_vis_logging(work_dir: Path):
     assert set(image_tags) == expected, (
         f"Got image tags {image_tags!r}, but expected exactly {sorted(expected)!r}"
     )
+
+
+if __name__ == "__main__":
+    work_dir = (
+        r"C:\Users\jerne\Desktop\luxonis-train-ml\luxonis-train\tests\data"
+    )
+    test_smart_vis_logging(work_dir)

--- a/tests/integration/test_smart_logging.py
+++ b/tests/integration/test_smart_logging.py
@@ -114,8 +114,8 @@ def test_smart_vis_logging(work_dir: Path):
                     },
                 }
             if (
-                i > 5
-            ):  # TODO: luxonis-ml bug, background class will not be assigned (self._load_data(0) in luxonis_loader.py)
+                i == 0 or i > 5
+            ):  # luxonis-ml: background class will be assigned based on 0-th sample (self._load_data(0) in luxonis_loader.py)
                 mask = np.zeros((512, 512), dtype=np.uint8)
                 mask[0:10, 0:10] = np.random.randint(
                     0, 2, (10, 10), dtype=np.uint8

--- a/tests/integration/test_smart_logging.py
+++ b/tests/integration/test_smart_logging.py
@@ -1,0 +1,72 @@
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+from luxonis_ml.data import LuxonisDataset
+from tensorboard.backend.event_processing import event_accumulator
+
+from luxonis_train import LuxonisModel
+
+
+def create_image(i: int, dir: Path) -> Path:
+    path = dir / f"img_{i}.jpg"
+    if not path.exists():
+        img = np.zeros((512, 512, 3), dtype=np.uint8)
+        img[0:10, 0:10] = np.random.randint(
+            0, 255, (10, 10, 3), dtype=np.uint8
+        )
+        cv2.imwrite(str(path), img)
+    return path
+
+
+def test_smart_vis_logging(work_dir: Path):
+    temp_dir = Path(work_dir) / "non_balanced"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    definitions = {"train": [], "val": []}
+
+    def generator():
+        for i in range(10):
+            path = create_image(i, temp_dir)
+            yield {
+                "file": str(path),
+                "annotation": {
+                    "class": "cat" if i in [0, 1] else "dog",
+                    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.1, "h": 0.3},
+                },
+            }
+            if i in [0, 1]:
+                definitions["train"].append(str(path))
+            else:
+                definitions["val"].append(str(path))
+
+    dataset = LuxonisDataset("non_balanced", delete_local=True)
+    dataset.add(generator())
+    dataset.make_splits(definitions)
+
+    opts = {
+        "loader.test_view": "val",
+        "loader.params.dataset_name": dataset.identifier,
+        "trainer.batch_size": 2,
+        "trainer.n_log_images": 9,
+    }
+
+    config_file = "configs/detection_light_model.yaml"
+    model = LuxonisModel(config_file, opts)
+    model.test()
+
+    log_dir = model.lightning_module.logger.experiment["tensorboard"].log_dir
+
+    ea = event_accumulator.EventAccumulator(str(log_dir))
+    ea.Reload()
+
+    image_tags = ea.Tags().get("images", [])
+
+    expected = [
+        f"test/visualizations/EfficientBBoxHead/BBoxVisualizer/{i}"
+        for i in range(8)
+    ]
+
+    assert set(image_tags) == set(expected), (
+        f"Got image tags {image_tags!r}, but expected exactly {expected!r}"
+    )

--- a/tests/integration/test_smart_logging.py
+++ b/tests/integration/test_smart_logging.py
@@ -48,7 +48,7 @@ def test_smart_vis_logging(work_dir: Path):
         "loader.test_view": "val",
         "loader.params.dataset_name": dataset.identifier,
         "trainer.batch_size": 2,
-        "trainer.n_log_images": 9,
+        "trainer.n_log_images": 8,
     }
 
     config_file = "configs/detection_light_model.yaml"

--- a/tests/integration/test_smart_logging.py
+++ b/tests/integration/test_smart_logging.py
@@ -172,10 +172,3 @@ def test_smart_vis_logging(work_dir: Path):
     assert set(image_tags) == expected, (
         f"Got image tags {image_tags!r}, but expected exactly {sorted(expected)!r}"
     )
-
-
-if __name__ == "__main__":
-    work_dir = (
-        r"C:\Users\jerne\Desktop\luxonis-train-ml\luxonis-train\tests\data"
-    )
-    test_smart_vis_logging(work_dir)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

This PR ensures we always log the full quota of validation images, even when some classes are missing:

- Return and track `logged_idxs` from `log_balanced_class_images`

- Extract and buffer only the leftover frames not consumed by balanced logging

- Guarantee `n_log_images` total visualizations per epoch by topping up the buffer once per run

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable