### PR TITLE
Make onnx simplification toggleable

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -500,10 +500,11 @@ Here you can define configuration for exporting.
 
 Option specific for `ONNX` export.
 
-| Key             | Type                     | Default value | Description                       |
-| --------------- | ------------------------ | ------------- | --------------------------------- |
-| `opset_version` | `int`                    | `12`          | Which `ONNX` opset version to use |
-| `dynamic_axes`  | `dict[str, Any] \| None` | `None`        | Whether to specify dynamic axes   |
+| Key             | Type                     | Default value | Description                          |
+| --------------- | ------------------------ | ------------- | ------------------------------------ |
+| `opset_version` | `int`                    | `12`          | Which `ONNX` opset version to use    |
+| `dynamic_axes`  | `dict[str, Any] \| None` | `None`        | Whether to specify dynamic axes      |
+| `simplify`      | `bool`                   | `True`        | Run ONNX simplification after export |
 
 ### `Blob`
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -500,11 +500,11 @@ Here you can define configuration for exporting.
 
 Option specific for `ONNX` export.
 
-| Key             | Type                     | Default value | Description                          |
-| --------------- | ------------------------ | ------------- | ------------------------------------ |
-| `opset_version` | `int`                    | `12`          | Which `ONNX` opset version to use    |
-| `dynamic_axes`  | `dict[str, Any] \| None` | `None`        | Whether to specify dynamic axes      |
-| `simplify`      | `bool`                   | `True`        | Run ONNX simplification after export |
+| Key                           | Type                     | Default value | Description                              |
+| ----------------------------- | ------------------------ | ------------- | ---------------------------------------- |
+| `opset_version`               | `int`                    | `12`          | Which `ONNX` opset version to use        |
+| `dynamic_axes`                | `dict[str, Any] \| None` | `None`        | Whether to specify dynamic axes          |
+| `disable_onnx_simplification` | `bool`                   | `False`       | Disable ONNX simplification after export |
 
 ### `Blob`
 

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -588,6 +588,7 @@ class TrainerConfig(BaseModelExtraForbid):
 class OnnxExportConfig(BaseModelExtraForbid):
     opset_version: PositiveInt = 12
     dynamic_axes: Params | None = None
+    simplify: bool = False
 
 
 class BlobconverterExportConfig(BaseModelExtraForbid):

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -588,7 +588,7 @@ class TrainerConfig(BaseModelExtraForbid):
 class OnnxExportConfig(BaseModelExtraForbid):
     opset_version: PositiveInt = 12
     dynamic_axes: Params | None = None
-    simplify: bool = False
+    disable_onnx_simplification: bool = False
 
 
 class BlobconverterExportConfig(BaseModelExtraForbid):

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -444,7 +444,7 @@ class LuxonisModel:
 
         with replace_weights(self.lightning_module, weights):
             onnx_kwargs = self.cfg.exporter.onnx.model_dump(
-                exclude={"simplify"}
+                exclude={"disable_onnx_simplification"}
             )
             output_names = self.lightning_module.export_onnx(
                 onnx_save_path,

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -443,8 +443,12 @@ class LuxonisModel:
         onnx_save_path = str(export_path.with_suffix(".onnx"))
 
         with replace_weights(self.lightning_module, weights):
+            onnx_kwargs = self.cfg.exporter.onnx.model_dump(
+                exclude={"simplify"}
+            )
             output_names = self.lightning_module.export_onnx(
-                onnx_save_path, **self.cfg.exporter.onnx.model_dump()
+                onnx_save_path,
+                **onnx_kwargs,
             )
 
         if self.cfg.exporter.onnx.simplify:

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -447,7 +447,8 @@ class LuxonisModel:
                 onnx_save_path, **self.cfg.exporter.onnx.model_dump()
             )
 
-        try_onnx_simplify(onnx_save_path)
+        if self.cfg.exporter.onnx.simplify:
+            try_onnx_simplify(onnx_save_path)
         self._exported_models["onnx"] = Path(onnx_save_path)
 
         mean, scale, color_space = get_preprocessing(

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -451,7 +451,7 @@ class LuxonisModel:
                 **onnx_kwargs,
             )
 
-        if self.cfg.exporter.onnx.simplify:
+        if not self.cfg.exporter.onnx.disable_onnx_simplification:
             try_onnx_simplify(onnx_save_path)
         self._exported_models["onnx"] = Path(onnx_save_path)
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Introducing a new optional flag in the exporter section where you can choose if you want to skip onnx simplification.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable