### PR TITLE
Skip passing normalization if it is not active in the config

### DIFF
--- a/luxonis_train/core/utils/export_utils.py
+++ b/luxonis_train/core/utils/export_utils.py
@@ -63,6 +63,9 @@ def get_preprocessing(
 ) -> tuple[
     list[float] | None, list[float] | None, Literal["RGB", "BGR", "GRAY"]
 ]:
+    if not cfg.normalize.active:
+        return None, None, cfg.color_space
+
     def _get_norm_param(key: Literal["mean", "std"]) -> list[float] | None:
         params = cfg.normalize.params
         if key not in params:  # pragma: no cover

--- a/tests/unittests/test_export_utils.py
+++ b/tests/unittests/test_export_utils.py
@@ -1,0 +1,41 @@
+from luxonis_train.config.config import PreprocessingConfig
+from luxonis_train.core.utils.export_utils import get_preprocessing
+
+
+def test_get_preprocessing_skips_inactive_normalization():
+    cfg = PreprocessingConfig(
+        color_space="BGR",
+        normalize={
+            "active": False,
+            "params": {
+                "mean": [0.485, 0.456, 0.406],
+                "std": [0.229, 0.224, 0.225],
+            },
+        },
+    )
+
+    mean, scale, color_space = get_preprocessing(
+        cfg, "Exporting to NN Archive"
+    )
+
+    assert mean is None
+    assert scale is None
+    assert color_space == "BGR"
+
+
+def test_get_preprocessing_returns_scaled_active_normalization():
+    cfg = PreprocessingConfig(
+        normalize={
+            "active": True,
+            "params": {
+                "mean": [0.5, 0.25, 0.125],
+                "std": [0.1, 0.2, 0.4],
+            },
+        },
+    )
+
+    mean, scale, color_space = get_preprocessing(cfg)
+
+    assert mean == [127.5, 63.75, 31.875]
+    assert scale == [25.5, 51.0, 102.0]
+    assert color_space == "RGB"

--- a/tests/unittests/test_export_utils.py
+++ b/tests/unittests/test_export_utils.py
@@ -1,17 +1,20 @@
-from luxonis_train.config.config import PreprocessingConfig
+from luxonis_train.config.config import (
+    NormalizeAugmentationConfig,
+    PreprocessingConfig,
+)
 from luxonis_train.core.utils.export_utils import get_preprocessing
 
 
 def test_get_preprocessing_skips_inactive_normalization():
     cfg = PreprocessingConfig(
         color_space="BGR",
-        normalize={
-            "active": False,
-            "params": {
+        normalize=NormalizeAugmentationConfig(
+            active=False,
+            params={
                 "mean": [0.485, 0.456, 0.406],
                 "std": [0.229, 0.224, 0.225],
             },
-        },
+        ),
     )
 
     mean, scale, color_space = get_preprocessing(
@@ -25,13 +28,13 @@ def test_get_preprocessing_skips_inactive_normalization():
 
 def test_get_preprocessing_returns_scaled_active_normalization():
     cfg = PreprocessingConfig(
-        normalize={
-            "active": True,
-            "params": {
+        normalize=NormalizeAugmentationConfig(
+            active=True,
+            params={
                 "mean": [0.5, 0.25, 0.125],
                 "std": [0.1, 0.2, 0.4],
             },
-        },
+        ),
     )
 
     mean, scale, color_space = get_preprocessing(cfg)


### PR DESCRIPTION
## Purpose
Resulting ONNX config:
<img width="379" height="382" alt="resulting_output_onnx" src="https://github.com/user-attachments/assets/dddb8731-9944-4dae-8dc5-eec86cffb775" />

Resulting RVC4 config:
<img width="381" height="529" alt="resulting_output_rvc4" src="https://github.com/user-attachments/assets/2cbf5b08-7dae-419c-96ba-602dfad3cd28" />

`None` for mean and scale is properly handled in `modelconverter`:

- https://github.com/luxonis/modelconverter/blob/main/modelconverter/utils/onnx_tools.py#L139
- https://github.com/luxonis/modelconverter/blob/main/modelconverter/utils/onnx_tools.py#L241
- https://github.com/luxonis/modelconverter/blob/main/modelconverter/utils/onnx_tools.py#L212

Another option would be to manually pass the identity (so [0, 0, 0] [1, 1, 1] for RGB and [0] [1] for grayscale) to the ONNX archive if normalization is not active, instead of passing `None` and letting it be handled downstream by `modelconverter`

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
