### PR TITLE
Log tuner augmentations by name instead of index

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -682,7 +682,10 @@ class LuxonisModel:
         from optuna.integration import PyTorchLightningPruningCallback
         from sqlalchemy import URL
 
-        from .utils.tune_utils import get_trial_params
+        from .utils.tune_utils import (
+            get_trial_params,
+            rename_params_for_logging,
+        )
 
         def _objective(trial: optuna.trial.Trial) -> float:
             """Objective function used to optimize Optuna study."""
@@ -734,7 +737,10 @@ class LuxonisModel:
 
             cfg.trainer.callbacks = filtered_callbacks
 
-            child_tracker.log_hyperparams(curr_params)
+            renamed_params = rename_params_for_logging(
+                curr_params, self.cfg.tuner.params
+            )
+            child_tracker.log_hyperparams(renamed_params)
 
             cfg.save_data(run_save_dir / "training_config.yaml")
             cfg.trainer.n_sanity_val_steps = 0

--- a/luxonis_train/core/utils/tune_utils.py
+++ b/luxonis_train/core/utils/tune_utils.py
@@ -79,3 +79,37 @@ def get_trial_params(
             "No paramteres to tune. Specify them under `tuner.params`."
         )
     return new_params
+
+
+def rename_params_for_logging(
+    params: dict, tuner_params: dict | None = None
+) -> dict:
+    """Rename augmentation keys in a flat param dict from numeric
+    indices to augmentation names.
+
+    Example:
+        'trainer.preprocessing.augmentations.0.active'
+        -> 'trainer.preprocessing.augmentations.Defocus.active'
+    """
+    aug_subset = []
+    if tuner_params:
+        aug_subset, _ = tuner_params.get(
+            "trainer.preprocessing.augmentations_subset", ([], [])
+        )
+
+    renamed = {}
+    for k, v in params.items():
+        if k.startswith("trainer.preprocessing.augmentations.") and aug_subset:
+            parts = k.split(".")
+            try:
+                idx = int(parts[3])  # augmentations.<index>.<field>
+                aug_name = aug_subset[idx]
+                new_key = (
+                    f"trainer.preprocessing.augmentations.{aug_name}.active"
+                )
+                renamed[new_key] = v
+            except (IndexError, ValueError):
+                renamed[k] = v
+        else:
+            renamed[k] = v
+    return renamed

--- a/luxonis_train/core/utils/tune_utils.py
+++ b/luxonis_train/core/utils/tune_utils.py
@@ -84,13 +84,7 @@ def get_trial_params(
 def rename_params_for_logging(
     params: dict, tuner_params: dict | None = None
 ) -> dict:
-    """Rename augmentation keys in a flat param dict from numeric
-    indices to augmentation names.
-
-    Example:
-        'trainer.preprocessing.augmentations.0.active'
-        -> 'trainer.preprocessing.augmentations.Defocus.active'
-    """
+    """Rename parameters used for logging."""
     aug_subset = []
     if tuner_params:
         aug_subset, _ = tuner_params.get(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

### **Tuner** 
Previously, augmentation parameters were logged with numeric indices, which made the logs harder to read:
```
'trainer.preprocessing.augmentations.0.active' = True
'trainer.preprocessing.augmentations.1.active' = False
'trainer.preprocessing.augmentations.2.active' = False
'trainer.preprocessing.augmentations.3.active' = True
```

We now log them with their actual augmentation names, making the logs much more readable:
```
'trainer.preprocessing.augmentations.Defocus.active' = True
'trainer.preprocessing.augmentations.Sharpen.active' = False
'trainer.preprocessing.augmentations.Flip.active' = False
'trainer.preprocessing.augmentations.Rotate.active' = True
```


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable