### PR TITLE
Use default head config when `get_custom_head_config` is not defined

### DIFF
--- a/luxonis_train/core/utils/archive_utils.py
+++ b/luxonis_train/core/utils/archive_utils.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import TypedDict
 
 import onnx
-from loguru import logger
 from luxonis_ml.nn_archive.config_building_blocks import DataType
 from onnx.onnx_pb import TensorProto
 
@@ -135,11 +134,7 @@ def get_head_configs(
     for node_name, node in lightning_module.nodes.items():
         if not isinstance(node, BaseHead) or node.remove_on_export:
             continue
-        try:
-            head_config = node.get_head_config()
-        except NotImplementedError as e:
-            logger.error(f"Failed to archive head `{node_name}`: {e}")
-            continue
+        head_config = node.get_head_config()
         head_name = (
             node_name
             if node_name not in head_names

--- a/luxonis_train/nodes/heads/base_head.py
+++ b/luxonis_train/nodes/heads/base_head.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 
 from luxonis_ml.data import DatasetIterator
+from luxonis_ml.typing import Params
 from torch import Tensor
 
 from luxonis_train.config.config import PreprocessingConfig
@@ -14,8 +15,6 @@ from luxonis_train.typing import Packet
 from luxonis_train.utils.annotation import default_annotate
 
 
-# TODO: We shouldn't skip the head completely
-# if custom config is not defined.
 class BaseHead(BaseNode[ForwardInputT, ForwardOutputT]):
     """Base class for all heads in the model.
 
@@ -49,15 +48,13 @@ class BaseHead(BaseNode[ForwardInputT, ForwardOutputT]):
             },
         }
 
-    def get_custom_head_config(self) -> dict[str, Any]:
+    def get_custom_head_config(self) -> Params:
         """Get custom head configuration.
 
         @rtype: dict
         @return: Custom head configuration.
         """
-        raise NotImplementedError(
-            "get_custom_head_config method must be implemented."
-        )
+        return {}
 
     def annotate(
         self,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes a bug where the default head parameters weren't saved in the archive config for custom heads without `get_custom_head_config` specified. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
The `get_custom_head_config` now returns an empty dicionary by default instead of raising `NotImplementedError`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable