### PR TITLE
Changes to account for stricter Pyright

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -988,6 +988,7 @@ class LuxonisModel:
             # If wandb used then init parent tracker separately at the end
             wandb_parent_tracker = LuxonisTrackerPL(
                 rank=rank_zero_only.rank,
+                _auto_finalize=True,
                 **(
                     self.cfg.tracker.model_dump()
                     | {"run_name": self.parent_tracker.run_name}


### PR DESCRIPTION
## Purpose
PyRight released 1.1.409 recently https://github.com/microsoft/pyright/releases and the current CI fails because the inference/policy is stricter.

Reproduce locally before the fix on previous PyRight version:

- Run PyRight on main: 0 errors should be visible
- Run  `npm install -g pyright@1.1.409`
- Run `npx pyright@1.1.409 --project pyproject.toml --pythonversion 3.10` and an error should appear

## Specification

## Dependencies & Potential Impact


## Deployment Plan

## Testing & Validation
