### PR TITLE
Predictions written in batches when save_dir is set instead of buffer in memory

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -152,13 +152,11 @@ class LuxonisModel:
 
         rich.traceback.install(suppress=[pl, torch], show_locals=False)
 
-        tracker_params = self.cfg.tracker.model_dump()
-        tracker_params.pop("_auto_finalize", None)
         self.tracker = LuxonisTrackerPL(
             rank=rank_zero_only.rank,
             mlflow_tracking_uri=self.environ.MLFLOW_TRACKING_URI,
-            **tracker_params,
             _auto_finalize=False,
+            **self.cfg.tracker.model_dump(),
         )
 
         self.run_save_dir = (

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -152,11 +152,13 @@ class LuxonisModel:
 
         rich.traceback.install(suppress=[pl, torch], show_locals=False)
 
+        tracker_params = self.cfg.tracker.model_dump()
+        tracker_params.pop("_auto_finalize", None)
         self.tracker = LuxonisTrackerPL(
             rank=rank_zero_only.rank,
             mlflow_tracking_uri=self.environ.MLFLOW_TRACKING_URI,
+            **tracker_params,
             _auto_finalize=False,
-            **self.cfg.tracker.model_dump(),
         )
 
         self.run_save_dir = (

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from collections.abc import Iterable
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -8,7 +8,6 @@ import cv2
 import numpy as np
 import torch
 import torch.utils.data as torch_data
-from lightning.pytorch.callbacks import BasePredictionWriter
 from loguru import logger
 from luxonis_ml.data import DatasetIterator, LuxonisDataset
 from luxonis_ml.typing import PathType
@@ -147,19 +146,30 @@ def infer_from_loader(
     @param img_paths: The paths to the images.
     """
     if save_dir is not None:
-        writer = InferenceSaveWriter(Path(save_dir), img_paths)
+        # Save outputs as each batch is predicted so we do not keep the full
+        # prediction list in memory before writing visualizations to disk.
+        save_dir = Path(save_dir)
+        lt_module = model.lightning_module.eval()
+        counter = Counter()
         trainer = cast(Any, model.pl_trainer)
-        callbacks = cast(list[Any], trainer.callbacks)
-        callbacks.append(writer)
-        try:
-            model.pl_trainer.predict(
-                model.lightning_module,
-                loader,
-                return_predictions=False,
+        # Prefer the trainer strategy's root device when available so this
+        # path follows the same placement as Trainer.predict().
+        device = getattr(
+            getattr(trainer, "strategy", None),
+            "root_device",
+            lt_module.device,
+        )
+
+        for batch in loader:
+            batch = _move_batch_to_device(batch, trainer, device)
+            with torch.inference_mode(), _get_predict_context(trainer):
+                outputs = lt_module.predict_step(batch)
+            _save_renders_batch(
+                process_visualizations(outputs.visualizations),
+                save_dir,
+                counter,
+                img_paths,
             )
-        finally:
-            with suppress(ValueError):
-                callbacks.remove(writer)
         return
 
     predictions = model.pl_trainer.predict(model.lightning_module, loader)
@@ -188,90 +198,60 @@ def infer_from_loader(
         cv2.destroyAllWindows()
 
 
-class InferenceSaveWriter(BasePredictionWriter):
-    """Writes rendered inference batches as soon as they are
-    predicted."""
+def _get_predict_context(trainer: Any) -> Any:
+    strategy = getattr(trainer, "strategy", None)
+    # The precision plugin is owned by the strategy. Fall back to a no-op
+    # context for tests or simplified trainers that do not attach one.
+    precision_plugin = getattr(strategy, "precision_plugin", None)
+    if precision_plugin is None:
+        return nullcontext()
+    return precision_plugin.forward_context()
 
-    def __init__(
-        self,
-        save_dir: Path,
-        img_paths: list[PathType] | None = None,
-    ) -> None:
-        super().__init__(write_interval="batch")
-        self.save_dir = Path(save_dir)
-        self.img_paths = img_paths
-        self.counter = Counter()
 
-    def write_on_batch_end(
-        self,
-        trainer: Any,
-        pl_module: Any,
-        prediction: LuxonisOutput,
-        batch_indices: Any,
-        batch: Any,
-        batch_idx: int,
-        dataloader_idx: int = 0,
-    ) -> None:
-        del trainer, pl_module, batch, batch_idx, dataloader_idx
-
-        renders = process_visualizations(prediction.visualizations)
-        if not renders:
-            return
-
-        batch_img_paths = None
-        if self.img_paths is not None and batch_indices is not None:
-            try:
-                indices = [int(idx) for idx in batch_indices]
-            except TypeError:
-                indices = [int(batch_indices)]
-
-            try:
-                batch_img_paths = [
-                    Path(self.img_paths[idx]) for idx in indices
-                ]
-            except IndexError:
-                batch_img_paths = None
-
-        self._save_renders(
-            renders,
-            batch_img_paths,
+def _move_batch_to_device(
+    batch: tuple[dict[str, Tensor], dict[str, Tensor]],
+    trainer: Any,
+    device: torch.device,
+) -> tuple[dict[str, Tensor], dict[str, Tensor]]:
+    strategy = getattr(trainer, "strategy", None)
+    # Reuse Lightning's device transfer when it exists so accelerator- or
+    # strategy-specific batch handling still applies on this narrower path.
+    if strategy is not None and hasattr(strategy, "batch_to_device"):
+        return cast(
+            tuple[dict[str, Tensor], dict[str, Tensor]],
+            strategy.batch_to_device(batch, device, 0),
         )
 
-    def write_on_epoch_end(
-        self,
-        trainer: Any,
-        pl_module: Any,
-        predictions: Any,
-        batch_indices: Any,
-    ) -> None:
-        del trainer, pl_module, predictions, batch_indices
+    inputs, labels = batch
+    # Simple fallback for code paths that do not expose a Lightning strategy.
+    return (
+        {name: tensor.to(device) for name, tensor in inputs.items()},
+        {name: tensor.to(device) for name, tensor in labels.items()},
+    )
 
-    def _save_renders(
-        self,
-        renders: dict[tuple[str, str], list[np.ndarray]],
-        batch_img_paths: list[Path] | None = None,
-    ) -> None:
-        """Persist a rendered batch to disk."""
-        batch_size = len(next(iter(renders.values())))
-        if batch_img_paths is not None and len(batch_img_paths) != batch_size:
-            batch_img_paths = None
 
-        for i in range(batch_size):
-            img_path: Path | None = None
-            if batch_img_paths is not None:
-                img_path = batch_img_paths[i]
-            elif self.img_paths is not None:
-                idx = self.counter()
-                if idx < len(self.img_paths):
-                    img_path = Path(self.img_paths[idx])
-            for (node_name, viz_name), visualizations in renders.items():
-                viz = visualizations[i]
-                if img_path is not None:
-                    name = f"{img_path.stem}_{node_name}_{viz_name}"
-                else:
-                    name = f"{node_name}_{viz_name}_{self.counter()}"
-                name = name.replace("/", "-")
-                cv2.imwrite(str(self.save_dir / f"{name}.png"), viz)
+def _save_renders_batch(
+    renders: dict[tuple[str, str], list[np.ndarray]],
+    save_dir: Path,
+    counter: Counter,
+    img_paths: list[PathType] | None = None,
+) -> None:
+    if not renders:
+        return
+
+    batch_size = len(next(iter(renders.values())))
+    for i in range(batch_size):
+        img_path: Path | None = None
+        if img_paths is not None:
+            img_path = Path(img_paths[counter()])
+        for (node_name, viz_name), visualizations in renders.items():
+            viz = visualizations[i]
+            if img_path is not None:
+                name = f"{img_path.stem}_{node_name}_{viz_name}"
+            else:
+                name = f"{node_name}_{viz_name}_{counter()}"
+            name = name.replace("/", "-")
+            cv2.imwrite(str(save_dir / f"{name}.png"), viz)
 
 
 def create_loader_from_directory(

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -148,7 +148,8 @@ def infer_from_loader(
     """
     if save_dir is not None:
         writer = InferenceSaveWriter(Path(save_dir), img_paths)
-        callbacks = cast(list[Any], model.pl_trainer.callbacks)
+        trainer = cast(Any, model.pl_trainer)
+        callbacks = cast(list[Any], trainer.callbacks)
         callbacks.append(writer)
         try:
             model.pl_trainer.predict(

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
-from collections.abc import Iterable
-from contextlib import nullcontext, suppress
+from collections.abc import Generator, Iterable
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -8,6 +8,7 @@ import cv2
 import numpy as np
 import torch
 import torch.utils.data as torch_data
+from lightning.pytorch.callbacks import BasePredictionWriter
 from loguru import logger
 from luxonis_ml.data import DatasetIterator, LuxonisDataset
 from luxonis_ml.typing import PathType
@@ -146,21 +147,13 @@ def infer_from_loader(
     @param img_paths: The paths to the images.
     """
     if save_dir is not None:
-        # Save outputs as each batch is predicted so we do not keep the full
-        # prediction list in memory before writing visualizations to disk.
         save_dir = Path(save_dir)
-        lt_module = model.lightning_module.eval()
-        counter = Counter()
-        trainer = cast(Any, model.pl_trainer)
-
-        for batch in loader:
-            with torch.inference_mode(), _get_predict_context(trainer):
-                outputs = lt_module.predict_step(batch)
-            _save_renders_batch(
-                process_visualizations(outputs.visualizations),
-                save_dir,
-                counter,
-                img_paths,
+        writer = _VisualizationPredictionWriter(save_dir, img_paths)
+        with _temporary_callback(model.pl_trainer, writer):
+            model.pl_trainer.predict(
+                model.lightning_module,
+                loader,
+                return_predictions=False,
             )
         return
 
@@ -190,14 +183,49 @@ def infer_from_loader(
         cv2.destroyAllWindows()
 
 
-def _get_predict_context(trainer: Any) -> Any:
-    strategy = getattr(trainer, "strategy", None)
-    # The precision plugin is owned by the strategy. Fall back to a no-op
-    # context for tests or simplified trainers that do not attach one.
-    precision_plugin = getattr(strategy, "precision_plugin", None)
-    if precision_plugin is None:
-        return nullcontext()
-    return precision_plugin.forward_context()
+class _VisualizationPredictionWriter(BasePredictionWriter):
+    def __init__(
+        self,
+        save_dir: Path,
+        img_paths: list[PathType] | None = None,
+    ) -> None:
+        super().__init__(write_interval="batch")
+        self.save_dir = save_dir
+        self.img_paths = img_paths
+        self.counter = Counter()
+
+    def write_on_batch_end(
+        self,
+        trainer: Any,
+        pl_module: Any,
+        prediction: Any,
+        batch_indices: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        del trainer, pl_module, batch_indices, batch, batch_idx, dataloader_idx
+
+        assert isinstance(prediction, LuxonisOutput)
+        renders = process_visualizations(prediction.visualizations)
+        _save_renders_batch(
+            renders,
+            self.save_dir,
+            self.counter,
+            self.img_paths,
+        )
+
+
+@contextmanager
+def _temporary_callback(
+    trainer: Any, callback: Any
+) -> Generator[None, None, None]:
+    trainer.callbacks.append(callback)
+    try:
+        yield
+    finally:
+        with suppress(ValueError):
+            trainer.callbacks.remove(callback)
 
 
 def _save_renders_batch(

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -148,7 +148,8 @@ def infer_from_loader(
     """
     if save_dir is not None:
         writer = InferenceSaveWriter(Path(save_dir), img_paths)
-        model.pl_trainer.callbacks.append(writer)
+        callbacks = cast(list[Any], model.pl_trainer.callbacks)
+        callbacks.append(writer)
         try:
             model.pl_trainer.predict(
                 model.lightning_module,
@@ -157,7 +158,7 @@ def infer_from_loader(
             )
         finally:
             with suppress(ValueError):
-                model.pl_trainer.callbacks.remove(writer)
+                callbacks.remove(writer)
         return
 
     predictions = model.pl_trainer.predict(model.lightning_module, loader)

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -186,29 +186,6 @@ def infer_from_loader(
         cv2.destroyAllWindows()
 
 
-def save_renders(
-    renders: dict[tuple[str, str], list[np.ndarray]],
-    save_dir: Path,
-    counter: Counter,
-    img_paths: list[PathType] | None = None,
-) -> None:
-    """Persist a rendered batch to disk."""
-    batch_size = len(next(iter(renders.values())))
-
-    for i in range(batch_size):
-        if img_paths is not None:
-            idx = counter()
-            img_path = Path(img_paths[idx])
-        for (node_name, viz_name), visualizations in renders.items():
-            viz = visualizations[i]
-            if img_paths is not None:
-                name = f"{img_path.stem}_{node_name}_{viz_name}"
-            else:
-                name = f"{node_name}_{viz_name}_{counter()}"
-            name = name.replace("/", "-")
-            cv2.imwrite(str(save_dir / f"{name}.png"), viz)
-
-
 class InferenceSaveWriter(BasePredictionWriter):
     """Writes rendered inference batches as soon as they are
     predicted."""
@@ -239,7 +216,7 @@ class InferenceSaveWriter(BasePredictionWriter):
         if not renders:
             return
 
-        save_renders(renders, self.save_dir, self.counter, self.img_paths)
+        self._save_renders(renders)
 
     def write_on_epoch_end(
         self,
@@ -249,6 +226,25 @@ class InferenceSaveWriter(BasePredictionWriter):
         batch_indices: Any,
     ) -> None:
         del trainer, pl_module, predictions, batch_indices
+
+    def _save_renders(
+        self, renders: dict[tuple[str, str], list[np.ndarray]]
+    ) -> None:
+        """Persist a rendered batch to disk."""
+        batch_size = len(next(iter(renders.values())))
+
+        for i in range(batch_size):
+            if self.img_paths is not None:
+                idx = self.counter()
+                img_path = Path(self.img_paths[idx])
+            for (node_name, viz_name), visualizations in renders.items():
+                viz = visualizations[i]
+                if self.img_paths is not None:
+                    name = f"{img_path.stem}_{node_name}_{viz_name}"
+                else:
+                    name = f"{node_name}_{viz_name}_{self.counter()}"
+                name = name.replace("/", "-")
+                cv2.imwrite(str(self.save_dir / f"{name}.png"), viz)
 
 
 def create_loader_from_directory(

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -152,16 +152,8 @@ def infer_from_loader(
         lt_module = model.lightning_module.eval()
         counter = Counter()
         trainer = cast(Any, model.pl_trainer)
-        # Prefer the trainer strategy's root device when available so this
-        # path follows the same placement as Trainer.predict().
-        device = getattr(
-            getattr(trainer, "strategy", None),
-            "root_device",
-            lt_module.device,
-        )
 
         for batch in loader:
-            batch = _move_batch_to_device(batch, trainer, device)
             with torch.inference_mode(), _get_predict_context(trainer):
                 outputs = lt_module.predict_step(batch)
             _save_renders_batch(
@@ -206,28 +198,6 @@ def _get_predict_context(trainer: Any) -> Any:
     if precision_plugin is None:
         return nullcontext()
     return precision_plugin.forward_context()
-
-
-def _move_batch_to_device(
-    batch: tuple[dict[str, Tensor], dict[str, Tensor]],
-    trainer: Any,
-    device: torch.device,
-) -> tuple[dict[str, Tensor], dict[str, Tensor]]:
-    strategy = getattr(trainer, "strategy", None)
-    # Reuse Lightning's device transfer when it exists so accelerator- or
-    # strategy-specific batch handling still applies on this narrower path.
-    if strategy is not None and hasattr(strategy, "batch_to_device"):
-        return cast(
-            tuple[dict[str, Tensor], dict[str, Tensor]],
-            strategy.batch_to_device(batch, device, 0),
-        )
-
-    inputs, labels = batch
-    # Simple fallback for code paths that do not expose a Lightning strategy.
-    return (
-        {name: tensor.to(device) for name, tensor in inputs.items()},
-        {name: tensor.to(device) for name, tensor in labels.items()},
-    )
 
 
 def _save_renders_batch(

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -212,13 +212,30 @@ class InferenceSaveWriter(BasePredictionWriter):
         batch_idx: int,
         dataloader_idx: int = 0,
     ) -> None:
-        del trainer, pl_module, batch_indices, batch, batch_idx, dataloader_idx
+        del trainer, pl_module, batch, batch_idx, dataloader_idx
 
         renders = process_visualizations(prediction.visualizations)
         if not renders:
             return
 
-        self._save_renders(renders)
+        batch_img_paths = None
+        if self.img_paths is not None and batch_indices is not None:
+            try:
+                indices = [int(idx) for idx in batch_indices]
+            except TypeError:
+                indices = [int(batch_indices)]
+
+            try:
+                batch_img_paths = [
+                    Path(self.img_paths[idx]) for idx in indices
+                ]
+            except IndexError:
+                batch_img_paths = None
+
+        self._save_renders(
+            renders,
+            batch_img_paths,
+        )
 
     def write_on_epoch_end(
         self,
@@ -230,18 +247,26 @@ class InferenceSaveWriter(BasePredictionWriter):
         del trainer, pl_module, predictions, batch_indices
 
     def _save_renders(
-        self, renders: dict[tuple[str, str], list[np.ndarray]]
+        self,
+        renders: dict[tuple[str, str], list[np.ndarray]],
+        batch_img_paths: list[Path] | None = None,
     ) -> None:
         """Persist a rendered batch to disk."""
         batch_size = len(next(iter(renders.values())))
+        if batch_img_paths is not None and len(batch_img_paths) != batch_size:
+            batch_img_paths = None
 
         for i in range(batch_size):
-            if self.img_paths is not None:
+            img_path: Path | None = None
+            if batch_img_paths is not None:
+                img_path = batch_img_paths[i]
+            elif self.img_paths is not None:
                 idx = self.counter()
-                img_path = Path(self.img_paths[idx])
+                if idx < len(self.img_paths):
+                    img_path = Path(self.img_paths[idx])
             for (node_name, viz_name), visualizations in renders.items():
                 viz = visualizations[i]
-                if self.img_paths is not None:
+                if img_path is not None:
                     name = f"{img_path.stem}_{node_name}_{viz_name}"
                 else:
                     name = f"{node_name}_{viz_name}_{self.counter()}"

--- a/luxonis_train/core/utils/infer_utils.py
+++ b/luxonis_train/core/utils/infer_utils.py
@@ -8,6 +8,7 @@ import cv2
 import numpy as np
 import torch
 import torch.utils.data as torch_data
+from lightning.pytorch.callbacks import BasePredictionWriter
 from loguru import logger
 from luxonis_ml.data import DatasetIterator, LuxonisDataset
 from luxonis_ml.typing import PathType
@@ -145,13 +146,25 @@ def infer_from_loader(
     @type img_paths: list[Path] | None
     @param img_paths: The paths to the images.
     """
+    if save_dir is not None:
+        writer = InferenceSaveWriter(Path(save_dir), img_paths)
+        model.pl_trainer.callbacks.append(writer)
+        try:
+            model.pl_trainer.predict(
+                model.lightning_module,
+                loader,
+                return_predictions=False,
+            )
+        finally:
+            with suppress(ValueError):
+                model.pl_trainer.callbacks.remove(writer)
+        return
+
     predictions = model.pl_trainer.predict(model.lightning_module, loader)
 
     broken = False
     if predictions is None:  # pragma: no cover
         return
-
-    counter = Counter()
 
     for outputs in predictions:
         if broken:  # pragma: no cover
@@ -161,30 +174,81 @@ def infer_from_loader(
         renders = process_visualizations(visualizations)
         batch_size = len(next(iter(renders.values())))
         for i in range(batch_size):
-            if img_paths is not None:
-                idx = counter()
             for (node_name, viz_name), visualizations in renders.items():
                 viz = visualizations[i]
-                if save_dir is not None:
-                    save_dir = Path(save_dir)
-                    if img_paths is not None:
-                        img_path = Path(img_paths[idx])
-                        name = f"{img_path.stem}_{node_name}_{viz_name}"
-                    else:
-                        name = f"{node_name}_{viz_name}_{counter()}"
-                    name = name.replace("/", "-")
-                    save_path = save_dir / f"{name}.png"
-                    cv2.imwrite(str(save_path), viz)
-                else:
-                    cv2.imshow(f"{node_name}/{viz_name}", viz)
+                cv2.imshow(f"{node_name}/{viz_name}", viz)
 
-            if not save_dir and window_closed():  # pragma: no cover
+            if window_closed():  # pragma: no cover
                 broken = True
                 break
 
-    if save_dir is None:  # pragma: no cover
-        with suppress(cv2.error):  # type: ignore
-            cv2.destroyAllWindows()
+    with suppress(cv2.error):  # pragma: no cover
+        cv2.destroyAllWindows()
+
+
+def save_renders(
+    renders: dict[tuple[str, str], list[np.ndarray]],
+    save_dir: Path,
+    counter: Counter,
+    img_paths: list[PathType] | None = None,
+) -> None:
+    """Persist a rendered batch to disk."""
+    batch_size = len(next(iter(renders.values())))
+
+    for i in range(batch_size):
+        if img_paths is not None:
+            idx = counter()
+            img_path = Path(img_paths[idx])
+        for (node_name, viz_name), visualizations in renders.items():
+            viz = visualizations[i]
+            if img_paths is not None:
+                name = f"{img_path.stem}_{node_name}_{viz_name}"
+            else:
+                name = f"{node_name}_{viz_name}_{counter()}"
+            name = name.replace("/", "-")
+            cv2.imwrite(str(save_dir / f"{name}.png"), viz)
+
+
+class InferenceSaveWriter(BasePredictionWriter):
+    """Writes rendered inference batches as soon as they are
+    predicted."""
+
+    def __init__(
+        self,
+        save_dir: Path,
+        img_paths: list[PathType] | None = None,
+    ) -> None:
+        super().__init__(write_interval="batch")
+        self.save_dir = Path(save_dir)
+        self.img_paths = img_paths
+        self.counter = Counter()
+
+    def write_on_batch_end(
+        self,
+        trainer: Any,
+        pl_module: Any,
+        prediction: LuxonisOutput,
+        batch_indices: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        del trainer, pl_module, batch_indices, batch, batch_idx, dataloader_idx
+
+        renders = process_visualizations(prediction.visualizations)
+        if not renders:
+            return
+
+        save_renders(renders, self.save_dir, self.counter, self.img_paths)
+
+    def write_on_epoch_end(
+        self,
+        trainer: Any,
+        pl_module: Any,
+        predictions: Any,
+        batch_indices: Any,
+    ) -> None:
+        del trainer, pl_module, predictions, batch_indices
 
 
 def create_loader_from_directory(

--- a/tests/unittests/test_utils/test_infer_utils.py
+++ b/tests/unittests/test_utils/test_infer_utils.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+from luxonis_ml.typing import PathType
+
+from luxonis_train.core.utils.infer_utils import infer_from_loader
+from luxonis_train.lightning import LuxonisOutput
+
+
+class _MockTrainer:
+    def __init__(self, prediction: LuxonisOutput, callbacks: list[object]):
+        self._prediction = prediction
+        self.callbacks = callbacks
+
+    def predict(
+        self,
+        lightning_module: object,
+        loader: list[object],
+        return_predictions: bool = True,
+    ) -> list[LuxonisOutput] | None:
+        if return_predictions:
+            return [self._prediction]
+
+        for batch_idx, _ in enumerate(loader):
+            for callback in list(self.callbacks):
+                write_on_batch_end = getattr(
+                    callback, "write_on_batch_end", None
+                )
+                if write_on_batch_end is None:
+                    continue
+                write_on_batch_end(
+                    self,
+                    lightning_module,
+                    self._prediction,
+                    None,
+                    None,
+                    batch_idx,
+                    0,
+                )
+        return None
+
+
+def test_infer_from_loader_temporary_callback_does_not_leak(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    saved_paths: list[str] = []
+    monkeypatch.setattr(
+        "luxonis_train.core.utils.infer_utils.cv2.imwrite",
+        lambda path, _: saved_paths.append(Path(path).name) or True,
+    )
+
+    prediction = LuxonisOutput(
+        outputs={},
+        losses={},
+        visualizations={
+            "DiscSubNetHead": {
+                "SegmentationVisualizer": torch.zeros((1, 3, 4, 4))
+            }
+        },
+    )
+    existing_callback = object()
+    trainer = _MockTrainer(prediction, [existing_callback])
+    model: Any = SimpleNamespace(
+        pl_trainer=trainer,
+        lightning_module=object(),
+    )
+    loader: Any = [object()]
+    img_paths: list[PathType] = [tmp_path / "first.png"]
+
+    infer_from_loader(model, loader, tmp_path, img_paths)
+
+    assert trainer.callbacks == [existing_callback]
+    assert saved_paths == ["first_DiscSubNetHead_SegmentationVisualizer.png"]
+
+    trainer.predict(model.lightning_module, loader, return_predictions=False)
+
+    assert trainer.callbacks == [existing_callback]
+    assert saved_paths == ["first_DiscSubNetHead_SegmentationVisualizer.png"]
+
+    infer_from_loader(model, loader, tmp_path, img_paths)
+
+    assert trainer.callbacks == [existing_callback]
+    assert saved_paths == [
+        "first_DiscSubNetHead_SegmentationVisualizer.png",
+        "first_DiscSubNetHead_SegmentationVisualizer.png",
+    ]


### PR DESCRIPTION
## Purpose
- `luxonis_train infer --weights ... --config ... --save_dir` was only writing the images after all the predictions are made
- This takes a lot of space in the memory especially if the val set consists of many batches
- In this PR the only behavior that is modified is when `save_dir` is set: write the images after each predicted batch
- Tested locally

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
