### PR TITLE
Ensure the best checkpoint is used in the `TestOnTrainEnd` callback.

### DIFF
--- a/luxonis_train/callbacks/test_on_train_end.py
+++ b/luxonis_train/callbacks/test_on_train_end.py
@@ -1,17 +1,25 @@
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import ModelCheckpoint
+from loguru import logger
 
 import luxonis_train as lxt
 from luxonis_train.registry import CALLBACKS
 
+from .needs_checkpoint import NeedsCheckpoint
+
 
 @CALLBACKS.register()
-class TestOnTrainEnd(pl.Callback):
+class TestOnTrainEnd(NeedsCheckpoint):
     """Callback to perform a test run at the end of the training."""
 
     def on_train_end(
         self, trainer: pl.Trainer, pl_module: "lxt.LuxonisLightningModule"
     ) -> None:
+        checkpoint = self.get_checkpoint(pl_module)
+        if checkpoint is None:  # pragma: no cover
+            logger.warning(
+                "Best model checkpoint not found. Using last checkpoint for testing."
+            )
         # `trainer.test` would delete the paths so we need to save them
         best_paths = {
             hash(callback.monitor): callback.best_model_path
@@ -21,7 +29,7 @@ class TestOnTrainEnd(pl.Callback):
 
         device_before = pl_module.device
 
-        trainer.test(pl_module, pl_module.core.pytorch_loaders["test"])
+        pl_module.core.test(weights=checkpoint)
 
         # .test() moves pl_module to "cpu", we move it back to original device after
         pl_module.to(device_before)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
By default, `trainer.test()` will run evaluation on whatever the model’s current weights are (i.e. the last training checkpoint), which means you may not be testing the version of the model that achieved the best validation performance.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Inherit from `NeedsCheckpoint` to fetch best_model_path.
- Warn and fall back if no best checkpoint is found.
- Call `pl_module.core.test(weights=checkpoint)` for explicit weight loading.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Tested locally with a small dataset. Verified that when the “best” checkpoint differs from the last, evaluation metrics correspond to the best one.