### PR TITLE
Allow MeanAveragePrecisionBBox for composite tasks

### DIFF
--- a/luxonis_train/attached_modules/metrics/mean_average_precision/mean_average_precision_bbox.py
+++ b/luxonis_train/attached_modules/metrics/mean_average_precision/mean_average_precision_bbox.py
@@ -9,16 +9,25 @@ from .utils import compute_metric_lists, postprocess_metrics
 
 
 class MeanAveragePrecisionBBox(MeanAveragePrecision, BaseMetric):
-    supported_tasks = [Tasks.BOUNDINGBOX]
+    supported_tasks = [
+        Tasks.BOUNDINGBOX,
+        Tasks.INSTANCE_KEYPOINTS,
+        Tasks.INSTANCE_SEGMENTATION,
+        Tasks.INSTANCE_SEGMENTATION_KEYPOINTS,
+    ]
 
     def __init__(self, **kwargs):
         super().__init__(iou_type="bbox", **kwargs)
 
     @override
-    def update(self, predictions: list[Tensor], targets: Tensor) -> None:
+    def update(
+        self, boundingbox: list[Tensor], target_boundingbox: Tensor
+    ) -> None:
         super().update(
             *compute_metric_lists(
-                predictions, targets, *self.original_in_shape[1:]
+                boundingbox,
+                target_boundingbox,
+                *self.original_in_shape[1:],
             )
         )
 

--- a/tests/unittests/test_metrics/test_mean_average_precision.py
+++ b/tests/unittests/test_metrics/test_mean_average_precision.py
@@ -222,6 +222,48 @@ def test_compute_mean_average_precision_bbox(
     assert torch.isclose(result, expected, atol=5e-3)
 
 
+def test_compute_mean_average_precision_bbox_for_instance_keypoints():
+    class DummyNodeKeypoints(BaseNode, register=False):
+        task = Tasks.INSTANCE_KEYPOINTS
+
+        def forward(self, _: Tensor) -> Tensor: ...
+
+    image_size = Size([3, 200, 200])
+    metric = MeanAveragePrecisionBBox(
+        node=DummyNodeKeypoints(
+            n_classes=2,
+            n_keypoints=4,
+            dataset_metadata=DatasetMetadata(
+                classes={"": {"class1": 0, "class2": 1}}
+            ),
+            original_in_shape=image_size,
+        )
+    )
+
+    predictions = [
+        torch.tensor(
+            [
+                [12, 12, 48, 48, 0.9, 0],
+                [62, 60, 98, 100, 0.8, 1],
+                [15, 15, 45, 45, 0.75, 0],
+            ]
+        )
+    ]
+    targets = convert_bboxes_to_xyxy_and_normalize(
+        torch.tensor(
+            [
+                [0, 0, 10, 10, 50, 50],
+                [0, 1, 60, 60, 100, 100],
+            ]
+        ),
+        image_size,
+    )
+
+    metric.update(predictions, targets)
+    result = metric.compute()[0]
+    assert torch.isclose(result, torch.tensor(0.8), atol=5e-3)
+
+
 @pytest.mark.parametrize(
     (
         "keypoints",


### PR DESCRIPTION
## Purpose
Allow `MeanAveragePrecisionBBox` to be attached to composite detection tasks: INSTANCE_KEYPOINTS, INSTANCE_SEGMENTATION and INSTANCE_SEGMENTATION_KEYPOINTS.

Specifying `MeanAveragePrecision` initializes the implementation based on the task. For instance-keypoint tasks the keypoint mAP is initialized but no bbox metrics like `map_50` are exposed by this. 

This means that this config returns the same keypoint metrics twice:

```
      metrics:
        - name: MeanAveragePrecisionKeypoints
          is_main_metric: True
        - name: MeanAveragePrecision
```

It also wasn't possible to specify `MeanAveragePrecisionBBox` directly on the composite tasks because of the label binding in the `update` signature (that's why the signature changes in this PR to specify bboxes).

Possible metric config now which wasn't possible before:

```
      metrics:
        - name: MeanAveragePrecisionKeypoints
          is_main_metric: True
        - name: MeanAveragePrecisionBBox
```

Example val results:

```
| Name | Value |
|------|-------|
| MeanAveragePrecisionKeypoints | 0.06867 |
| kpt_map_50 | 0.14966 |
| kpt_map_75 | 0.05238 |
| kpt_map_medium | 0.07961 |
| kpt_map_large | 0.09435 |
| kpt_mar | 0.13868 |
| kpt_mar_50 | 0.24844 |
| kpt_mar_75 | 0.13356 |
| kpt_mar_medium | 0.15260 |
| kpt_mar_large | 0.19042 |
| kpt_f1_50 | 0.18679 |
| kpt_f1_75 | 0.07524 |
| kpt_f1_medium | 0.10463 |
| kpt_f1_large | 0.12618 |
| MeanAveragePrecisionBBox | 0.22462 |
| map_50 | 0.38856 |
| map_75 | 0.23946 |
| map_small | 0.02172 |
| map_medium | 0.22805 |
| map_large | 0.32222 |
| mar_1 | 0.25307 |
| mar_10 | 0.27556 |
| mar_100 | 0.27935 |
| mar_small | 0.03377 |
| mar_medium | 0.29307 |
| mar_large | 0.39717 |
| f1_small | 0.02644 |
| f1_medium | 0.25650 |
| f1_large | 0.35579 |
```

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
