### PR TITLE
Improved tuner storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ tuner:
   study_name: det_study
   n_trials: 10
   storage:
-    storage_type: local
+    backend: sqlite
   params:
     trainer.optimizer.name_categorical: ["Adam", "SGD"]
     trainer.optimizer.params.lr_float: [0.0001, 0.001]

--- a/configs/README.md
+++ b/configs/README.md
@@ -553,10 +553,11 @@ Here you can specify options for tuning.
 
 ### Storage
 
-| Key            | Type                         | Default value | Description                                         |
-| -------------- | ---------------------------- | ------------- | --------------------------------------------------- |
-| `active`       | `bool`                       | `True`        | Whether to use storage to make the study persistent |
-| `storage_type` | `Literal["local", "remote"]` | `"local"`     | Type of the storage                                 |
+| Key            | Type                         | Default value | Description                                                            |
+| -------------- | ---------------------------- | ------------- | ---------------------------------------------------------------------- |
+| `active`       | `bool`                       | `True`        | Whether to use storage to make the study persistent                    |
+| `storage_type` | `Literal["local", "remote"]` | `"local"`     | Type of the storage. Ignored if `url` is also specified.               |
+| `url`          | `str \| None`                | `None`        | Custom storage URL. `storage_type` is ignored when `url` is specified. |
 
 **Example:**
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -553,11 +553,11 @@ Here you can specify options for tuning.
 
 ### Storage
 
-| Key            | Type                         | Default value | Description                                                            |
-| -------------- | ---------------------------- | ------------- | ---------------------------------------------------------------------- |
-| `active`       | `bool`                       | `True`        | Whether to use storage to make the study persistent                    |
-| `storage_type` | `Literal["local", "remote"]` | `"local"`     | Type of the storage. Ignored if `url` is also specified.               |
-| `url`          | `str \| None`                | `None`        | Custom storage URL. `storage_type` is ignored when `url` is specified. |
+| Key            | Type                         | Default value | Description                                                                                                                                                                                                                                                      |
+| -------------- | ---------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `active`       | `bool`                       | `True`        | Whether to use storage to make the study persistent                                                                                                                                                                                                              |
+| `storage_type` | `Literal["local", "remote"]` | `"local"`     | Type of the storage. Ignored if `url` is also specified.                                                                                                                                                                                                         |
+| `url`          | `str \| None`                | `None`        | Custom storage URL. `storage_type` is ignored when `url` is specified. `optuna` internally uses `SQLAlchemy` to handle the database. Visit the [documentation](https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls) to see the supported URLs. |
 
 **Example:**
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -553,11 +553,25 @@ Here you can specify options for tuning.
 
 ### Storage
 
-| Key            | Type                         | Default value | Description                                                                                                                                                                                                                                                      |
-| -------------- | ---------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `active`       | `bool`                       | `True`        | Whether to use storage to make the study persistent                                                                                                                                                                                                              |
-| `storage_type` | `Literal["local", "remote"]` | `"local"`     | Type of the storage. Ignored if `url` is also specified.                                                                                                                                                                                                         |
-| `url`          | `str \| None`                | `None`        | Custom storage URL. `storage_type` is ignored when `url` is specified. `optuna` internally uses `SQLAlchemy` to handle the database. Visit the [documentation](https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls) to see the supported URLs. |
+`optuna` uses `SQLAlchemy` for handling database connections. To see the supported storage backends, refer to the [SQLAlchemy documentation](https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls)
+
+| Key        | Type          | Default value | Description                                         |
+| ---------- | ------------- | ------------- | --------------------------------------------------- |
+| `active`   | `bool`        | `True`        | Whether to use storage to make the study persistent |
+| `backend`  | `str`         | `"sqlite"`    | Type of the storage.                                |
+| `username` | `str \| None` | `None`        | Username for the storage.                           |
+| `password` | `str \| None` | `None`        | Password for the storage.                           |
+| `host`     | `str \| None` | `None`        | Host for the storage.                               |
+| `port`     | `int \| None` | `None`        | Port for the storage.                               |
+| `database` | `str \| None` | `None`        | Database name for the storage.                      |
+
+In case of `"postgres"` backend, the additional parameters will be read from these environment variables if not provided in the config file:
+
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `POSTGRES_DB`
 
 **Example:**
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -580,7 +580,7 @@ tuner:
   study_name: "seg_study"
   n_trials: 10
   storage:
-    storage_type: "local"
+    backend: sqlite
   params:
     trainer.optimizer.name_categorical: ["Adam", "SGD"]
     trainer.optimizer.params.lr_float: [0.0001, 0.001]

--- a/configs/example_tuning.yaml
+++ b/configs/example_tuning.yaml
@@ -43,7 +43,7 @@ tuner:
   study_name: det_study
   n_trials: 10
   storage:
-    storage_type: local
+    backend: sqlite
   params:
     trainer.optimizer.name_categorical: ["Adam", "SGD"]
     trainer.optimizer.params.lr_float: [0.0001, 0.001]

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -853,13 +853,14 @@ class LuxonisModel:
                 port=cfg_tuner.storage.port,
             )
             logger.info(f"Using '{storage}' as Optuna storage.")
-            storage = storage.render_as_string(hide_password=False)
         else:
             storage = None
 
         study = optuna.create_study(
             study_name=cfg_tuner.study_name,
-            storage=storage,
+            storage=storage.render_as_string(hide_password=False)
+            if storage
+            else None,
             direction="minimize"
             if cfg_tuner.monitor == "loss"
             else "maximize",

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -685,6 +685,7 @@ class LuxonisModel:
         """Runs Optuna tuning of hyperparameters."""
         import optuna
         from optuna.integration import PyTorchLightningPruningCallback
+        from sqlalchemy import URL
 
         from .utils.tune_utils import get_trial_params
 
@@ -840,24 +841,22 @@ class LuxonisModel:
             else optuna.pruners.NopPruner()
         )
 
-        storage = None
         if cfg_tuner.storage.active:
-            if cfg_tuner.storage.url is not None:
-                logger.info(
-                    f"Using custom storage for Optuna "
-                    f"study at '{cfg_tuner.storage.url}'"
-                )
-                storage = cfg_tuner.storage.url
-            elif cfg_tuner.storage.storage_type == "sqlite":
-                storage = "sqlite:///study_local.db"
-            else:  # pragma: no cover
-                storage = "postgresql://{}:{}@{}:{}/{}".format(  # noqa: UP032
-                    self.cfg.ENVIRON.POSTGRES_USER,
-                    self.cfg.ENVIRON.POSTGRES_PASSWORD,
-                    self.cfg.ENVIRON.POSTGRES_HOST,
-                    self.cfg.ENVIRON.POSTGRES_PORT,
-                    self.cfg.ENVIRON.POSTGRES_DB,
-                )
+            storage = URL.create(
+                cfg_tuner.storage.backend,
+                username=cfg_tuner.storage.username,
+                password=cfg_tuner.storage.password.get_secret_value()
+                if cfg_tuner.storage.password is not None
+                else None,
+                host=cfg_tuner.storage.host,
+                database=cfg_tuner.storage.database,
+                port=cfg_tuner.storage.port,
+            )
+            logger.info(f"Using '{storage}' as Optuna storage.")
+            storage = storage.render_as_string(hide_password=False)
+        else:
+            storage = None
+
         study = optuna.create_study(
             study_name=cfg_tuner.study_name,
             storage=storage,

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -842,7 +842,13 @@ class LuxonisModel:
 
         storage = None
         if cfg_tuner.storage.active:
-            if cfg_tuner.storage.storage_type == "local":
+            if cfg_tuner.storage.url is not None:
+                logger.info(
+                    f"Using custom storage for Optuna "
+                    f"study at '{cfg_tuner.storage.url}'"
+                )
+                storage = cfg_tuner.storage.url
+            elif cfg_tuner.storage.storage_type == "sqlite":
                 storage = "sqlite:///study_local.db"
             else:  # pragma: no cover
                 storage = "postgresql://{}:{}@{}:{}/{}".format(  # noqa: UP032

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -182,7 +182,7 @@ def test_parsing_loader():
 )
 def test_tune(opts: Params, coco_dataset: LuxonisDataset):
     opts |= {
-        "tuner.storage.url": f"sqlite:///{STUDY_PATH}",
+        "tuner.storage.database": f"{STUDY_PATH}",
         "tuner.params": {
             "trainer.optimizer.name_categorical": ["Adam", "SGD"],
             "trainer.optimizer.params.lr_float": [0.0001, 0.001],


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it possible to specify custom database URL for tuning.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added  URL params as fields under `tuner.storage`
- Deprecated `storage_type` -> renamed to `backend`
- Added an extra check for db length to tuner tests
## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable