### PR TITLE
DinoV3 encoder + transfomer heads for classification and segmentation

### DIFF
--- a/configs/dinov3_classification_classic_head.yaml
+++ b/configs/dinov3_classification_classic_head.yaml
@@ -17,6 +17,9 @@ model:
         - name: Accuracy
           is_main_metric: true
 
+      visualizers:
+        - name: ClassificationVisualizer
+
 loader:
   params:
     dataset_name: bean_classification_dataset

--- a/configs/dinov3_classification_classic_head.yaml
+++ b/configs/dinov3_classification_classic_head.yaml
@@ -21,15 +21,19 @@ loader:
   params:
     dataset_name: bean_classification_dataset
 
+exporter:
+  onnx:
+    opset_version: 16
+
 trainer:
   preprocessing:
-    train_image_size: [500, 500]
+    train_image_size: [ 500, 500 ]
     keep_aspect_ratio: true
     normalize:
       active: true
 
   batch_size: 16
-  epochs: &epochs 10
+  epochs: 10
   n_workers: 8
   validation_interval: 5
   n_log_images: 8

--- a/configs/dinov3_classification_classic_head.yaml
+++ b/configs/dinov3_classification_classic_head.yaml
@@ -1,0 +1,43 @@
+model:
+  name: dino_model
+  nodes:
+    - name: DinoV3
+      params:
+        weights_link: "REDACTED"
+        return_sequence: false  # this will change the encoder output to a feature map
+
+    - name: ClassificationHead
+      inputs:
+        - DinoV3
+
+      losses:
+        - name: CrossEntropyLoss
+
+      metrics:
+        - name: Accuracy
+          is_main_metric: true
+
+loader:
+  params:
+    dataset_name: bean_classification_dataset
+
+trainer:
+  preprocessing:
+    train_image_size: [500, 500]
+    keep_aspect_ratio: true
+    normalize:
+      active: true
+
+  batch_size: 16
+  epochs: &epochs 10
+  n_workers: 8
+  validation_interval: 5
+  n_log_images: 8
+
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.0003
+
+  scheduler:
+    name: ConstantLR

--- a/configs/dinov3_classification_classic_head.yaml
+++ b/configs/dinov3_classification_classic_head.yaml
@@ -30,7 +30,7 @@ exporter:
 
 trainer:
   preprocessing:
-    train_image_size: [ 500, 500 ]
+    train_image_size: [ 384, 384 ]
     keep_aspect_ratio: true
     normalize:
       active: true
@@ -40,6 +40,10 @@ trainer:
   n_workers: 8
   validation_interval: 5
   n_log_images: 8
+
+  callbacks:
+    - name: ExportOnTrainEnd
+    - name: TestOnTrainEnd
 
   optimizer:
     name: Adam

--- a/configs/dinov3_classification_transformer_head.yaml
+++ b/configs/dinov3_classification_transformer_head.yaml
@@ -16,6 +16,10 @@ model:
       metrics:
         - name: Accuracy
           is_main_metric: true
+
+      visualizers:
+        - name: ClassificationVisualizer
+
 loader:
   params:
     dataset_name: bean_classification_dataset

--- a/configs/dinov3_classification_transformer_head.yaml
+++ b/configs/dinov3_classification_transformer_head.yaml
@@ -16,10 +16,13 @@ model:
       metrics:
         - name: Accuracy
           is_main_metric: true
-
 loader:
   params:
     dataset_name: bean_classification_dataset
+
+exporter:
+  onnx:
+    opset_version: 16
 
 trainer:
   preprocessing:

--- a/configs/dinov3_classification_transformer_head.yaml
+++ b/configs/dinov3_classification_transformer_head.yaml
@@ -30,16 +30,20 @@ exporter:
 
 trainer:
   preprocessing:
-    train_image_size: [500, 500]
+    train_image_size: [ 384, 384 ]
     keep_aspect_ratio: true
     normalize:
       active: true
 
   batch_size: 16
-  epochs: &epochs 10
+  epochs: 10
   n_workers: 8
   validation_interval: 5
   n_log_images: 8
+
+  callbacks:
+    - name: ExportOnTrainEnd
+    - name: TestOnTrainEnd
 
   optimizer:
     name: Adam

--- a/configs/dinov3_classification_transformer_head.yaml
+++ b/configs/dinov3_classification_transformer_head.yaml
@@ -1,0 +1,43 @@
+model:
+  name: dino_model
+  nodes:
+    - name: DinoV3
+      params:
+        weights_link: "REDACTED"
+        return_sequence: true # this will return patch-level embeddings to send to the transformer head
+
+    - name: TransformerClassificationHead
+      inputs:
+        - DinoV3
+
+      losses:
+        - name: CrossEntropyLoss
+
+      metrics:
+        - name: Accuracy
+          is_main_metric: true
+
+loader:
+  params:
+    dataset_name: bean_classification_dataset
+
+trainer:
+  preprocessing:
+    train_image_size: [500, 500]
+    keep_aspect_ratio: true
+    normalize:
+      active: true
+
+  batch_size: 16
+  epochs: &epochs 10
+  n_workers: 8
+  validation_interval: 5
+  n_log_images: 8
+
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.0003
+
+  scheduler:
+    name: ConstantLR

--- a/configs/dinov3_semantic_segmentation.yaml
+++ b/configs/dinov3_semantic_segmentation.yaml
@@ -1,0 +1,54 @@
+model:
+  name: CustomUNet
+  nodes:
+    - name: DinoV3
+
+    - name: SegmentationHead
+      inputs:
+        - DinoV3
+
+      losses:
+        - name: MyBCEWithLogitsLoss
+
+      metrics:
+        - name: Accuracy
+          is_main_metric: true
+
+      visualizers:
+        - name: SegmentationVisualizer
+
+loader:
+  params:
+    dataset_name: "leafs_dataset"
+    dataset_dir: "roboflow://giovi/leaf-segmentation-uxlob/4/coco"
+
+trainer:
+  precision: "16-mixed"
+  preprocessing:
+    train_image_size: [384, 384]
+    keep_aspect_ratio: true
+    normalize:
+      active: true
+
+  batch_size: 4
+  epochs: &epochs 1
+  n_workers: 4
+  validation_interval: 10
+  n_log_images: 20
+
+  callbacks:
+    - name: TestOnTrainEnd
+    - name: ExportOnTrainEnd
+
+  optimizer:
+    name: AdamW
+    params:
+      lr: 0.0005
+      weight_decay: 0.0001
+
+
+  scheduler:
+    name: CosineAnnealingLR
+    params:
+      T_max: *epochs
+      eta_min: 0.0001

--- a/configs/dinov3_semantic_segmentation.yaml
+++ b/configs/dinov3_semantic_segmentation.yaml
@@ -22,6 +22,10 @@ loader:
     dataset_name: "leafs_dataset"
     dataset_dir: "roboflow://giovi/leaf-segmentation-uxlob/4/coco"
 
+exporter:
+  onnx:
+    opset_version: 16
+      
 trainer:
   precision: "16-mixed"
   preprocessing:

--- a/configs/dinov3_semantic_segmentation_transformer_head.yaml
+++ b/configs/dinov3_semantic_segmentation_transformer_head.yaml
@@ -1,0 +1,47 @@
+model:
+  name: dino_model
+  nodes:
+    - name: DinoV3
+      params:
+        weights_link: "REACTED"
+        return_sequence: true
+
+    - name: TransformerClassificationHead
+      inputs:
+        - DinoV3
+      
+      losses:
+        - name: CrossEntropyLoss
+          
+      metrics:
+        - name: Accuracy
+          is_main_metric: true
+
+loader:
+  params:
+    dataset_name: bean_classification_dataset
+
+exporter:
+  onnx:
+    opset_version: 16
+
+trainer:
+  preprocessing:
+    train_image_size: [500, 500]
+    keep_aspect_ratio: true
+    normalize:
+      active: true
+
+  batch_size: 4
+  epochs: 1
+  n_workers: 8
+  validation_interval: 1
+  n_log_images: 8
+
+  optimizer:
+    name: Adam
+    params:
+      lr: 0.0003
+
+  scheduler:
+    name: ConstantLR

--- a/configs/dinov3_semantic_segmentation_transformer_head.yaml
+++ b/configs/dinov3_semantic_segmentation_transformer_head.yaml
@@ -17,6 +17,9 @@ model:
         - name: Accuracy
           is_main_metric: true
 
+      visualizers:
+        - name: SegmentationVisualizer
+
 loader:
   params:
     dataset_name: bean_classification_dataset

--- a/luxonis_train/nodes/README.md
+++ b/luxonis_train/nodes/README.md
@@ -74,6 +74,16 @@ Adapted from [here](https://pytorch.org/vision/main/models/resnet.html).
 | --------- | ----------------------------------------- | ------------- | ---------------------- |
 | `variant` | `Literal["18", "34", "50", "101", "152"]` | `"18"`        | Variant of the network |
 
+### `DinoV3`
+
+Adapted from [here](https://github.com/facebookresearch/dinov3)
+
+
+| Key       | Type                                     | Default value | Description            |
+| --------- | ---------------------------------------- | ------------- | ---------------------- |
+| `variant` | `Literal["vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16", "convnext_tiny", "convnext_small", "convnext_base", "convnext_large"]` | `"vitb16"`        | Variant of the network |
+
+
 ### `MicroNet`
 
 Adapted from [here](https://github.com/liyunsheng13/micronet).

--- a/luxonis_train/nodes/backbones/__init__.py
+++ b/luxonis_train/nodes/backbones/__init__.py
@@ -11,6 +11,7 @@ from .pplcnet_v3 import PPLCNetV3
 from .recsubnet import RecSubNet
 from .repvgg import RepVGG
 from .resnet import ResNet
+from .dinov3 import DinoV3
 from .rexnetv1 import ReXNetV1_lite
 
 __all__ = [

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -11,7 +11,7 @@ from luxonis_train import BaseHead, BaseNode, BaseLoss
 from luxonis_train import Tasks
 
 
-class DinoV3Local(BaseNode):
+class DinoV3(BaseNode):
     DINOv3Kwargs = Dict[str, str]
 
     def __init__(

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -39,9 +39,13 @@ class DinoV3(BaseNode):
             repo_dir=repo_dir
         )
 
+        logger.warning(
+            "DinoV3 is not convertible for RVC2. If RVC2 is your target platform, please pick a different backbone."
+        )
+
     def forward(self, inputs: Tensor) -> list[Tensor]:
         x = self.backbone(inputs)
-        return [x]
+        return x
 
     @staticmethod
     @override

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -5,16 +5,43 @@ from typing import Literal, TypedDict
 
 class DinoV3(BaseNode):
     def __init__(
-            self,
-            variant: Literal["vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16",
+        self,
+        variant: Literal[
+            "vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16",
             "convnext_tiny", "convnext_small", "convnext_base", "convnext_large"
-            ] = "vits16",
-            **kwargs):
+        ] = "vitb16",
+        weights: Literal["download", "none"] | None = "download",
+        repo_dir: str = "facebookresearch/dinov3",
+        **kwargs):
+        """DinoV3 backbone
+
+        Source: U{https://github.com/facebookresearch/dinov3}
+
+        @param variant: Architecture variant of the DINOv3 backbone.
+        @type variant: Literal of supported DINOv3 variants.
+
+        @param weights: Whether to download pretrained weights ("download") or initialize randomly ("none").
+        @type weights: Literal["download", "none"] or None
+
+        @param repo_dir: Torch Hub repo to use. Defaults to the official "facebookresearch/dinov3".
+        @type repo_dir: str
+        """
         super().__init__(**kwargs)
-        self.backbone = self._get_backbone(variant)
+
+        if weights == "download":
+            weights_url = self._get_weights_url(variant)
+        else:
+            weights_url = None
+
+        self.backbone = self._get_backbone(
+            variant=variant,
+            weights=weights_url,
+            repo_dir=repo_dir
+        )
 
     def forward(self, inputs: Tensor) -> list[Tensor]:
-        return
+        x = self.backbone(inputs)
+        return [x]
 
     @staticmethod
     @override
@@ -34,12 +61,12 @@ class DinoV3(BaseNode):
 
     @staticmethod
     def _get_backbone(
-        variant: Literal[
-            "vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16",
-            "convnext_tiny", "convnext_small", "convnext_base", "convnext_large"
-        ],
-        weights: str,
-        repo_dir: str = "facebookresearch/dinov3",
+            variant: Literal[
+                "vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16",
+                "convnext_tiny", "convnext_small", "convnext_base", "convnext_large"
+            ],
+            weights: str,
+            repo_dir: str = "facebookresearch/dinov3",
     ):
         variant_to_hub_name = {
             "vits16": "dinov3_vits16",

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -16,14 +16,14 @@ class DinoV3(BaseNode):
 
     def __init__(
             self,
-            weights_link,
+            weights_link: str,
+            return_sequence: bool = False,
             variant: Literal[
                 "vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16",
                 "convnext_tiny", "convnext_small", "convnext_base", "convnext_large"
             ] = "vits16",
             weights: Literal["download", "none"] | None = "download",
             repo_dir: str = "facebookresearch/dinov3",
-            return_sequence=False,
             **kwargs):
         """DinoV3 backbone
 
@@ -42,6 +42,7 @@ class DinoV3(BaseNode):
         @type return_sequence: bool
         """
         super().__init__(**kwargs)
+
         self.return_sequence = return_sequence
 
         if weights == "download":
@@ -50,7 +51,7 @@ class DinoV3(BaseNode):
             weights_url = None
 
         self.backbone = self._get_backbone(
-            variant=variant,
+            variant=self.variant,
             weights=weights_url,
             repo_dir=repo_dir,
             **kwargs
@@ -61,13 +62,9 @@ class DinoV3(BaseNode):
         )
 
     def forward(self, inputs: Tensor) -> list[Tensor]:
-        """
-        If self.return_sequence is True: return patch sequence directly in the format [B, N, C] to be passed to transformer heads
-        If self.return sequence is False: convert patch-level embeddings to feature map to be passed to the classic heads
-        """
         x = self.backbone.get_intermediate_layers(inputs, n=1)[0]
 
-        if self.return_sequence:
+        if self.return_sequence:  # return patch sequence directly
             return [x]
 
         B, N, C = x.shape

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -1,5 +1,5 @@
 import torch
-
+from loguru import logger
 from typing import Literal, TypedDict
 
 
@@ -36,7 +36,8 @@ class DinoV3(BaseNode):
         self.backbone = self._get_backbone(
             variant=variant,
             weights=weights_url,
-            repo_dir=repo_dir
+            repo_dir=repo_dir,
+            **kwargs
         )
 
         logger.warning(
@@ -46,6 +47,34 @@ class DinoV3(BaseNode):
     def forward(self, inputs: Tensor) -> list[Tensor]:
         x = self.backbone(inputs)
         return x
+
+    @staticmethod
+    def _get_weights_url(variant: str) -> str: # these links are unfortunately incorrect, the correct weights are links sent by META after filling a form
+        """
+        Returns the pretrained weights URL for a given DINOv3 variant.
+
+        @param variant: The name of the DINOv3 variant.
+        @return: URL string pointing to the pretrained weights.
+        @raises ValueError: If the variant is not recognized.
+        """
+        base_url = "https://dl.fbaipublicfiles.com/dinov3"
+        variant_urls = {
+            "vits16": f"{base_url}/dinov3_vits16_pretrain.pth",
+            "vits16plus": f"{base_url}/dinov3_vits16plus_pretrain.pth",
+            "vitb16": f"{base_url}/dinov3_vitb16_pretrain.pth",
+            "vitl16": f"{base_url}/dinov3_vitl16_pretrain.pth",
+            "vith16plus": f"{base_url}/dinov3_vith16plus_pretrain.pth",
+            "vit7b16": f"{base_url}/dinov3_vit7b16_pretrain.pth",
+            "convnext_tiny": f"{base_url}/dinov3_convnext_tiny_pretrain.pth",
+            "convnext_small": f"{base_url}/dinov3_convnext_small_pretrain.pth",
+            "convnext_base": f"{base_url}/dinov3_convnext_base_pretrain.pth",
+            "convnext_large": f"{base_url}/dinov3_convnext_large_pretrain.pth",
+        }
+
+        if variant not in variant_urls:
+            raise ValueError(f"Unsupported variant '{variant}' for DINOv3 pretrained weights.")
+
+        return variant_urls[variant]
 
     @staticmethod
     @override
@@ -71,6 +100,7 @@ class DinoV3(BaseNode):
             ],
             weights: str,
             repo_dir: str = "facebookresearch/dinov3",
+            **kwargs
     ):
         variant_to_hub_name = {
             "vits16": "dinov3_vits16",
@@ -92,6 +122,7 @@ class DinoV3(BaseNode):
             repo_or_dir=repo_dir,
             model=variant_to_hub_name[variant],
             source="github",
-            weights=weights
+            weights=weights,
+            **kwargs
         )
         return model

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -42,7 +42,6 @@ class DinoV3Local(BaseNode):
         @type return_sequence: bool
         """
         super().__init__(**kwargs)
-
         self.return_sequence = return_sequence
 
         if weights == "download":
@@ -56,8 +55,6 @@ class DinoV3Local(BaseNode):
             repo_dir=repo_dir,
             **kwargs
         )
-
-        print(self.backbone)
 
         logger.warning(
             "DinoV3 is not convertible for RVC2. If RVC2 is your target platform, please pick a different backbone."

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -1,0 +1,66 @@
+import torch
+
+from typing import Literal, TypedDict
+
+
+class DinoV3(BaseNode):
+    def __init__(
+            self,
+            variant: Literal["vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16",
+            "convnext_tiny", "convnext_small", "convnext_base", "convnext_large"
+            ] = "vits16",
+            **kwargs):
+        super().__init__(**kwargs)
+        self.backbone = self._get_backbone(variant)
+
+    def forward(self, inputs: Tensor) -> list[Tensor]:
+        return
+
+    @staticmethod
+    @override
+    def get_variants() -> tuple[str, dict[str, DINOv3Kwargs]]:
+        return "vitb16", {
+            "vits16": {"variant": "vits16"},
+            "vits16plus": {"variant": "vits16plus"},
+            "vitb16": {"variant": "vitb16"},
+            "vitl16": {"variant": "vitl16"},
+            "vith16plus": {"variant": "vith16plus"},
+            "vit7b16": {"variant": "vit7b16"},
+            "convnext_tiny": {"variant": "convnext_tiny"},
+            "convnext_small": {"variant": "convnext_small"},
+            "convnext_base": {"variant": "convnext_base"},
+            "convnext_large": {"variant": "convnext_large"},
+        }
+
+    @staticmethod
+    def _get_backbone(
+        variant: Literal[
+            "vits16", "vits16plus", "vitb16", "vitl16", "vith16plus", "vit7b16",
+            "convnext_tiny", "convnext_small", "convnext_base", "convnext_large"
+        ],
+        weights: str,
+        repo_dir: str = "facebookresearch/dinov3",
+    ):
+        variant_to_hub_name = {
+            "vits16": "dinov3_vits16",
+            "vits16plus": "dinov3_vits16plus",
+            "vitb16": "dinov3_vitb16",
+            "vitl16": "dinov3_vitl16",
+            "vith16plus": "dinov3_vith16plus",
+            "vit7b16": "dinov3_vit7b16",
+            "convnext_tiny": "dinov3_convnext_tiny",
+            "convnext_small": "dinov3_convnext_small",
+            "convnext_base": "dinov3_convnext_base",
+            "convnext_large": "dinov3_convnext_large",
+        }
+
+        if variant not in variant_to_hub_name:
+            raise ValueError(f"Unsupported variant: {variant}")
+
+        model = torch.hub.load(
+            repo_or_dir=repo_dir,
+            model=variant_to_hub_name[variant],
+            source="github",
+            weights=weights
+        )
+        return model

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -61,9 +61,13 @@ class DinoV3(BaseNode):
         )
 
     def forward(self, inputs: Tensor) -> list[Tensor]:
+        """
+        If self.return_sequence is True: return patch sequence directly in the format [B, N, C] to be passed to transformer heads
+        If self.return sequence is False: convert patch-level embeddings to feature map to be passed to the classic heads
+        """
         x = self.backbone.get_intermediate_layers(inputs, n=1)[0]
 
-        if self.return_sequence:  # return patch sequence directly
+        if self.return_sequence:  #
             return [x]
 
         B, N, C = x.shape

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -67,7 +67,7 @@ class DinoV3(BaseNode):
         """
         x = self.backbone.get_intermediate_layers(inputs, n=1)[0]
 
-        if self.return_sequence:  #
+        if self.return_sequence:
             return [x]
 
         B, N, C = x.shape

--- a/luxonis_train/nodes/backbones/dinov3.py
+++ b/luxonis_train/nodes/backbones/dinov3.py
@@ -51,7 +51,7 @@ class DinoV3(BaseNode):
             weights_url = None
 
         self.backbone = self._get_backbone(
-            variant=self.variant,
+            variant=variant,
             weights=weights_url,
             repo_dir=repo_dir,
             **kwargs

--- a/luxonis_train/nodes/heads/__init__.py
+++ b/luxonis_train/nodes/heads/__init__.py
@@ -11,6 +11,8 @@ from .ocr_ctc_head import OCRCTCHead
 from .precision_bbox_head import PrecisionBBoxHead
 from .precision_seg_bbox_head import PrecisionSegmentBBoxHead
 from .segmentation_head import SegmentationHead
+from .transformer_classification_head import TransformerClassificationHead
+from .transformer_segmentation_head import TransformerSegmentationHead
 
 __all__ = [
     "BaseHead",
@@ -26,4 +28,6 @@ __all__ = [
     "PrecisionBBoxHead",
     "PrecisionSegmentBBoxHead",
     "SegmentationHead",
+    "TransformerClassificationHead",
+    "TransformerSegmentationHead"
 ]

--- a/luxonis_train/nodes/heads/transformer_classification_head.py
+++ b/luxonis_train/nodes/heads/transformer_classification_head.py
@@ -1,6 +1,7 @@
 from luxonis_ml.typing import Params
 from torch import Tensor, nn
 from typing_extensions import override
+from loguru import logger
 
 from luxonis_train.nodes.heads import BaseHead
 from luxonis_train.tasks import Tasks
@@ -23,6 +24,9 @@ class TransformerClassificationHead(BaseHead):
 
         self.dropout = nn.Dropout(dropout_rate)
         self.fc = nn.Linear(self.in_channels, self.n_classes)
+
+        if len(self.input_shapes[0]['features']) == 4:
+            logger.warning("The transformer segmentation head will not work with feature maps of dimension [B, C, H, W] as input. Please provide patch-level embeddings from transformer backbones in the format [B, C, N]")
 
     @property
     def in_channels(self) -> int:

--- a/luxonis_train/nodes/heads/transformer_classification_head.py
+++ b/luxonis_train/nodes/heads/transformer_classification_head.py
@@ -1,0 +1,59 @@
+from luxonis_ml.typing import Params
+from torch import Tensor, nn
+from typing_extensions import override
+
+from luxonis_train.nodes.heads import BaseHead
+from luxonis_train.tasks import Tasks
+
+
+class TransformerClassificationHead(BaseHead):
+    task = Tasks.CLASSIFICATION
+    parser: str = "ClassificationParser"
+
+    def __init__(self, dropout_rate: float = 0.2, use_cls_token: bool = False, **kwargs):
+        """
+        Classification head for transformer patch embeddings.
+
+        @param dropout_rate: Dropout rate before last layer.
+        @param use_cls_token: If True, use the first token (CLS token)
+                              instead of pooling across patches.
+        """
+        super().__init__(**kwargs)
+        self.use_cls_token = use_cls_token
+
+        self.dropout = nn.Dropout(dropout_rate)
+        self.fc = nn.Linear(self.in_channels, self.n_classes)
+
+    @property
+    def in_channels(self) -> int:
+        """
+        Override to extract embedding dim from transformer output shape.
+        Expected input_shapes: [{'features': [torch.Size([B, N, C])]}]
+        """
+        try:
+            shape_dict = self.input_shapes[0]
+            feature_shape = shape_dict["features"][0]
+
+            return feature_shape[-1]
+        except Exception as e:
+            raise RuntimeError(f"Could not determine in_channels from input_shapes: {self.input_shapes} — {e}")
+
+    def forward(self, inputs: Tensor) -> Tensor:
+        """
+        Args:
+            inputs: Patch embeddings of shape [B, N_patches, C]
+        Returns:
+            Class logits of shape [B, n_classes]
+        """
+        if self.use_cls_token:
+            x = inputs[:, 0]  # [B, C]
+        else:
+            x = inputs.mean(dim=1)
+
+        x = self.dropout(x)
+        x = self.fc(x)
+        return x
+
+    @override
+    def get_custom_head_config(self) -> Params:
+        return {"is_softmax": False}

--- a/luxonis_train/nodes/heads/transformer_classification_head.py
+++ b/luxonis_train/nodes/heads/transformer_classification_head.py
@@ -26,7 +26,8 @@ class TransformerClassificationHead(BaseHead):
         self.fc = nn.Linear(self.in_channels, self.n_classes)
 
         if len(self.input_shapes[0]['features']) == 4:
-            logger.warning("The transformer segmentation head will not work with feature maps of dimension [B, C, H, W] as input. Please provide patch-level embeddings from transformer backbones in the format [B, C, N]")
+            logger.warning(
+                "The transformer segmentation head will not work with feature maps of dimension [B, C, H, W] as input. Please provide patch-level embeddings from transformer backbones in the format [B, C, N]")
 
     @property
     def in_channels(self) -> int:

--- a/luxonis_train/nodes/heads/transformer_classification_head.py
+++ b/luxonis_train/nodes/heads/transformer_classification_head.py
@@ -46,7 +46,7 @@ class TransformerClassificationHead(BaseHead):
             Class logits of shape [B, n_classes]
         """
         if self.use_cls_token:
-            x = inputs[:, 0]  # [B, C]
+            x = inputs[:, 0]
         else:
             x = inputs.mean(dim=1)
 

--- a/luxonis_train/nodes/heads/transformer_segmentation_head.py
+++ b/luxonis_train/nodes/heads/transformer_segmentation_head.py
@@ -60,13 +60,12 @@ class TransformerSegmentationHead(BaseNode):
             5) Upsample to original image resolution
         """
         B, N, C = x.shape
+        h, w = self.original_in_shape[1:]
 
         x = self.head(x)
 
-        h, w = self.original_in_shape[1:]  # Original input image size
-
         aspect_ratio = w / h
-        H_p = int(round((N / aspect_ratio) ** 0.5))
+        H_p = int(round((N / aspect_ratio) ** 0.5)) # note: for now it seems like I cannot export a model that ues round() to ONNX
         W_p = N // H_p
         assert H_p * W_p == N, f"Cannot reshape: N={N}, inferred H_p={H_p}, W_p={W_p}, product={H_p * W_p}"
 

--- a/luxonis_train/nodes/heads/transformer_segmentation_head.py
+++ b/luxonis_train/nodes/heads/transformer_segmentation_head.py
@@ -1,0 +1,82 @@
+import torch
+import torch.nn as nn
+from torch import Tensor
+from typing import Any, Optional, Tuple
+from typing_extensions import override
+
+from luxonis_ml.typing import Params
+from luxonis_train.nodes.heads import BaseHead
+from luxonis_train.tasks import Tasks
+
+import torch.nn.functional as F
+
+
+class TransformerSegmentationHead(BaseNode):
+    in_height: int
+    in_width: int
+    in_channels: int
+    n_classes: int
+
+    task = Tasks.SEGMENTATION
+    parser: str = "SegmentationParser"
+
+    def __init__(self, **kwargs: Any):
+        """
+        Decoder head for patch sequence from DINOv3.
+        Converts [B, N, C] to segmentation map [B, n_classes, H, W]
+        """
+        super().__init__(**kwargs)
+        self.head = nn.Sequential(
+            nn.LayerNorm(self.in_channels),
+            nn.Linear(self.in_channels, self.n_classes),
+        )
+
+    @property
+    def in_channels(self) -> int:
+        """
+        Override to extract embedding dim from transformer output shape.
+        Expected input_shapes: [{'features': [torch.Size([B, N, C])]}]
+        """
+        try:
+            shape_dict = self.input_shapes[0]
+            feature_shape = shape_dict["features"][0]
+
+            return feature_shape[-1]
+        except Exception as e:
+            raise RuntimeError(f"Could not determine in_channels from input_shapes: {self.input_shapes} — {e}")
+
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        Args:
+            x: [B, N, C] = patch tokens
+        Returns:
+            Segmentation logits: [B, n_classes, H, W]
+
+        Steps:
+            1) Pass through LayerNorm to normalize the features then a Linear layer to map embedding size C to number of classes
+            2) Get original image input size
+            3) Infer patch grid dimensions H_p x W_p
+            4) Reshape patch sequence into 2d grids
+            5) Upsample to original image resolution
+        """
+        B, N, C = x.shape
+
+        x = self.head(x)
+
+        h, w = self.original_in_shape[1:]  # Original input image size
+
+        aspect_ratio = w / h
+        H_p = int(round((N / aspect_ratio) ** 0.5))
+        W_p = N // H_p
+        assert H_p * W_p == N, f"Cannot reshape: N={N}, inferred H_p={H_p}, W_p={W_p}, product={H_p * W_p}"
+
+        # Reshape to image grid: [B, n_classes, H_p, W_p]
+        x = x.permute(0, 2, 1).reshape(B, self.n_classes, H_p, W_p)
+
+        # Upsample to match original input image size
+        x = F.interpolate(x, size=(h, w), mode="bilinear", align_corners=False)
+        return x
+
+    @override
+    def get_custom_head_config(self) -> dict:
+        return {"is_softmax": False}

--- a/luxonis_train/nodes/heads/transformer_segmentation_head.py
+++ b/luxonis_train/nodes/heads/transformer_segmentation_head.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 from torch import Tensor
 from typing import Any, Optional, Tuple
 from typing_extensions import override
+from loguru import logger
 
 from luxonis_ml.typing import Params
 from luxonis_train.nodes.heads import BaseHead
@@ -30,6 +31,13 @@ class TransformerSegmentationHead(BaseNode):
             nn.LayerNorm(self.in_channels),
             nn.Linear(self.in_channels, self.n_classes),
         )
+
+        if len(self.input_shapes[0]['features']) == 4:
+            logger.warning(
+                "The transformer segmentation head will not work with feature maps of dimension [B, C, H, W] as input. Please provide patch-level embeddings from transformer backbones in the format [B, C, N]")
+
+        logger.warning(
+            "In order to accurately calculate the patch size, this class assumes that the CLS token is in the given patch embeddings. Please make sure that the previously-defined transformer encoder does not remove the CLS token.")
 
     @property
     def in_channels(self) -> int:

--- a/luxonis_train/nodes/heads/transformer_segmentation_head.py
+++ b/luxonis_train/nodes/heads/transformer_segmentation_head.py
@@ -69,10 +69,8 @@ class TransformerSegmentationHead(BaseNode):
         W_p = N // H_p
         assert H_p * W_p == N, f"Cannot reshape: N={N}, inferred H_p={H_p}, W_p={W_p}, product={H_p * W_p}"
 
-        # Reshape to image grid: [B, n_classes, H_p, W_p]
         x = x.permute(0, 2, 1).reshape(B, self.n_classes, H_p, W_p)
 
-        # Upsample to match original input image size
         x = F.interpolate(x, size=(h, w), mode="bilinear", align_corners=False)
         return x
 


### PR DESCRIPTION
## Purpose
To make transformer backbones and heads available in RVC4 devices. In this case this is done using the DinoV3 encoder.

## Specification
None / not applicable

## Dependencies & Potential Impact
Uses Opset 16 instead of Opset 12 for exporting to ONNX.

## Deployment Plan
None / not applicable

## Testing & Validation
Tested:
- DinoV3 encoder with traditional classification and transformer classification heads on the bean classification dataset
- DinoV3 encoder with traditional classification and transformer segmentation heads on the leaf segmentation dataset

On both square images and non-square images