### PR TITLE
Map predefined per_class_metrics to metric-specific kwargs

### DIFF
--- a/luxonis_train/attached_modules/metrics/README.md
+++ b/luxonis_train/attached_modules/metrics/README.md
@@ -10,6 +10,7 @@ List of all the available metrics.
 
 - [Accuracy](#accuracy)
 - [JaccardIndex](#jaccardindex)
+- [MIoU](#miou)
 - [F1Score](#f1score)
 - [Precision](#precision)
 - [Recall](#recall)
@@ -31,6 +32,21 @@ Works with tasks such as **classification, segmentation, and anomaly detection.*
 Jaccard Index (Intersection over Union) metric from the [`torchmetrics`](https://lightning.ai/docs/torchmetrics/stable/classification/jaccard_index.html) module.
 
 Works with tasks such as **classification, segmentation, and anomaly detection.**
+
+## MIoU
+
+Mean Intersection over Union metric from the [`torchmetrics`](https://lightning.ai/docs/torchmetrics/stable/segmentation/mean_iou.html) module.
+
+Works with **segmentation tasks.**
+
+**Params**
+
+| Key                  | Type                          | Default value | Description                                                    |
+| -------------------- | ----------------------------- | ------------- | -------------------------------------------------------------- |
+| `num_classes`        | `int`                         | required      | Number of classes                                              |
+| `include_background` | `bool`                        | `True`        | Whether to include the background class in the IoU computation |
+| `per_class`          | `bool`                        | `False`       | Whether to return IoU values for individual classes            |
+| `input_format`       | `Literal["one-hot", "index"]` | `"index"`     | Format of the input predictions and targets                    |
 
 ## F1Score
 

--- a/luxonis_train/attached_modules/metrics/base_metric.py
+++ b/luxonis_train/attached_modules/metrics/base_metric.py
@@ -6,6 +6,7 @@ from inspect import Parameter
 from types import EllipsisType
 from typing import (
     Annotated,
+    ClassVar,
     Literal,
     get_args,
     get_origin,
@@ -19,6 +20,7 @@ from torchmetrics import Metric
 
 from luxonis_train.attached_modules import BaseAttachedModule
 from luxonis_train.registry import METRICS
+from luxonis_train.tasks import Task
 from luxonis_train.typing import Labels, Packet, get_signature
 
 
@@ -87,6 +89,14 @@ class BaseMetric(BaseAttachedModule, Metric, register=False, registry=METRICS):
     automatic registration of defined subclasses to a L{METRICS}
     registry.
     """
+
+    predefined_model_params_aliases: ClassVar[dict[str, str]] = {}
+
+    @classmethod
+    def get_predefined_model_params_aliases(
+        cls, task: Task | None = None
+    ) -> dict[str, str]:
+        return cls.predefined_model_params_aliases
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/luxonis_train/attached_modules/metrics/mean_average_precision/mean_average_precision.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision/mean_average_precision.py
@@ -1,6 +1,6 @@
 from luxonis_train.nodes import BaseNode
 from luxonis_train.registry import METRICS
-from luxonis_train.tasks import Tasks
+from luxonis_train.tasks import Task, Tasks
 
 from .mean_average_precision_bbox import MeanAveragePrecisionBBox
 from .mean_average_precision_keypoints import MeanAveragePrecisionKeypoints
@@ -15,6 +15,14 @@ class MeanAveragePrecision:
 
     Creates the appropriate mAP metric based on the task of the node.
     """
+
+    @classmethod
+    def get_predefined_model_params_aliases(
+        cls, task: Task | None = None
+    ) -> dict[str, str]:
+        if task in {Tasks.BOUNDINGBOX, Tasks.INSTANCE_SEGMENTATION}:
+            return {"per_class_metrics": "class_metrics"}
+        return {}
 
     def __new__(
         cls, node: BaseNode, **kwargs

--- a/luxonis_train/attached_modules/metrics/mean_iou.py
+++ b/luxonis_train/attached_modules/metrics/mean_iou.py
@@ -37,6 +37,7 @@ class MIoU(BaseMetric):
         """
         super().__init__(**kwargs)
         self.input_format = input_format
+        self.per_class = per_class
         self.metric = MeanIoU(
             num_classes=num_classes,
             include_background=include_background,
@@ -69,7 +70,7 @@ class MIoU(BaseMetric):
 
     def compute(self) -> Tensor | tuple[Tensor, dict[str, Tensor]]:
         x = self.metric.compute()
-        if x.ndim == 0 or x.numel() == 1:
+        if not self.per_class or x.ndim == 0 or x.numel() == 1:
             return x
 
         class_names = {

--- a/luxonis_train/attached_modules/metrics/mean_iou.py
+++ b/luxonis_train/attached_modules/metrics/mean_iou.py
@@ -67,8 +67,19 @@ class MIoU(BaseMetric):
 
         self.metric.update(converted_preds, converted_target)
 
-    def compute(self) -> Tensor:
-        return self.metric.compute()
+    def compute(self) -> Tensor | tuple[Tensor, dict[str, Tensor]]:
+        x = self.metric.compute()
+        if x.ndim == 0 or x.numel() == 1:
+            return x
+
+        class_names = {
+            class_idx: class_name
+            for class_name, class_idx in self.classes.items()
+        }
+
+        return x.mean(), {
+            f"{self.name}_{class_names[i]}": x[i] for i in range(x.numel())
+        }
 
     def reset(self) -> None:
         self.metric.reset()

--- a/luxonis_train/attached_modules/metrics/mean_iou.py
+++ b/luxonis_train/attached_modules/metrics/mean_iou.py
@@ -37,6 +37,7 @@ class MIoU(BaseMetric):
         """
         super().__init__(**kwargs)
         self.input_format = input_format
+        self.include_background = include_background
         self.per_class = per_class
         self.metric = MeanIoU(
             num_classes=num_classes,
@@ -73,13 +74,18 @@ class MIoU(BaseMetric):
         if not self.per_class or x.ndim == 0 or x.numel() == 1:
             return x
 
-        class_names = {
-            class_idx: class_name
-            for class_name, class_idx in self.classes.items()
-        }
+        class_names = [
+            class_name
+            for class_name, _ in sorted(
+                self.classes.items(), key=lambda item: item[1]
+            )
+        ]
+        if not self.include_background:
+            class_names = class_names[1:]
 
         return x.mean(), {
-            f"{self.name}_{class_names[i]}": x[i] for i in range(x.numel())
+            f"{self.name}_{class_name}": value
+            for class_name, value in zip(class_names, x, strict=True)
         }
 
     def reset(self) -> None:

--- a/luxonis_train/attached_modules/metrics/mean_iou.py
+++ b/luxonis_train/attached_modules/metrics/mean_iou.py
@@ -13,6 +13,7 @@ class MIoU(BaseMetric):
     """Mean IoU metric for SEGMENTATION tasks."""
 
     supported_tasks = [Tasks.SEGMENTATION]
+    predefined_model_params_aliases = {"per_class_metrics": "per_class"}
 
     def __init__(
         self,

--- a/luxonis_train/config/predefined_models/README.md
+++ b/luxonis_train/config/predefined_models/README.md
@@ -114,7 +114,7 @@ FPS (frames per second) for `light`, `medium` and `heavy` variants on different 
 | `loss_params`       | `dict`                                | `{}`             | Additional parameters to the loss                                                                  |
 | `visualizer_params` | `dict`                                | `{}`             | Additional parameters to the visualizer                                                            |
 | `task_name`         | `str \| None`                         | `None`           | Custom task name for the head                                                                      |
-| `per_class_metrics` | `bool`                                | `True`           | Whether to calculate class-specific mAP                                                            |
+| `per_class_metrics` | `bool`                                | `False`          | Whether to calculate and display class-specific mAP metrics                                        |
 
 ## `KeypointDetectionModel`
 
@@ -281,7 +281,7 @@ FPS (frames per second) for `light`, `medium` and `heavy` variants on different 
 | `loss_params`       | `dict`                                | `{}`             | Additional parameters to the loss function                                                                                           |
 | `visualizer_params` | `dict`                                | `{}`             | Additional parameters to the visualizer                                                                                              |
 | `task_name`         | `str \| None`                         | `None`           | Custom task name for the head                                                                                                        |
-| `per_class_metrics` | `bool`                                | `True`           | Whether to calculate class-specific mAP                                                                                              |
+| `per_class_metrics` | `bool`                                | `False`          | Whether to calculate and display class-specific mAP metrics                                                                          |
 
 ## `AnomalyDetectionModel`
 

--- a/luxonis_train/config/predefined_models/base_predefined_model.py
+++ b/luxonis_train/config/predefined_models/base_predefined_model.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import Literal
 
+from loguru import logger
 from luxonis_ml.typing import Kwargs, Params, check_type
 from typeguard import typechecked
 from typing_extensions import override
@@ -12,7 +13,7 @@ from luxonis_train.config import (
     NodeConfig,
 )
 from luxonis_train.config.config import FreezingConfig
-from luxonis_train.registry import MODELS
+from luxonis_train.registry import METRICS, MODELS, NODES
 from luxonis_train.variants import VariantBase
 
 
@@ -125,12 +126,10 @@ class SimplePredefinedModel(BasePredefinedModel):
                 )
         self._main_metric = main_metric
         self._metrics_params = metrics_params or {}
+        self._per_class_metrics = per_class_metrics
 
         if torchmetrics_task is not None:
             self._metrics_params["torchmetrics_task"] = torchmetrics_task
-
-        if per_class_metrics is not None:
-            self._metrics_params["class_metrics"] = per_class_metrics
 
         self._visualizer = visualizer
         self._visualizer_params = visualizer_params or {}
@@ -145,6 +144,39 @@ class SimplePredefinedModel(BasePredefinedModel):
     @property
     @override
     def nodes(self) -> list[NodeConfig]:
+        task = NODES.get(self._head).task
+        metrics = []
+        applied_per_class_override = False
+
+        for metric in self._metrics:
+            metric_params = dict(self._metrics_params)
+            if self._per_class_metrics is not None:
+                metric_cls = METRICS.get(metric)
+                aliases = metric_cls.get_predefined_model_params_aliases(task)
+                param_name = aliases.get("per_class_metrics")
+                if param_name is not None:
+                    metric_params[param_name] = self._per_class_metrics
+                    applied_per_class_override = True
+
+            metrics.append(
+                MetricModuleConfig(
+                    name=metric,
+                    params=metric_params,
+                    is_main_metric=metric == self._main_metric,
+                )
+            )
+
+        if (
+            self._per_class_metrics is not None
+            and self._metrics
+            and not applied_per_class_override
+        ):
+            logger.warning(
+                "Ignoring `per_class_metrics` for predefined model metrics "
+                f"{self._metrics} because none of them support a per-class "
+                "override."
+            )
+
         nodes = [
             NodeConfig(
                 name=self._backbone,
@@ -182,14 +214,7 @@ class SimplePredefinedModel(BasePredefinedModel):
                         weight=1.0,
                     )
                 ],
-                metrics=[
-                    MetricModuleConfig(
-                        name=metric,
-                        params=self._metrics_params,
-                        is_main_metric=metric == self._main_metric,
-                    )
-                    for metric in self._metrics
-                ]
+                metrics=metrics
                 + (
                     [
                         MetricModuleConfig(

--- a/luxonis_train/config/predefined_models/base_predefined_model.py
+++ b/luxonis_train/config/predefined_models/base_predefined_model.py
@@ -141,47 +141,6 @@ class SimplePredefinedModel(BasePredefinedModel):
         )
         self._confusion_matrix_params = confusion_matrix_params or {}
 
-    def _generate_metrics(self) -> list[MetricModuleConfig]:
-        if self._per_class_metrics is None:
-            return [
-                MetricModuleConfig(
-                    name=metric,
-                    params=self._metrics_params,
-                    is_main_metric=metric == self._main_metric,
-                )
-                for metric in self._metrics
-            ]
-
-        task = NODES.get(self._head).task
-        metrics = []
-        applied_per_class_override = False
-
-        for metric in self._metrics:
-            metric_params = dict(self._metrics_params)
-            metric_cls = METRICS.get(metric)
-            aliases = metric_cls.get_predefined_model_params_aliases(task)
-            param_name = aliases.get("per_class_metrics")
-            if param_name is not None:
-                metric_params[param_name] = self._per_class_metrics
-                applied_per_class_override = True
-
-            metrics.append(
-                MetricModuleConfig(
-                    name=metric,
-                    params=metric_params,
-                    is_main_metric=metric == self._main_metric,
-                )
-            )
-
-        if self._metrics and not applied_per_class_override:
-            logger.warning(
-                "Ignoring `per_class_metrics` for predefined model metrics "
-                f"{self._metrics} because none of them support a per-class "
-                "override."
-            )
-
-        return metrics
-
     @property
     @override
     def nodes(self) -> list[NodeConfig]:
@@ -247,3 +206,44 @@ class SimplePredefinedModel(BasePredefinedModel):
             )
         )
         return nodes
+
+    def _generate_metrics(self) -> list[MetricModuleConfig]:
+        if self._per_class_metrics is None:
+            return [
+                MetricModuleConfig(
+                    name=metric,
+                    params=self._metrics_params,
+                    is_main_metric=metric == self._main_metric,
+                )
+                for metric in self._metrics
+            ]
+
+        task = NODES.get(self._head).task
+        metrics = []
+        applied_per_class_override = False
+
+        for metric in self._metrics:
+            metric_params = dict(self._metrics_params)
+            metric_cls = METRICS.get(metric)
+            aliases = metric_cls.get_predefined_model_params_aliases(task)
+            param_name = aliases.get("per_class_metrics")
+            if param_name is not None:
+                metric_params[param_name] = self._per_class_metrics
+                applied_per_class_override = True
+
+            metrics.append(
+                MetricModuleConfig(
+                    name=metric,
+                    params=metric_params,
+                    is_main_metric=metric == self._main_metric,
+                )
+            )
+
+        if self._metrics and not applied_per_class_override:
+            logger.warning(
+                "Ignoring `per_class_metrics` for predefined model metrics "
+                f"{self._metrics} because none of them support a per-class "
+                "override."
+            )
+
+        return metrics

--- a/luxonis_train/config/predefined_models/base_predefined_model.py
+++ b/luxonis_train/config/predefined_models/base_predefined_model.py
@@ -141,22 +141,29 @@ class SimplePredefinedModel(BasePredefinedModel):
         )
         self._confusion_matrix_params = confusion_matrix_params or {}
 
-    @property
-    @override
-    def nodes(self) -> list[NodeConfig]:
+    def _generate_metrics(self) -> list[MetricModuleConfig]:
+        if self._per_class_metrics is None:
+            return [
+                MetricModuleConfig(
+                    name=metric,
+                    params=self._metrics_params,
+                    is_main_metric=metric == self._main_metric,
+                )
+                for metric in self._metrics
+            ]
+
         task = NODES.get(self._head).task
         metrics = []
         applied_per_class_override = False
 
         for metric in self._metrics:
             metric_params = dict(self._metrics_params)
-            if self._per_class_metrics is not None:
-                metric_cls = METRICS.get(metric)
-                aliases = metric_cls.get_predefined_model_params_aliases(task)
-                param_name = aliases.get("per_class_metrics")
-                if param_name is not None:
-                    metric_params[param_name] = self._per_class_metrics
-                    applied_per_class_override = True
+            metric_cls = METRICS.get(metric)
+            aliases = metric_cls.get_predefined_model_params_aliases(task)
+            param_name = aliases.get("per_class_metrics")
+            if param_name is not None:
+                metric_params[param_name] = self._per_class_metrics
+                applied_per_class_override = True
 
             metrics.append(
                 MetricModuleConfig(
@@ -166,16 +173,19 @@ class SimplePredefinedModel(BasePredefinedModel):
                 )
             )
 
-        if (
-            self._per_class_metrics is not None
-            and self._metrics
-            and not applied_per_class_override
-        ):
+        if self._metrics and not applied_per_class_override:
             logger.warning(
                 "Ignoring `per_class_metrics` for predefined model metrics "
                 f"{self._metrics} because none of them support a per-class "
                 "override."
             )
+
+        return metrics
+
+    @property
+    @override
+    def nodes(self) -> list[NodeConfig]:
+        metrics = self._generate_metrics()
 
         nodes = [
             NodeConfig(

--- a/tests/unittests/test_metrics/test_segmentation_metrics.py
+++ b/tests/unittests/test_metrics/test_segmentation_metrics.py
@@ -114,6 +114,7 @@ def test_dice_coefficient_one_hot(
 
     metric.update(predictions, targets)
     result = metric.compute()
+    assert isinstance(result, Tensor)
     assert torch.isclose(result, expected, atol=1e-4), (
         f"Expected {expected}, got {result}"
     )
@@ -182,6 +183,7 @@ def test_dice_coefficient_index(
 
     metric.update(predictions, targets)
     result = metric.compute()
+    assert isinstance(result, Tensor)
     assert torch.isclose(result, expected, atol=1e-4), (
         f"Expected {expected}, got {result}"
     )
@@ -320,6 +322,7 @@ def test_dice_coefficient_background(
 
     metric.update(predictions, targets)
     result = metric.compute()
+    assert isinstance(result, Tensor)
     assert torch.isclose(result, expected, atol=1e-4), (
         f"Expected {expected}, got {result}"
     )
@@ -389,6 +392,7 @@ def test_mean_iou_one_hot(
 
     metric.update(predictions, targets)
     result = metric.compute()
+    assert isinstance(result, Tensor)
     assert torch.isclose(result, expected, atol=1e-4), (
         f"Expected {expected}, got {result}"
     )
@@ -456,6 +460,7 @@ def test_mean_iou_index(
 
     metric.update(predictions, targets)
     result = metric.compute()
+    assert isinstance(result, Tensor)
     assert torch.isclose(result, expected, atol=1e-4), (
         f"Expected {expected}, got {result}"
     )
@@ -513,6 +518,7 @@ def test_mean_iou_background(
 
     metric.update(predictions, targets)
     result = metric.compute()
+    assert isinstance(result, Tensor)
     assert torch.isclose(result, expected, atol=1e-4), (
         f"Expected {expected}, got {result}"
     )
@@ -636,6 +642,7 @@ def test_batch_updates():
     iou_metric.update(batch2_pred, batch2_target)
     iou_result = iou_metric.compute()
 
+    assert isinstance(iou_result, Tensor)
     assert torch.isclose(iou_result, torch.tensor(0.5), atol=1e-4)
 
 
@@ -709,4 +716,5 @@ def test_edge_cases(
 
     iou_metric.update(predictions, targets)
     iou_result = iou_metric.compute()
+    assert isinstance(iou_result, Tensor)
     assert torch.isclose(iou_result, expected_iou, atol=1e-4)

--- a/tests/unittests/test_metrics/test_segmentation_metrics.py
+++ b/tests/unittests/test_metrics/test_segmentation_metrics.py
@@ -588,6 +588,75 @@ def test_mean_iou_per_class(
     assert torch.allclose(result[1]["MIoU_vehicle"], expected[1], atol=1e-4)
 
 
+@pytest.mark.parametrize(
+    ("include_background", "expected_keys"),
+    [
+        (
+            True,
+            ("MIoU_background", "MIoU_vehicle", "MIoU_pedestrian"),
+        ),
+        (
+            False,
+            ("MIoU_vehicle", "MIoU_pedestrian"),
+        ),
+    ],
+)
+def test_mean_iou_per_class_metric_names_respect_background_setting(
+    include_background: bool, expected_keys: tuple[str, ...]
+):
+    predictions = torch.tensor(
+        [
+            [
+                [1.0, 0.0],
+                [1.0, 0.0],
+            ],
+            [
+                [0.0, 1.0],
+                [0.0, 0.0],
+            ],
+            [
+                [0.0, 0.0],
+                [0.0, 1.0],
+            ],
+        ]
+    ).unsqueeze(0)
+    targets = predictions.clone()
+
+    metric = MIoU(
+        num_classes=3,
+        include_background=include_background,
+        per_class=True,
+        input_format="one-hot",
+        node=DummyNodeSegmentation(
+            n_classes=3,
+            dataset_metadata=DatasetMetadata(
+                classes={
+                    "": {
+                        "background": 0,
+                        "vehicle": 1,
+                        "pedestrian": 2,
+                    }
+                }
+            ),
+        ),
+    )
+
+    metric.update(predictions, targets)
+    result = metric.compute()
+
+    assert isinstance(result, tuple)
+    assert metric.classes == {
+        "background": 0,
+        "vehicle": 1,
+        "pedestrian": 2,
+    }
+    assert torch.allclose(result[0], torch.tensor(1.0), atol=1e-4)
+    assert len(result[1]) == len(expected_keys)
+    assert tuple(result[1]) == expected_keys
+    for key in expected_keys:
+        assert torch.allclose(result[1][key], torch.tensor(1.0))
+
+
 def test_batch_updates():
     batch1_pred = torch.tensor(
         [

--- a/tests/unittests/test_metrics/test_segmentation_metrics.py
+++ b/tests/unittests/test_metrics/test_segmentation_metrics.py
@@ -10,6 +10,7 @@ from luxonis_train.attached_modules.metrics.dice_coefficient import (
 from luxonis_train.attached_modules.metrics.mean_iou import MIoU
 from luxonis_train.nodes import BaseNode
 from luxonis_train.tasks import Tasks
+from luxonis_train.utils.dataset_metadata import DatasetMetadata
 
 
 class DummyNodeSegmentation(BaseNode, register=False):
@@ -563,14 +564,22 @@ def test_mean_iou_per_class(
         include_background=True,
         per_class=True,
         input_format="one-hot",
-        node=DummyNodeSegmentation(n_classes=2),
+        node=DummyNodeSegmentation(
+            n_classes=2,
+            dataset_metadata=DatasetMetadata(
+                classes={"": {"background": 0, "vehicle": 1}}
+            ),
+        ),
     )
 
     metric.update(predictions, targets)
     result = metric.compute()
-    assert torch.allclose(result, expected, atol=1e-4), (
-        f"Expected {expected}, got {result}"
+    assert isinstance(result, tuple)
+    assert torch.allclose(result[0], expected.mean(), atol=1e-4), (
+        f"Expected mean {expected.mean()}, got {result[0]}"
     )
+    assert torch.allclose(result[1]["MIoU_background"], expected[0], atol=1e-4)
+    assert torch.allclose(result[1]["MIoU_vehicle"], expected[1], atol=1e-4)
 
 
 def test_batch_updates():


### PR DESCRIPTION
## Purpose
There are three metrics so far that consume `per_class_metrics`:
- `MeanAveragePrecision`: the Torchmetrics class has the `class_metrics` option for `MeanAveragePrecisionSegmentation` and `MeanAveragePrecisionBBox` (`MeanAveragePrecisionKeypoints` does not inherit from `Torchmetrics` or expose anything class-specific)
- `MIoU` exposes the equivalent `per_class`

The solution to some metrics having per-class metrics and some here is to add a `get_predefined_model_params_aliases` so metrics can declare how `per_class_metrics` should be forwarded. If no metric supports a per-class flag and the user is trying to override `per_class_metrics` then a warning is logged instead of crashing.

Additional metrics-related changes:

- fixes to the README (per_class_metrics was not by default True for segmentation and detection) and addition of `MIoU` (was missing from the README).
- When `per_class` is set to True (passed from `per_class_metrics`) MIoU returns the same main IoU and per-class submetrics

Example config with object detection:

```
model:
  name: detection_light
  predefined_model:
    name: DetectionModel
    variant: light
    params:
      per_class_metrics: true
      task_name: vehicles
      metrics_params:
      loss_params:
        iou_type: "siou"
        iou_loss_weight: 20
        class_loss_weight: 8
```

Result:

<img width="599" height="652" alt="per_class_detection" src="https://github.com/user-attachments/assets/4fd30fbe-d8ab-4503-b2ef-fa1a3a5ac9d3" />

Example config with classification (unsupported argument):

```
model:
  name: classification_light
  predefined_model:
    name: ClassificationModel
    variant: light
    params:
      per_class_metrics: true
      task_name: vehicles
```

Result:

<img width="1876" height="84" alt="classification" src="https://github.com/user-attachments/assets/7fc6a4d6-03d6-4dab-964e-d533f2f88854" />

Example config with segmentation:

```
model:
  name: segmentation_light
  predefined_model:
    name: SegmentationModel
    variant: light
    params:
      task_name: vehicles
      per_class_metrics: true
      metrics_params:
        num_classes: 3
```

Result:

<img width="423" height="299" alt="segmentation_metrics" src="https://github.com/user-attachments/assets/2b4a6c73-f70e-47a1-b563-b8aff18fe843" />

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
