### PR TITLE
Fix OKS metric in case of batches without annotations 

### DIFF
--- a/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
+++ b/luxonis_train/attached_modules/metrics/object_keypoint_similarity.py
@@ -71,11 +71,15 @@ class ObjectKeypointSimilarity(BaseMetric):
         h, w = self.original_in_shape[1:]
         bs = len(keypoints)
 
-        self.pred_keypoints.extend(map(fix_empty_tensor, keypoints))
-
-        for bboxes, kpts in instances_from_batch(
-            target_boundingbox, target_keypoints, batch_size=bs
+        for i, (bboxes, kpts) in enumerate(
+            instances_from_batch(
+                target_boundingbox, target_keypoints, batch_size=bs
+            )
         ):
+            if kpts.numel() == 0:
+                # Skipping images with no keypoints annotations
+                continue
+
             bbox_w = bboxes[:, 3] * w
             bbox_h = bboxes[:, 4] * h
 
@@ -83,6 +87,7 @@ class ObjectKeypointSimilarity(BaseMetric):
             kpts[:, 0::3] *= w
             kpts[:, 1::3] *= h
 
+            self.pred_keypoints.append(fix_empty_tensor(keypoints[i]))
             self.target_keypoints.append(fix_empty_tensor(kpts))
             self.scales.append(bbox_w * bbox_h * self.area_factor)
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

In the update loop of OKS, the GT bounding boxes and keypoints skipped empty batches because the` batch_size` parameter wasn’t passed to `instances_from_batch`. As a result, `self.pred_keypoints` had the correct length, but `self.target_keypoints` was shorter, missing entries for those batches.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable