### PR TITLE
Fix inconsistent view arguments

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -162,7 +162,7 @@ def test(
     /,
     *,
     config: str | None = None,
-    view: Literal["train", "val", "test"] = "val",
+    view: Literal["train", "val", "test"] = "test",
     weights: str | None = None,
     debug: bool = False,
 ):

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -540,7 +540,7 @@ class LuxonisModel:
     def test(
         self,
         new_thread: Literal[False] = ...,
-        view: Literal["train", "test", "val"] = "val",
+        view: Literal["train", "test", "val"] = "test",
         weights: PathType | None = ...,
     ) -> Mapping[str, float]: ...
 

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -34,6 +34,7 @@ from luxonis_train.loaders import (
     LuxonisLoaderTorch,
 )
 from luxonis_train.registry import LOADERS
+from luxonis_train.typing import View
 from luxonis_train.utils import (
     DatasetMetadata,
     LuxonisTrackerPL,
@@ -60,8 +61,6 @@ from .utils.infer_utils import (
     infer_from_video,
 )
 from .utils.train_utils import create_trainer
-
-View: TypeAlias = Literal["train", "val", "test"]
 
 
 class LuxonisModel:

--- a/luxonis_train/typing.py
+++ b/luxonis_train/typing.py
@@ -2,6 +2,8 @@ from typing import Literal, TypeAlias, TypeVar
 
 from torch import Size, Tensor
 
+View: TypeAlias = Literal["train", "val", "test"]
+
 Labels: TypeAlias = dict[str, Tensor]
 """Labels is a dictionary mapping task names to tensors."""
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes inconsistent default values of `view` arguments.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Makes `"test"` the default `view` for testing
- Adds an option to specify the view for `TestOnTrainEnd` 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable