### PR TITLE
Remove p == 1 override and note on new catching behavior in luxonis-ml

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -302,6 +302,9 @@ Additionally, we support `Mosaic4` and `MixUp` batch augmentations and letterbox
 > [!NOTE]
 > The VerticalFlip and HorizontalFlip transforms do not change keypoint index ordering. They can be safely used only when the dataset has no symmetrical classes (e.g., left arm vs. right arm).
 
+> [!NOTE]
+> When `use_for_resizing: true`, the augmentation `height` and `width` are normalized to `train_image_size`. If `p < 1`, the default resize is used for the remaining probability mass so that resizing still always occurs.
+
 **Example:**
 
 ```yaml

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -423,6 +423,7 @@ class PreprocessingConfig(BaseModelExtraForbid):
 
             aug_h = aug.params.get("height")
             aug_w = aug.params.get("width")
+            aug.params.setdefault("p", 1.0)
             if aug_h != train_h or aug_w != train_w:
                 logger.warning(
                     f"Augmentation '{aug.name}' is marked as 'use_for_resizing' "
@@ -433,16 +434,7 @@ class PreprocessingConfig(BaseModelExtraForbid):
             aug.params["height"] = train_h
             aug.params["width"] = train_w
 
-            aug_p = aug.params.get("p")
-            if aug_p != 1:
-                if aug_p is not None:
-                    logger.warning(
-                        f"Augmentation '{aug.name}' is marked as 'use_for_resizing' "
-                        f"but has p={aug_p}. Overriding to p=1."
-                    )
-                aug.params["p"] = 1
-
-            if self.keep_aspect_ratio:
+            if self.keep_aspect_ratio and aug.params["p"] == 1:
                 logger.warning(
                     f"Augmentation '{aug.name}' is marked as 'use_for_resizing'. "
                     f"The 'keep_aspect_ratio' preprocessing parameter is ignored "


### PR DESCRIPTION
## Purpose
- Allow for p < 1.0, now handled by [this corresponding PR in luxonis-ml](https://github.com/luxonis/luxonis-ml/pull/406)
- Other overrides are still there: for example we still warn and override if the height and width of the `use_for_resizing` augmentation are not equal to the `train_image_size` parameter

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
