### PR TITLE
`DatasetMetadata` loading from weights

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -16,7 +16,6 @@ from luxonis_train.upgrade import upgrade_config, upgrade_installation
 if TYPE_CHECKING:
     import numpy as np
 
-    from luxonis_train import LuxonisModel
 
 app = App(
     help="Luxonis Train CLI",
@@ -57,6 +56,8 @@ def train(
         suppresses some exceptions to allow training without a fully
         defined model.
     """
+    from luxonis_train import LuxonisModel
+
     LuxonisModel(config, opts, weights=weights, debug_mode=debug).train(
         weights=weights
     )
@@ -71,6 +72,8 @@ def tune(opts: list[str] | None = None, /, *, config: str | None = None):
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
+    from luxonis_train import LuxonisModel
+
     LuxonisModel(config, opts).tune()
 
 
@@ -85,6 +88,8 @@ def _yield_visualizations(
     import cv2
     import numpy as np
     from luxonis_ml.data.utils.visualizations import visualize
+
+    from luxonis_train import LuxonisModel
 
     opts = opts or []
     opts.extend(["trainer.preprocessing.normalize.active", "False"])
@@ -189,6 +194,8 @@ def test(
         suppresses some exceptions to allow training without a fully
         defined model.
     """
+    from luxonis_train import LuxonisModel
+
     LuxonisModel(config, opts, weights=weights, debug_mode=debug).test(
         view=view, weights=weights
     )
@@ -226,6 +233,8 @@ def infer(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
+    from luxonis_train import LuxonisModel
+
     LuxonisModel(config, opts, weights=weights, debug_mode=True).infer(
         view=view,
         save_dir=save_dir,
@@ -276,6 +285,8 @@ def annotate(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
+    from luxonis_train import LuxonisModel
+
     model = LuxonisModel(
         config,
         opts,
@@ -323,6 +334,8 @@ def export(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the
     """
+    from luxonis_train import LuxonisModel
+
     LuxonisModel(config, opts, weights=weights, debug_mode=True).export(
         save_path=save_path, weights=weights, ckpt_only=ckpt_only
     )
@@ -349,6 +362,8 @@ def archive(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
+    from luxonis_train import LuxonisModel
+
     LuxonisModel(str(config), opts, weights=weights).archive(
         path=executable, weights=weights
     )
@@ -379,6 +394,8 @@ def convert(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
+    from luxonis_train import LuxonisModel
+
     LuxonisModel(config, opts, weights=weights).convert(
         weights=weights, save_dir=save_dir
     )
@@ -441,6 +458,8 @@ def checkpoint(
     @param new: Where to save the upgraded checkpoint. If left empty,
         the old file will be overriden.
     """
+    from luxonis_train import LuxonisModel
+
     logger.info("Performing a full checkpoint upgrade.")
     model = LuxonisModel(config, opts, weights=path, debug_mode=True)
     model.lightning_module.load_checkpoint(path)

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -442,10 +442,7 @@ def checkpoint(
         the old file will be overriden.
     """
     logger.info("Performing a full checkpoint upgrade.")
-    cfg = None
-    if config is not None:
-        cfg = upgrade_config(config)
-    model = LuxonisModel(cfg, opts, weights=path, debug_mode=True)
+    model = LuxonisModel(config, opts, weights=path, debug_mode=True)
     model.lightning_module.load_checkpoint(path)
 
     # Needs to be called in order to attach the model to the trainer

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -1,6 +1,7 @@
 import importlib
 import importlib.util
 import json
+import sys
 from collections.abc import Iterator
 from functools import lru_cache
 from importlib.metadata import version
@@ -10,11 +11,14 @@ from typing import TYPE_CHECKING, Annotated, Literal
 import yaml
 from cyclopts import App, Group, Parameter, validators
 from loguru import logger
+from luxonis_ml.typing import Params, PathType
 
 from luxonis_train.upgrade import upgrade_config, upgrade_installation
 
 if TYPE_CHECKING:
     import numpy as np
+
+    from luxonis_train import LuxonisModel
 
 
 app = App(
@@ -32,6 +36,24 @@ evaluation_group = Group.create_ordered("Evaluation")
 export_group = Group.create_ordered("Export")
 annotation_group = Group.create_ordered("Annotation")
 management_group = Group.create_ordered("Management")
+
+
+def create_model(
+    config: PathType | Params | None,
+    opts: list[str] | None = None,
+    weights: PathType | None = None,
+    debug_mode: bool = False,
+) -> "LuxonisModel":
+    importlib.reload(sys.modules["luxonis_train"])
+
+    from luxonis_train import LuxonisModel
+
+    return LuxonisModel(
+        config,
+        opts,
+        weights=weights,
+        debug_mode=debug_mode,
+    )
 
 
 @app.command(group=training_group, sort_key=1)
@@ -56,9 +78,7 @@ def train(
         suppresses some exceptions to allow training without a fully
         defined model.
     """
-    from luxonis_train import LuxonisModel
-
-    LuxonisModel(config, opts, weights=weights, debug_mode=debug).train(
+    create_model(config, opts, weights=weights, debug_mode=debug).train(
         weights=weights
     )
 
@@ -72,9 +92,7 @@ def tune(opts: list[str] | None = None, /, *, config: str | None = None):
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    from luxonis_train import LuxonisModel
-
-    LuxonisModel(config, opts).tune()
+    create_model(config, opts).tune()
 
 
 def _yield_visualizations(
@@ -89,7 +107,6 @@ def _yield_visualizations(
     import numpy as np
     from luxonis_ml.data.utils.visualizations import visualize
 
-    from luxonis_train import LuxonisModel
     from luxonis_train.utils.general import decode_text_metadata_labels
 
     def get_visualization_item(
@@ -122,7 +139,7 @@ def _yield_visualizations(
     opts = opts or []
     opts.extend(["trainer.preprocessing.normalize.active", "False"])
 
-    model = LuxonisModel(config, opts)
+    model = create_model(config, opts)
 
     loader = model.loaders[view]
     metadata_types = loader.get_metadata_types()
@@ -223,9 +240,7 @@ def test(
         suppresses some exceptions to allow training without a fully
         defined model.
     """
-    from luxonis_train import LuxonisModel
-
-    LuxonisModel(config, opts, weights=weights, debug_mode=debug).test(
+    create_model(config, opts, weights=weights, debug_mode=debug).test(
         view=view, weights=weights
     )
 
@@ -262,9 +277,7 @@ def infer(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    from luxonis_train import LuxonisModel
-
-    LuxonisModel(config, opts, weights=weights, debug_mode=True).infer(
+    create_model(config, opts, weights=weights, debug_mode=True).infer(
         view=view,
         save_dir=save_dir,
         source_path=source_path,
@@ -314,14 +327,7 @@ def annotate(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    from luxonis_train import LuxonisModel
-
-    model = LuxonisModel(
-        config,
-        opts,
-        weights=weights,
-        debug_mode=debug,
-    )
+    model = create_model(config, opts, weights=weights, debug_mode=debug)
 
     model.annotate(
         dir_path=dir_path,
@@ -363,9 +369,7 @@ def export(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the
     """
-    from luxonis_train import LuxonisModel
-
-    LuxonisModel(config, opts, weights=weights, debug_mode=True).export(
+    create_model(config, opts, weights=weights, debug_mode=True).export(
         save_path=save_path, weights=weights, ckpt_only=ckpt_only
     )
 
@@ -391,9 +395,7 @@ def archive(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    from luxonis_train import LuxonisModel
-
-    LuxonisModel(str(config), opts, weights=weights).archive(
+    create_model(config, opts, weights=weights, debug_mode=True).archive(
         path=executable, weights=weights
     )
 
@@ -423,10 +425,8 @@ def convert(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    from luxonis_train import LuxonisModel
-
-    LuxonisModel(config, opts, weights=weights).convert(
-        weights=weights, save_dir=save_dir
+    create_model(config, opts, weights=weights, debug_mode=True).convert(
+        save_dir=save_dir, weights=weights
     )
 
 

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -1,7 +1,6 @@
 import importlib
 import importlib.util
 import json
-import sys
 from collections.abc import Iterator
 from functools import lru_cache
 from importlib.metadata import version
@@ -11,9 +10,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 import yaml
 from cyclopts import App, Group, Parameter, validators
 from loguru import logger
-from luxonis_ml.typing import Params, PathType
 
-from luxonis_train.config import Config
 from luxonis_train.upgrade import upgrade_config, upgrade_installation
 
 if TYPE_CHECKING:
@@ -38,49 +35,6 @@ annotation_group = Group.create_ordered("Annotation")
 management_group = Group.create_ordered("Management")
 
 
-def create_model(
-    config: PathType | Params | None,
-    opts: list[str] | None = None,
-    weights: PathType | None = None,
-    debug_mode: bool = False,
-    load_dataset_metadata: bool = True,
-) -> "LuxonisModel":
-    importlib.reload(sys.modules["luxonis_train"])
-    import torch
-
-    from luxonis_train import LuxonisModel
-    from luxonis_train.utils.dataset_metadata import DatasetMetadata
-
-    if weights is not None and config is None:
-        ckpt = torch.load(weights, map_location="cpu")  # nosemgre
-        if "config" not in ckpt:  # pragma: no cover
-            raise ValueError(
-                f"Checkpoint '{weights}' does not contain the 'config' key. "
-                "Cannot restore `LuxonisModel` from checkpoint."
-            )
-        cfg = Config.get_config(upgrade_config(ckpt["config"]), opts)
-        dataset_metadata = None
-        if load_dataset_metadata:
-            if "dataset_metadata" not in ckpt:
-                logger.error("Checkpoint does not contain dataset metadata.")
-            else:
-                try:
-                    dataset_metadata = DatasetMetadata(
-                        **ckpt["dataset_metadata"]
-                    )
-                except Exception as e:  # pragma: no cover
-                    logger.error(
-                        "Failed to load dataset metadata from the checkpoint. "
-                        f"Error: {e}"
-                    )
-
-        return LuxonisModel(
-            cfg, debug_mode=debug_mode, dataset_metadata=dataset_metadata
-        )
-
-    return LuxonisModel(config, opts, debug_mode=debug_mode)
-
-
 @app.command(group=training_group, sort_key=1)
 def train(
     opts: list[str] | None = None,
@@ -103,7 +57,7 @@ def train(
         suppresses some exceptions to allow training without a fully
         defined model.
     """
-    create_model(config, opts, weights, debug_mode=debug).train(
+    LuxonisModel(config, opts, weights=weights, debug_mode=debug).train(
         weights=weights
     )
 
@@ -117,7 +71,7 @@ def tune(opts: list[str] | None = None, /, *, config: str | None = None):
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    create_model(config, opts).tune()
+    LuxonisModel(config, opts).tune()
 
 
 def _yield_visualizations(
@@ -135,7 +89,7 @@ def _yield_visualizations(
     opts = opts or []
     opts.extend(["trainer.preprocessing.normalize.active", "False"])
 
-    model = create_model(config, opts)
+    model = LuxonisModel(config, opts)
 
     loader = model.loaders[view]
     for images, labels in loader:
@@ -235,7 +189,7 @@ def test(
         suppresses some exceptions to allow training without a fully
         defined model.
     """
-    create_model(config, opts, weights, debug_mode=debug).test(
+    LuxonisModel(config, opts, weights=weights, debug_mode=debug).test(
         view=view, weights=weights
     )
 
@@ -272,7 +226,7 @@ def infer(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    create_model(config, opts, weights=weights, debug_mode=True).infer(
+    LuxonisModel(config, opts, weights=weights, debug_mode=True).infer(
         view=view,
         save_dir=save_dir,
         source_path=source_path,
@@ -322,11 +276,10 @@ def annotate(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    model = create_model(
+    model = LuxonisModel(
         config,
         opts,
         weights=weights,
-        load_dataset_metadata=True,
         debug_mode=debug,
     )
 
@@ -370,7 +323,7 @@ def export(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the
     """
-    create_model(config, opts, weights=weights, debug_mode=True).export(
+    LuxonisModel(config, opts, weights=weights, debug_mode=True).export(
         save_path=save_path, weights=weights, ckpt_only=ckpt_only
     )
 
@@ -396,7 +349,7 @@ def archive(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    create_model(str(config), opts, weights=weights).archive(
+    LuxonisModel(str(config), opts, weights=weights).archive(
         path=executable, weights=weights
     )
 
@@ -426,7 +379,7 @@ def convert(
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
-    create_model(config, opts, weights=weights).convert(
+    LuxonisModel(config, opts, weights=weights).convert(
         weights=weights, save_dir=save_dir
     )
 
@@ -492,7 +445,7 @@ def checkpoint(
     cfg = None
     if config is not None:
         cfg = upgrade_config(config)
-    model = create_model(config=cfg, weights=path, opts=opts, debug_mode=True)
+    model = LuxonisModel(cfg, opts, weights=path, debug_mode=True)
     model.lightning_module.load_checkpoint(path)
 
     # Needs to be called in order to attach the model to the trainer

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -43,6 +43,7 @@ from typing_extensions import Self, override
 
 import luxonis_train as lxt
 from luxonis_train.registry import MODELS, NODES, from_registry
+from luxonis_train.upgrade import upgrade_config
 
 
 class ImageSize(NamedTuple):
@@ -865,6 +866,9 @@ class Config(LuxonisConfig):
         cfg: PathType | Params | None = None,
         overrides: Params | list[str] | tuple[str, ...] | None = None,
     ) -> "Config":
+        if cfg is not None:
+            cfg = upgrade_config(cfg)
+
         instance = super().get_config(cfg, overrides)
         if not isinstance(cfg, str):
             return instance.smart_auto_populate()

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -867,15 +867,14 @@ class Config(LuxonisConfig):
             cfg = upgrade_config(cfg)
 
         instance = super().get_config(cfg, overrides)
-        if not isinstance(cfg, str):
-            return instance.smart_auto_populate()
-        fs = LuxonisFileSystem(cfg)
-        if fs.is_mlflow:
-            logger.info(
-                "Setting `project_id` and `run_id` to config's MLFlow run"
-            )
-            instance.tracker.project_id = fs.experiment_id
-            instance.tracker.run_id = fs.run_id
+        if isinstance(cfg, str):
+            fs = LuxonisFileSystem(cfg)
+            if fs.is_mlflow:
+                logger.info(
+                    "Setting `project_id` and `run_id` to config's MLFlow run"
+                )
+                instance.tracker.project_id = fs.experiment_id
+                instance.tracker.run_id = fs.run_id
 
         if instance.trainer.smart_cfg_auto_populate:
             return instance.smart_auto_populate()

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -859,10 +859,9 @@ class Config(LuxonisConfig):
         overrides: Params | list[str] | tuple[str, ...] | None = None,
     ) -> "Config":
         if isinstance(cfg, PathType):
-            fs = LuxonisFileSystem(
-                str(cfg), cache_storage=".cache/luxonis_train"
-            )
-            cfg = fs.get_file("", ".cache/luxonis_train")
+            cache = Path(".cache/luxonis_train/")
+            cache.mkdir(parents=True, exist_ok=True)
+            cfg = LuxonisFileSystem.download(str(cfg), cache)
 
         if cfg is not None:
             cfg = upgrade_config(cfg)

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -866,6 +866,12 @@ class Config(LuxonisConfig):
         cfg: PathType | Params | None = None,
         overrides: Params | list[str] | tuple[str, ...] | None = None,
     ) -> "Config":
+        if isinstance(cfg, PathType):
+            fs = LuxonisFileSystem(
+                str(cfg), cache_storage=".cache/luxonis_train"
+            )
+            cfg = fs.get_file("", ".cache/luxonis_train")
+
         if cfg is not None:
             cfg = upgrade_config(cfg)
 

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -124,7 +124,7 @@ class LuxonisModel:
 
             if cfg is None:
                 cfg = ckpt.get("config")
-            if "dataset_metadata" in ckpt:
+            if "dataset_metadata" in ckpt and dataset_metadata is None:
                 try:
                     dataset_metadata = DatasetMetadata(
                         **ckpt["dataset_metadata"]
@@ -311,6 +311,7 @@ class LuxonisModel:
             self.dataset_metadata = DatasetMetadata.from_loader(
                 self.loaders["train"]
             )
+        logger.info(f"Dataset metadata: {self.dataset_metadata}")
         self.config_file = self.run_save_dir / "training_config.yaml"
         self.cfg.save_data(self.config_file)
 

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -2,7 +2,7 @@ import threading
 from collections.abc import Mapping
 from pathlib import Path
 from threading import ExceptHookArgs
-from typing import Literal, overload
+from typing import Any, Literal, overload
 
 import lightning.pytorch as pl
 import lightning_utilities.core.rank_zero as rank_zero_module
@@ -79,7 +79,7 @@ class LuxonisModel:
         cfg: PathType | Params | Config | None,
         opts: Params | list[str] | tuple[str, ...] | None = None,
         *,
-        weights: PathType | None = None,
+        weights: PathType | dict[str, Any] | None = None,
         debug_mode: bool = False,
         dataset_metadata: DatasetMetadata | None = None,
     ):
@@ -105,12 +105,21 @@ class LuxonisModel:
             without it being fully functional.
         """
         if weights is not None:
-            weights = safe_download(weights)
-            if weights is None:
-                raise RuntimeError(
-                    f"Failed to download weights from {weights}."
+            if isinstance(weights, dict):
+                ckpt = weights
+            elif isinstance(weights, PathType):
+                weights = safe_download(weights)
+                if weights is None:
+                    raise RuntimeError(
+                        f"Failed to download weights from {weights}."
+                    )
+                ckpt = torch.load(weights, map_location="cpu")  # nosemgre
+            else:  # pragma: no cover
+                raise ValueError(
+                    f"Invalid type for weights: {type(weights)}. "
+                    "Expected str or dict."
                 )
-            ckpt = torch.load(weights, map_location="cpu")  # nosemgre
+
             if cfg is None:
                 cfg = ckpt.get("config")
             if "dataset_metadata" in ckpt:
@@ -329,7 +338,9 @@ class LuxonisModel:
             self.tracker._finalize(status)
 
     def train(
-        self, new_thread: bool = False, weights: PathType | None = None
+        self,
+        new_thread: bool = False,
+        weights: PathType | None = None,
     ) -> None:
         """Runs training.
 
@@ -348,7 +359,7 @@ class LuxonisModel:
                 self.cfg.trainer.matmul_precision
             )
 
-        weights = self.resolve_weights(weights)
+        weights = self.resolve_weights(weights)  # type: ignore
 
         if self.cfg.trainer.resume_training and weights is None:
             logger.warning(
@@ -398,7 +409,7 @@ class LuxonisModel:
     def export(
         self,
         save_path: PathType | None = None,
-        weights: PathType | None = None,
+        weights: PathType | dict[str, Any] | None = None,
         ignore_missing_weights: bool = False,
         ckpt_only: bool = False,
     ) -> None:
@@ -539,7 +550,7 @@ class LuxonisModel:
         self,
         new_thread: Literal[False] = ...,
         view: Literal["train", "test", "val"] = "test",
-        weights: PathType | None = ...,
+        weights: PathType | dict[str, Any] | None = ...,
     ) -> Mapping[str, float]: ...
 
     @overload
@@ -547,7 +558,7 @@ class LuxonisModel:
         self,
         new_thread: Literal[True] = ...,
         view: Literal["train", "test", "val"] = "test",
-        weights: PathType | None = ...,
+        weights: PathType | dict[str, Any] | None = ...,
     ) -> None: ...
 
     @typechecked
@@ -555,7 +566,7 @@ class LuxonisModel:
         self,
         new_thread: bool = False,
         view: Literal["train", "val", "test"] = "test",
-        weights: PathType | None = None,
+        weights: PathType | dict[str, Any] | None = None,
     ) -> Mapping[str, float] | None:
         """Runs testing.
 
@@ -591,7 +602,7 @@ class LuxonisModel:
         view: Literal["train", "val", "test"] = "val",
         save_dir: PathType | None = None,
         source_path: PathType | None = None,
-        weights: PathType | None = None,
+        weights: PathType | dict[str, Any] | None = None,
     ) -> None:
         """Runs inference.
 
@@ -645,7 +656,7 @@ class LuxonisModel:
         self,
         dir_path: PathType,
         dataset_name: str,
-        weights: PathType | None = None,
+        weights: PathType | dict[str, Any] | None = None,
         bucket_storage: Literal["local", "gcs"] = "local",
         delete_local: bool = True,
         delete_remote: bool = True,
@@ -914,7 +925,7 @@ class LuxonisModel:
     def archive(
         self,
         path: PathType | None = None,
-        weights: PathType | None = None,
+        weights: PathType | dict[str, Any] | None = None,
         save_dir: PathType | None = None,
     ) -> Path:
         """Generates an NN Archive out of a model executable.
@@ -1032,7 +1043,7 @@ class LuxonisModel:
 
     def convert(
         self,
-        weights: PathType | None = None,
+        weights: PathType | dict[str, Any] | None = None,
         save_dir: PathType | None = None,
     ) -> tuple[Path, dict[str, Path]]:
         """Exports the model to ONNX, creates an NN Archive, and
@@ -1201,10 +1212,18 @@ class LuxonisModel:
         """
         return self.lightning_module.get_mlflow_logging_keys()
 
-    def resolve_weights(self, weights: PathType | None) -> PathType | None:
+    def resolve_weights(
+        self, weights: PathType | dict[str, Any] | None
+    ) -> PathType | dict[str, Any] | None:
+
+        if isinstance(weights, dict):
+            return weights
 
         if weights is None:
+            if isinstance(self.weights, dict):
+                return self.weights
             return safe_download(self.weights)
+
         logger.warning(
             "Weights provided on the command line, but config weights are set. "
             "Ignoring weights provided in config or during LuxonisModel initialization."

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -41,6 +41,7 @@ from luxonis_train.utils import (
     LuxonisTrackerPL,
     setup_logging,
 )
+from luxonis_train.utils.general import safe_download
 
 from .utils.annotate_utils import annotate_from_directory
 from .utils.archive_utils import (
@@ -104,10 +105,11 @@ class LuxonisModel:
             without it being fully functional.
         """
         if weights is not None:
-            weights = LuxonisFileSystem.download(
-                str(weights), self.run_save_dir
-            )
-
+            weights = safe_download(str(weights))
+            if weights is None:
+                raise RuntimeError(
+                    f"Failed to download weights from {weights}."
+                )
             ckpt = torch.load(weights, map_location="cpu")  # nosemgre
             if cfg is None:
                 cfg = ckpt.get("config")
@@ -1202,9 +1204,9 @@ class LuxonisModel:
     def resolve_weights(self, weights: PathType | None) -> PathType | None:
 
         if weights is None:
-            return self.weights
+            return safe_download(str(self.weights))
         logger.warning(
             "Weights provided on the command line, but config weights are set. "
             "Ignoring weights provided in config or during LuxonisModel initialization."
         )
-        return LuxonisFileSystem.download(str(weights), self.run_save_dir)
+        return safe_download(str(weights))

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -106,6 +106,8 @@ class LuxonisModel:
         """
         if weights is not None:
             if isinstance(weights, dict):
+                if "state_dict" not in weights:
+                    weights = {"state_dict": weights}
                 ckpt = weights
             elif isinstance(weights, PathType):
                 weights = safe_download(weights)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -78,6 +78,7 @@ class LuxonisModel:
         cfg: PathType | Params | Config | None,
         opts: Params | list[str] | tuple[str, ...] | None = None,
         *,
+        weights: PathType | None = None,
         debug_mode: bool = False,
         dataset_metadata: DatasetMetadata | None = None,
     ):
@@ -92,15 +93,37 @@ class LuxonisModel:
         @type opts: list[str] | tuple[str, ...] | dict[str, Any] | None
         @param opts: Argument dict provided through command line, used for config overriding.
 
+        @type weights: str | None
+        @param weights: Path to the weights. If user specifies weights
+            in the config file, the weights provided here will take
+            precedence.
+
         @type debug_mode: bool
         @param debug_mode: If set to True, enables debug mode which ignores some
             normaly unrecovarable exceptions and allows to test the model
             without it being fully functional.
         """
+        if weights is not None:
+            ckpt = torch.load(weights, map_location="cpu")  # nosemgre
+            if cfg is None:
+                cfg = ckpt.get("config")
+            if "dataset_metadata" in ckpt:
+                try:
+                    dataset_metadata = DatasetMetadata(
+                        **ckpt["dataset_metadata"]
+                    )
+                except Exception as e:  # pragma: no cover
+                    logger.error(
+                        "Failed to load dataset metadata from the checkpoint. "
+                        f"Error: {e}"
+                    )
+
         if isinstance(cfg, Config):
             self.cfg = cfg
         else:
             self.cfg = Config.get_config(cfg, opts)
+
+        self.weights = weights or self.cfg.model.weights
 
         self.debug_mode = debug_mode
 
@@ -319,18 +342,7 @@ class LuxonisModel:
                 self.cfg.trainer.matmul_precision
             )
 
-        if weights is not None:
-            weights = LuxonisFileSystem.download(
-                str(weights), self.run_save_dir
-            )
-            if self.cfg.model.weights is not None:
-                logger.warning(
-                    "Weights provided in the command line, but config weights are set. "
-                    "Ignoring weights provided in config."
-                )
-            self.lightning_module.load_checkpoint(weights)
-        else:
-            weights = self.cfg.model.weights
+        weights = self.resolve_weights(weights)
 
         if self.cfg.trainer.resume_training and weights is None:
             logger.warning(
@@ -405,7 +417,7 @@ class LuxonisModel:
             file in case they changed (e.g. new configuration file,
             architectural changes affecting the exection order etc.)
         """
-        weights = weights or self.cfg.model.weights
+        weights = self.resolve_weights(weights)
 
         if not ignore_missing_weights and weights is None:
             logger.warning(
@@ -555,7 +567,7 @@ class LuxonisModel:
             model will be temporarily replaced with the weights from the
             specified checkpoint.
         """
-        weights = weights or self.cfg.model.weights
+        weights = self.resolve_weights(weights)
         loader = self.pytorch_loaders[view]
 
         with replace_weights(self.lightning_module, weights):
@@ -595,7 +607,7 @@ class LuxonisModel:
             specified checkpoint.
         """
         self.lightning_module.eval()
-        weights = weights or self.cfg.model.weights
+        weights = self.resolve_weights(weights)
 
         with replace_weights(self.lightning_module, weights):
             if save_dir is not None:
@@ -634,7 +646,7 @@ class LuxonisModel:
         team_id: str | None = None,
     ) -> LuxonisDataset:
         self.lightning_module.eval()
-        weights = weights or self.cfg.model.weights
+        weights = self.resolve_weights(weights)
 
         with replace_weights(self.lightning_module, weights):
             dir_path = Path(dir_path)
@@ -913,7 +925,7 @@ class LuxonisModel:
         @rtype: Path
         @return: Path to the generated NN Archive.
         """
-        weights = weights or self.cfg.model.weights
+        weights = self.resolve_weights(weights)
         with replace_weights(self.lightning_module, weights):
             return self._archive(path, save_dir)
 
@@ -1182,3 +1194,9 @@ class LuxonisModel:
         2) "artifacts"  -> Keys expected to be logged as artifacts (e.g. confusion_matrix.json, visualizations)
         """
         return self.lightning_module.get_mlflow_logging_keys()
+
+    def resolve_weights(self, weights: PathType | None) -> PathType | None:
+
+        if weights is None:
+            return self.weights
+        return LuxonisFileSystem.download(str(weights), self.run_save_dir)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -105,7 +105,7 @@ class LuxonisModel:
             without it being fully functional.
         """
         if weights is not None:
-            weights = safe_download(str(weights))
+            weights = safe_download(weights)
             if weights is None:
                 raise RuntimeError(
                     f"Failed to download weights from {weights}."
@@ -1204,9 +1204,9 @@ class LuxonisModel:
     def resolve_weights(self, weights: PathType | None) -> PathType | None:
 
         if weights is None:
-            return safe_download(str(self.weights))
+            return safe_download(self.weights)
         logger.warning(
             "Weights provided on the command line, but config weights are set. "
             "Ignoring weights provided in config or during LuxonisModel initialization."
         )
-        return safe_download(str(weights))
+        return safe_download(weights)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -104,6 +104,10 @@ class LuxonisModel:
             without it being fully functional.
         """
         if weights is not None:
+            weights = LuxonisFileSystem.download(
+                str(weights), self.run_save_dir
+            )
+
             ckpt = torch.load(weights, map_location="cpu")  # nosemgre
             if cfg is None:
                 cfg = ckpt.get("config")

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -1203,4 +1203,8 @@ class LuxonisModel:
 
         if weights is None:
             return self.weights
+        logger.warning(
+            "Weights provided on the command line, but config weights are set. "
+            "Ignoring weights provided in config or during LuxonisModel initialization."
+        )
         return LuxonisFileSystem.download(str(weights), self.run_save_dir)

--- a/luxonis_train/core/utils/export_utils.py
+++ b/luxonis_train/core/utils/export_utils.py
@@ -3,7 +3,7 @@ import shutil
 from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from loguru import logger
 from luxonis_ml.typing import PathType, check_type
@@ -15,12 +15,13 @@ from luxonis_train.config.config import HubAIExportConfig, PreprocessingConfig
 
 @contextmanager
 def replace_weights(
-    module: "lxt.LuxonisLightningModule", weights: PathType | None = None
+    module: "lxt.LuxonisLightningModule",
+    weights: PathType | dict[str, Any] | None = None,
 ) -> Generator:
     old_weights = None
     if weights is not None:
         old_weights = module.state_dict()
-        module.load_checkpoint(str(weights))
+        module.load_checkpoint(weights)
         object.__setattr__(module, "_weights_explicitly_loaded", True)
 
     yield

--- a/luxonis_train/nodes/base_node.py
+++ b/luxonis_train/nodes/base_node.py
@@ -470,7 +470,7 @@ class BaseNode(nn.Module, VariantBase, register=False, registry=NODES):
         if isinstance(ckpt, dict):
             state_dict = ckpt
         else:
-            local_path = safe_download(url=ckpt)
+            local_path = safe_download(ckpt)
             if local_path:
                 # load explicitly to cpu, PL takes care of transfering to CUDA is needed
                 state_dict = torch.load(  # nosemgrep

--- a/luxonis_train/upgrade.py
+++ b/luxonis_train/upgrade.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from types import EllipsisType
 from typing import Any
 
-import requests
 import yaml
 from loguru import logger
 from luxonis_ml.typing import Params, ParamValue, PathType
@@ -62,7 +61,7 @@ class NestedDict:
         current = self._dict
         for k in keys[:-1]:
             current = current[k]
-        return current.pop(keys[-1])
+        return current.pop(keys[-1], default)
 
     def update(self, key: str, value: Any) -> None:
         old_value = self[key]
@@ -148,7 +147,7 @@ def upgrade_config(config: PathType | Params) -> Params:
     if "tuner" in cfg and cfg["tuner"] is None:
         cfg.pop("tuner")
 
-    nodes = cfg["model"]["nodes"] or []
+    nodes = cfg.get("model.nodes", [])
     assert isinstance(nodes, list)
 
     heads: dict[str, NestedDict] = {}
@@ -165,7 +164,7 @@ def upgrade_config(config: PathType | Params) -> Params:
         if node.pop("params.download_weights", False):
             node["params.weights"] = "download"
 
-    export_output_names = cfg.pop("exporter.output_names")
+    export_output_names = cfg.pop("exporter.output_names", None)
     if export_output_names is not None:
         if len(heads) == 1:
             head = next(iter(heads.values()))
@@ -225,6 +224,8 @@ def upgrade_installation() -> None:
 
 
 def get_latest_version() -> Version | None:
+    import requests
+
     url = "https://pypi.org/pypi/luxonis_train/json"
     response = requests.get(url, timeout=5)
     if response.status_code == 200:

--- a/luxonis_train/utils/dataset_metadata.py
+++ b/luxonis_train/utils/dataset_metadata.py
@@ -148,8 +148,9 @@ class DatasetMetadata:
 
         @type task_name: str | None
         @param task_name: Task to get the class names for.
-        @rtype: list[str]
-        @return: List of class names for the specified task type.
+        @rtype: bidict[str, int]
+        @return: Bidirectional dictionary mapping class names to their
+            indices for the specified task type.
         @raises ValueError: If the C{task} is not present in the
             dataset.
         @raises RuntimeError: If the C{task} was not provided and the

--- a/luxonis_train/utils/general.py
+++ b/luxonis_train/utils/general.py
@@ -152,7 +152,7 @@ def get_with_default(
 
 
 def safe_download(
-    url: str,
+    url: PathType | None,
     file: str | None = None,
     dir: PathType = ".cache/luxonis_train",
     retry: int = 3,
@@ -161,8 +161,9 @@ def safe_download(
     """Downloads file from the web and returns either local path or None
     if downloading failed.
 
-    @type url: str
-    @param url: URL of the file you want to download.
+    @type url: str | None
+    @param url: URL of the file you want to download. If None, returns
+        None.
     @type file: str | None
     @param file: Name of the saved file, if None infers it from URL.
         Defaults to None.
@@ -177,6 +178,10 @@ def safe_download(
     @rtype: Path | None
     @return: Path to local file or None if downloading failed.
     """
+    if url is None or isinstance(url, Path):
+        return url
+    if LuxonisFileSystem.get_protocol(url) == "file":
+        return Path(url)
     dir = Path(dir) / __version__
     dir.mkdir(parents=True, exist_ok=True)
     f = dir / (file or url2file(url))

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -64,8 +64,9 @@ def test_weights_loading(cifar10_dataset: LuxonisDataset, opts: Params):
 
     model = LuxonisModel(config_file, opts)
     test_results = model.test()
-    weights = model.get_min_loss_checkpoint_path()
-    assert test_results == model.test(weights=weights)
+    assert test_results == model.test(
+        weights={"state_dict": model.lightning_module.state_dict()}
+    )
 
 
 def test_precision_fallback_to_bf16_on_cpu(

--- a/tests/integration/test_loader.py
+++ b/tests/integration/test_loader.py
@@ -44,6 +44,7 @@ def test_splits(
     model = LuxonisModel(cfg, opts)
 
     for key, exp_len in expected.items():
+        assert len(model.loaders[key]) == exp_len
         assert len(model.pytorch_loaders[key]) == exp_len
 
 

--- a/tests/unittests/test_utils/test_general.py
+++ b/tests/unittests/test_utils/test_general.py
@@ -59,12 +59,6 @@ def test_safe_download():
         local_path.unlink()
 
 
-def test_safe_download_failed():
-    url = "fake_url.fake"
-    local_path = safe_download(url=url, file="test.ckpt", dir=".", force=True)
-    assert local_path is None
-
-
 def test_instances_from_batch(subtests: SubTests):
     with subtests.test("bboxes"):
         bboxes = torch.tensor([[0, 1], [0, 2], [1, 3]])


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
When weights are provided to `LuxonisModel`, the `DatasetMetadata` are loaded from it if the weights contain it.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Moved config restoration from checkpoint from `__main__` to `LuxonisModel`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable