### PR TITLE
Raise clear error when using SoftmaxFocalLoss for binary tasks

### DIFF
--- a/luxonis_train/attached_modules/losses/softmax_focal_loss.py
+++ b/luxonis_train/attached_modules/losses/softmax_focal_loss.py
@@ -8,7 +8,6 @@ from luxonis_train.attached_modules.losses import BaseLoss
 from luxonis_train.tasks import Tasks
 
 
-# TODO: Add support for multi-class tasks
 class SoftmaxFocalLoss(BaseLoss):
     supported_tasks = [Tasks.SEGMENTATION, Tasks.CLASSIFICATION]
 
@@ -48,6 +47,12 @@ class SoftmaxFocalLoss(BaseLoss):
             raise ValueError("smooth value should be in [0,1]")
 
     def forward(self, predictions: Tensor, targets: Tensor) -> Tensor:
+        if predictions.size(1) <= 2:
+            raise ValueError(
+                "SoftmaxFocalLoss is not suitable for binary tasks. "
+                "Please use SigmoidFocalLoss instead."
+            )
+
         if predictions.shape != targets.shape:
             raise ValueError(
                 f"Shape mismatch: {predictions.shape} vs {targets.shape}"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Adds a check in `SoftmaxFocalLoss` to raise an error when used for binary tasks, guiding users to use `SigmoidFocalLoss` instead.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable