### PR TITLE
Prevent drawing empty keypoints

### DIFF
--- a/luxonis_train/attached_modules/visualizers/utils.py
+++ b/luxonis_train/attached_modules/visualizers/utils.py
@@ -166,7 +166,10 @@ def draw_keypoint_labels(img: Tensor, label: Tensor, **kwargs) -> Tensor:
     else:
         out_keypoints = keypoints_points.reshape((n_instances, -1, 2)).int()
 
-    return draw_keypoints(img, out_keypoints, **kwargs)
+    if out_keypoints.numel() == 0:
+        return img
+    else:
+        return draw_keypoints(img, out_keypoints, **kwargs)
 
 
 def denormalize(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
When an empty keypoint tensor is passed to the `draw_keypoints() `function, an error is thrown.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Return an unchanged image if a target keypoints tensor is empty.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable