### PR TITLE
Fix annotate scenario where paths have different lengths

### DIFF
--- a/luxonis_train/core/utils/annotate_utils.py
+++ b/luxonis_train/core/utils/annotate_utils.py
@@ -82,10 +82,7 @@ def annotated_dataset_generator(
             batch_out = lt_module(imgs).outputs
 
         for head_name, head_output in batch_out.items():
-            img_paths = [
-                Path("".join(chr(int(c.item())) for c in raw_meta))
-                for raw_meta in metas["/metadata/path"]
-            ]
+            img_paths = [Path(p) for p in metas["/metadata/path"]]
             head = lt_module.nodes[head_name]
             if isinstance(head, lxt.BaseHead):
                 for record in head.annotate(

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -10,6 +10,7 @@ import torch.utils.data as torch_data
 from luxonis_ml.data import DatasetIterator, LuxonisDataset
 from luxonis_ml.typing import PathType
 from torch import Tensor
+from torch.utils.data._utils.collate import default_collate
 
 import luxonis_train as lxt
 from luxonis_train.attached_modules.visualizers import get_denormalized_images
@@ -231,8 +232,26 @@ def create_loader_from_directory(
         color_space=model.cfg_preprocessing.color_space,
         keep_aspect_ratio=model.cfg_preprocessing.keep_aspect_ratio,
     )
+
+    def collate_fix_paths(batch: list[tuple[Tensor, dict[str, Any]]]) -> Any:
+        for _, m in batch:
+            m["/metadata/path"] = (
+                m["/metadata/path"]
+                .view(-1)
+                .byte()
+                .cpu()
+                .numpy()
+                .tobytes()
+                .rstrip(b"\0")
+                .decode("utf-8", "ignore")
+            )
+        return default_collate(batch)
+
     loader = torch_data.DataLoader(
         loader,
+        collate_fn=collate_fix_paths
+        if add_path_annotation
+        else default_collate,
         batch_size=model.cfg.trainer.batch_size,
         pin_memory=True,
         shuffle=False,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

In luxonis-ml, metadata strings are converted to lists of integers. PyTorch’s default collate fails when path lengths differ, so this is fixed by a new collate_fn used when annotation is enabled.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable