### PR TITLE
--list-augmentations for inspect command

### DIFF
--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -121,12 +121,33 @@ def _yield_visualizations(
     size_multiplier: Annotated[
         float, Parameter(["--size_multiplier", "-s"])
     ] = 1.0,
+    list_augmentations: bool = False,
 ) -> Iterator["np.ndarray"]:
     import cv2
     import numpy as np
-    from luxonis_ml.data.utils.visualizations import visualize
+    from luxonis_ml.data.utils.augmentations_collector import (
+        AugmentationsCollector,
+    )
+    from luxonis_ml.data.utils.visualizations import (
+        append_text_block,
+        visualize,
+    )
 
     from luxonis_train.utils.general import decode_text_metadata_labels
+
+    def add_augmentation_footer(
+        image: np.ndarray, augmentations: list[str]
+    ) -> np.ndarray:
+        min_dimension = min(image.shape[:2])
+        font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
+        augmentations_text = (
+            ", ".join(augmentations) if augmentations else "none"
+        )
+        return append_text_block(
+            image,
+            [f"Augmentations: {augmentations_text}"],
+            font_scale=font_scale,
+        )
 
     def get_visualization_item(
         idx: int,
@@ -161,6 +182,19 @@ def _yield_visualizations(
     model = create_model(config, opts)
 
     loader = model.loaders[view]
+    raw_loader = getattr(loader, "loader", None)
+    if list_augmentations and raw_loader is not None:
+        collector = AugmentationsCollector(
+            raw_loader.augmentations,  # type: ignore[attr-defined]
+            [
+                aug.model_dump()
+                for aug in model.cfg_preprocessing.get_active_augmentations()
+            ],
+        )
+        get_applied_augmentations = collector.get_applied_augmentations
+    else:
+        get_applied_augmentations = list
+
     metadata_types = loader.get_metadata_types()
     categorical_encodings = loader.get_categorical_encodings()
     for idx in range(len(loader)):
@@ -174,13 +208,16 @@ def _yield_visualizations(
         h, w, _ = main_image.shape
         new_h, new_w = int(h * size_multiplier), int(w * size_multiplier)
         main_image = cv2.resize(main_image, (new_w, new_h))
-        yield visualize(
+        viz = visualize(
             image=main_image,
             labels=np_labels,
             classes=loader.get_classes(),
             source_name=loader.image_source,
             categorical_encodings=categorical_encodings,
         )
+        if list_augmentations:
+            viz = add_augmentation_footer(viz, get_applied_augmentations())
+        yield viz
 
 
 @app.command(group=training_group, sort_key=3)
@@ -193,6 +230,7 @@ def inspect(
     size_multiplier: Annotated[
         float, Parameter(["--size_multiplier", "-s"])
     ] = 1.0,
+    list_augmentations: bool = False,
 ):
     """Inspect the dataset as specified in the configuration.
 
@@ -207,6 +245,9 @@ def inspect(
     @param size_multiplier: Multiplier for the image size. By default
         the images are shown in their original size. Use this option to
         scale them.
+    @type list_augmentations: bool
+    @param list_augmentations: Show the augmentations applied to each
+        displayed image in the footer.
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
@@ -222,6 +263,7 @@ def inspect(
         config=config,
         view=view,
         size_multiplier=size_multiplier,
+        list_augmentations=list_augmentations,
         opts=opts,
     ):
         window_name = get_window()

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -129,25 +129,11 @@ def _yield_visualizations(
         AugmentationsCollector,
     )
     from luxonis_ml.data.utils.visualizations import (
-        append_text_block,
+        add_augmentation_footer,
         visualize,
     )
 
     from luxonis_train.utils.general import decode_text_metadata_labels
-
-    def add_augmentation_footer(
-        image: np.ndarray, augmentations: list[str]
-    ) -> np.ndarray:
-        min_dimension = min(image.shape[:2])
-        font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
-        augmentations_text = (
-            ", ".join(augmentations) if augmentations else "none"
-        )
-        return append_text_block(
-            image,
-            [f"Augmentations: {augmentations_text}"],
-            font_scale=font_scale,
-        )
 
     def get_visualization_item(
         idx: int,


### PR DESCRIPTION
## Purpose
Relies on methods defined in the corresponding `luxonis-ml` PR: https://github.com/luxonis/luxonis-ml/pull/408/changes

Usage: `luxonis_train inspect --config <config-path> --list-augmentations`

Example (with `use_for_resizing`):

<img width="936" height="536" alt="lt-Use_for_resizing" src="https://github.com/user-attachments/assets/cfcf7c8a-e58c-4a63-bb84-62c7e0208ac5" />

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
