### PR TITLE
Decode text and categorical metadata labels in inspect footer

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -134,6 +134,33 @@ def _yield_visualizations(
 
     from luxonis_train.utils.general import decode_text_metadata_labels
 
+    def get_visualization_item(
+        idx: int,
+    ) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+        raw_loader = getattr(loader, "loader", None)
+        if raw_loader is not None:
+            np_images, np_labels = raw_loader[idx]
+            if isinstance(np_images, np.ndarray):
+                np_images = {loader.image_source: np_images}
+
+            remap_keypoints = getattr(loader, "_remap_keypoints", None)
+            if (
+                getattr(loader, "kpts_mapping_per_task", None) is not None
+                and remap_keypoints is not None
+            ):
+                np_labels = remap_keypoints(np_labels)
+
+            return np_images, np_labels
+
+        images, labels = loader[idx]
+        return (
+            {
+                name: image.numpy().transpose(1, 2, 0)
+                for name, image in images.items()
+            },
+            {task: label.numpy() for task, label in labels.items()},
+        )
+
     opts = opts or []
     opts.extend(["trainer.preprocessing.normalize.active", "False"])
 
@@ -142,18 +169,13 @@ def _yield_visualizations(
     loader = model.loaders[view]
     metadata_types = loader.get_metadata_types()
     categorical_encodings = loader.get_categorical_encodings()
-    for images, labels in loader:
-        np_images = {
-            k: v.numpy().transpose(1, 2, 0) for k, v in images.items()
-        }
+    for idx in range(len(loader)):
+        np_images, np_labels = get_visualization_item(idx)
         main_image = np_images[loader.image_source]
         main_image = cv2.cvtColor(main_image, cv2.COLOR_RGB2BGR).astype(
             np.uint8
         )
-        np_labels = decode_text_metadata_labels(
-            {task: label.numpy() for task, label in labels.items()},
-            metadata_types,
-        )
+        np_labels = decode_text_metadata_labels(np_labels, metadata_types)
 
         h, w, _ = main_image.shape
         new_h, new_w = int(h * size_multiplier), int(w * size_multiplier)

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -132,12 +132,16 @@ def _yield_visualizations(
     import numpy as np
     from luxonis_ml.data.utils.visualizations import visualize
 
+    from luxonis_train.utils.general import decode_text_metadata_labels
+
     opts = opts or []
     opts.extend(["trainer.preprocessing.normalize.active", "False"])
 
     model = create_model(config, opts)
 
     loader = model.loaders[view]
+    metadata_types = loader.get_metadata_types()
+    categorical_encodings = loader.get_categorical_encodings()
     for images, labels in loader:
         np_images = {
             k: v.numpy().transpose(1, 2, 0) for k, v in images.items()
@@ -146,7 +150,10 @@ def _yield_visualizations(
         main_image = cv2.cvtColor(main_image, cv2.COLOR_RGB2BGR).astype(
             np.uint8
         )
-        np_labels = {task: label.numpy() for task, label in labels.items()}
+        np_labels = decode_text_metadata_labels(
+            {task: label.numpy() for task, label in labels.items()},
+            metadata_types,
+        )
 
         h, w, _ = main_image.shape
         new_h, new_w = int(h * size_multiplier), int(w * size_multiplier)
@@ -156,6 +163,7 @@ def _yield_visualizations(
             labels=np_labels,
             classes=loader.get_classes(),
             source_name=loader.image_source,
+            categorical_encodings=categorical_encodings,
         )
 
 

--- a/luxonis_train/loaders/base_loader.py
+++ b/luxonis_train/loaders/base_loader.py
@@ -271,6 +271,9 @@ class BaseLoaderTorch(
     ) -> dict[str, type[int] | type[Category] | type[float] | type[str]]:
         return {}
 
+    def get_categorical_encodings(self) -> dict[str, dict[str, int]]:
+        return {}
+
     def dict_numpy_to_torch(
         self, numpy_dictionary: dict[str, np.ndarray]
     ) -> dict[str, Tensor]:

--- a/luxonis_train/loaders/luxonis_loader_torch.py
+++ b/luxonis_train/loaders/luxonis_loader_torch.py
@@ -213,6 +213,10 @@ class LuxonisLoaderTorch(BaseLoaderTorch):
         }
 
     @override
+    def get_categorical_encodings(self) -> dict[str, dict[str, int]]:
+        return self.dataset.get_categorical_encodings()
+
+    @override
     def augment_test_image(self, img: dict[str, Tensor]) -> Tensor:
         if self.loader.augmentations is None:
             return img[self.image_source]

--- a/luxonis_train/utils/general.py
+++ b/luxonis_train/utils/general.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from pathlib import Path, PurePosixPath
 from typing import Any, TypeVar, overload
 
+import numpy as np
 import torch
 from loguru import logger
 from luxonis_ml.typing import PathType
@@ -340,6 +341,56 @@ def instances_from_batch(
                 get_batch_instances(i, bboxes, payload)
                 for payload in [None, *args]
             )
+
+
+def decode_text_metadata_labels(
+    labels: dict[str, np.ndarray],
+    metadata_types: dict[str, type],
+) -> dict[str, np.ndarray]:
+    """Decode text metadata labels from character-code arrays."""
+    decoded_labels: dict[str, np.ndarray] = {}
+
+    for task, label in labels.items():
+        if metadata_types.get(task) is not str:
+            decoded_labels[task] = label
+            continue
+
+        arr = np.asarray(label)
+        if arr.size == 0 or arr.dtype.kind in {"U", "S", "O"}:
+            decoded_labels[task] = arr
+            continue
+
+        decoded_values: list[str] = []
+        for row in np.atleast_2d(arr):
+            chars: list[str] = []
+            for value in np.asarray(row).reshape(-1):
+                if isinstance(value, np.generic):
+                    value = value.item()
+                if isinstance(value, float):
+                    if not value.is_integer():
+                        decoded_values = []
+                        break
+                    value = int(value)
+                elif not isinstance(value, int):
+                    decoded_values = []
+                    break
+
+                if value == 0:
+                    break
+                if value < 0:
+                    decoded_values = []
+                    break
+                chars.append(chr(value))
+
+            if not decoded_values and not chars and arr.size != 0:
+                break
+            decoded_values.append("".join(chars))
+
+        decoded_labels[task] = (
+            np.asarray(decoded_values) if decoded_values else arr
+        )
+
+    return decoded_labels
 
 
 class Counter:


### PR DESCRIPTION
## Purpose
- Match the shown `luxonis_train inspect --config ...` text to `luxonis-ml data inspect ...` display
- Previously `luxonis_train` inspect could pass text metadata as character-code arrays to the visualizer, and categorical metadata could be displayed as encoded integer ids instead of original labels
- This change only concerns the inspect/display behavior
- Other issue fixed in this PR: text metadata labels were truncated (only the first element was being shown). Here the fix is also only limited to `inspect`, make it use the raw numpy labels from the luxonis-ml loader for visualization

Examples before with `luxonis_train inspect --config ...`:

<img width="250" height="127" alt="previous_text" src="https://github.com/user-attachments/assets/85779658-6560-4047-87ca-9778cb68e2f3" />
<img width="791" height="420" alt="before_encoded" src="https://github.com/user-attachments/assets/d2e0f3b0-9776-4c64-83ec-406dac033460" />

Same examples after this change:

<img width="257" height="129" alt="after_decode_text" src="https://github.com/user-attachments/assets/c738dc6b-5039-4e98-8e21-d98392711109" />
<img width="793" height="420" alt="after_decode" src="https://github.com/user-attachments/assets/40c51fdc-f255-4e96-96de-03293fe1f065" />


## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
