### PR TITLE
`apply_on_stages` config item

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -292,12 +292,13 @@ Additionally, we support `Mosaic4` and `MixUp` batch augmentations and letterbox
 
 #### Augmentations
 
-| Key                | Type   | Default value | Description                                                    |
-| ------------------ | ------ | ------------- | -------------------------------------------------------------- |
-| `name`             | `str`  | -             | Name of the augmentation                                       |
-| `active`           | `bool` | `True`        | Whether the augmentation is active                             |
-| `use_for_resizing` | `bool` | `False`       | Indicates whether the augmentation should be used for resizing |
-| `params`           | `dict` | `{}`          | Parameters of the augmentation                                 |
+| Key                | Type        | Default value | Description                                                                  |
+| ------------------ | ----------- | ------------- | ---------------------------------------------------------------------------- |
+| `name`             | `str`       | -             | Name of the augmentation                                                     |
+| `active`           | `bool`      | `True`        | Whether the augmentation is active                                           |
+| `use_for_resizing` | `bool`      | `False`       | Indicates whether the augmentation should be used for resizing               |
+| `apply_on_stages`  | `list[str]` | `["train"]`   | Which pipeline stages should apply the augmentation (`train`, `val`, `test`) |
+| `params`           | `dict`      | `{}`          | Parameters of the augmentation                                               |
 
 > [!NOTE]
 > The VerticalFlip and HorizontalFlip transforms do not change keypoint index ordering. They can be safely used only when the dataset has no symmetrical classes (e.g., left arm vs. right arm).

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -121,12 +121,33 @@ def _yield_visualizations(
     size_multiplier: Annotated[
         float, Parameter(["--size_multiplier", "-s"])
     ] = 1.0,
+    list_augmentations: bool = False,
 ) -> Iterator["np.ndarray"]:
     import cv2
     import numpy as np
-    from luxonis_ml.data.utils.visualizations import visualize
+    from luxonis_ml.data.utils.augmentations_collector import (
+        AugmentationsCollector,
+    )
+    from luxonis_ml.data.utils.visualizations import (
+        append_text_block,
+        visualize,
+    )
 
     from luxonis_train.utils.general import decode_text_metadata_labels
+
+    def add_augmentation_footer(
+        image: np.ndarray, augmentations: list[str]
+    ) -> np.ndarray:
+        min_dimension = min(image.shape[:2])
+        font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
+        augmentations_text = (
+            ", ".join(augmentations) if augmentations else "none"
+        )
+        return append_text_block(
+            image,
+            [f"Augmentations: {augmentations_text}"],
+            font_scale=font_scale,
+        )
 
     def get_visualization_item(
         idx: int,
@@ -161,6 +182,19 @@ def _yield_visualizations(
     model = create_model(config, opts)
 
     loader = model.loaders[view]
+    raw_loader = getattr(loader, "loader", None)
+    if list_augmentations and raw_loader is not None:
+        collector = AugmentationsCollector(
+            raw_loader.augmentations,  # type: ignore[attr-defined]
+            [
+                aug.model_dump()
+                for aug in model.cfg_preprocessing.get_active_augmentations()
+            ],
+        )
+        get_applied_augmentations = collector.get_applied_augmentations
+    else:
+        get_applied_augmentations = list
+
     metadata_types = loader.get_metadata_types()
     categorical_encodings = loader.get_categorical_encodings()
     for idx in range(len(loader)):
@@ -174,13 +208,16 @@ def _yield_visualizations(
         h, w, _ = main_image.shape
         new_h, new_w = int(h * size_multiplier), int(w * size_multiplier)
         main_image = cv2.resize(main_image, (new_w, new_h))
-        yield visualize(
+        viz = visualize(
             image=main_image,
             labels=np_labels,
             classes=loader.get_classes(),
             source_name=loader.image_source,
             categorical_encodings=categorical_encodings,
         )
+        if list_augmentations:
+            viz = add_augmentation_footer(viz, get_applied_augmentations())
+        yield viz
 
 
 @app.command(group=training_group, sort_key=3)
@@ -193,6 +230,7 @@ def inspect(
     size_multiplier: Annotated[
         float, Parameter(["--size_multiplier", "-s"])
     ] = 1.0,
+    list_augmentations: bool = False,
 ):
     """Inspect the dataset as specified in the configuration.
 
@@ -207,6 +245,9 @@ def inspect(
     @param size_multiplier: Multiplier for the image size. By default
         the images are shown in their original size. Use this option to
         scale them.
+    @type list_augmentations: bool
+    @param list_augmentations: Show the augmentations applied to each
+        displayed image in the footer.
     @type opts: list[str]
     @param opts: A list of optional CLI overrides of the config file.
     """
@@ -222,6 +263,7 @@ def inspect(
         config=config,
         view=view,
         size_multiplier=size_multiplier,
+        list_augmentations=list_augmentations,
         opts=opts,
     ):
         window_name = get_window()

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -129,25 +129,11 @@ def _yield_visualizations(
         AugmentationsCollector,
     )
     from luxonis_ml.data.utils.visualizations import (
-        append_text_block,
+        add_augmentation_footer,
         visualize,
     )
 
     from luxonis_train.utils.general import decode_text_metadata_labels
-
-    def add_augmentation_footer(
-        image: np.ndarray, augmentations: list[str]
-    ) -> np.ndarray:
-        min_dimension = min(image.shape[:2])
-        font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
-        augmentations_text = (
-            ", ".join(augmentations) if augmentations else "none"
-        )
-        return append_text_block(
-            image,
-            [f"Augmentations: {augmentations_text}"],
-            font_scale=font_scale,
-        )
 
     def get_visualization_item(
         idx: int,

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -378,6 +378,9 @@ class NormalizeAugmentationConfig(BaseModelExtraForbid):
 class AugmentationConfig(ConfigItem):
     active: bool = True
     use_for_resizing: bool = False
+    apply_on_stages: list[Literal["train", "val", "test"]] = Field(
+        default_factory=lambda: ["train"]
+    )
 
 
 class PreprocessingConfig(BaseModelExtraForbid):
@@ -472,6 +475,7 @@ class PreprocessingConfig(BaseModelExtraForbid):
                 name=aug.name,
                 params=aug.params,
                 use_for_resizing=aug.use_for_resizing,
+                apply_on_stages=aug.apply_on_stages,
             )
             for aug in self.augmentations
             if aug.active

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -1,11 +1,16 @@
 from pathlib import Path
-from typing import cast
+from typing import Any, Literal, cast
 
 import pytest
-from luxonis_ml.data import LuxonisDataset
+from luxonis_ml.data import AlbumentationsEngine, LuxonisDataset
+from luxonis_ml.data.loaders.luxonis_loader import LuxonisLoader
 from luxonis_ml.typing import Params
 
-from luxonis_train.config.config import Config
+from luxonis_train.config.config import (
+    AugmentationConfig,
+    Config,
+    PreprocessingConfig,
+)
 
 
 def test_smart_cfg_auto_populate(coco_dataset: LuxonisDataset):
@@ -143,6 +148,83 @@ def test_get_active_augmentations_preserves_apply_on_stages():
     active_augmentations = cfg.trainer.preprocessing.get_active_augmentations()
 
     assert active_augmentations[0].apply_on_stages == ["train", "test"]
+
+
+def test_apply_on_stages_reaches_stage_specific_augmentation_engines():
+    def get_transform_names(wrapped_transform: Any) -> list[str]:
+        if wrapped_transform is None:
+            return []
+        return next(
+            (
+                [type(item).__name__ for item in cell.cell_contents.transforms]
+                for cell in wrapped_transform.__closure__
+                if hasattr(cell.cell_contents, "transforms")
+            ),
+            [],
+        )
+
+    def resolve_pipeline_stage(
+        view: list[str],
+    ) -> Literal["train", "val", "test"]:
+        loader = LuxonisLoader.__new__(LuxonisLoader)
+        loader.view = view
+        return loader._get_augmentation_pipeline_stage()
+
+    preprocessing = PreprocessingConfig(
+        augmentations=[
+            AugmentationConfig(
+                name="HorizontalFlip",
+                params={"p": 1.0},
+                apply_on_stages=["train"],
+            ),
+            AugmentationConfig(
+                name="Defocus",
+                params={"p": 1.0},
+                apply_on_stages=["train", "val"],
+            ),
+        ]
+    )
+    engine_config = [
+        augmentation.model_dump(exclude={"active"})
+        for augmentation in preprocessing.get_active_augmentations()
+    ]
+
+    expected = {
+        "train": {
+            "spatial": ["HorizontalFlip"],
+            "pixel": ["Defocus", "Normalize"],
+        },
+        "val": {
+            "spatial": [],
+            "pixel": ["Defocus", "Normalize"],
+        },
+        "test": {
+            "spatial": [],
+            "pixel": ["Normalize"],
+        },
+    }
+
+    for loader_name, view in {
+        "train": ["train"],
+        "val": ["val"],
+        "test": ["test"],
+    }.items():
+        engine = AlbumentationsEngine(
+            256,
+            256,
+            {"/classification": "classification"},
+            {"/classification": 1},
+            ["image"],
+            engine_config,
+            pipeline_stage=resolve_pipeline_stage(view),
+        )
+
+        actual = {
+            "spatial": get_transform_names(engine.spatial_transform),
+            "pixel": get_transform_names(engine.pixel_transform),
+        }
+
+        assert actual == expected[loader_name]
 
 
 def test_config_invalid():

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -102,6 +102,49 @@ def test_explicit_dataset_type(tmp_path: Path):
     )
 
 
+def test_augmentation_apply_on_stages_defaults_to_train():
+    cfg = Config.get_config(
+        cast(
+            Params,
+            {
+                "model": {"nodes": [{"name": "ResNet"}]},
+                "trainer": {
+                    "preprocessing": {"augmentations": [{"name": "Defocus"}]}
+                },
+            },
+        )
+    )
+
+    assert cfg.trainer.preprocessing.augmentations[0].apply_on_stages == [
+        "train"
+    ]
+
+
+def test_get_active_augmentations_preserves_apply_on_stages():
+    cfg = Config.get_config(
+        cast(
+            Params,
+            {
+                "model": {"nodes": [{"name": "ResNet"}]},
+                "trainer": {
+                    "preprocessing": {
+                        "augmentations": [
+                            {
+                                "name": "Defocus",
+                                "apply_on_stages": ["train", "test"],
+                            }
+                        ]
+                    }
+                },
+            },
+        )
+    )
+
+    active_augmentations = cfg.trainer.preprocessing.get_active_augmentations()
+
+    assert active_augmentations[0].apply_on_stages == ["train", "test"]
+
+
 def test_config_invalid():
     cfg: Params = {
         "model": {

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -168,7 +168,10 @@ def test_apply_on_stages_reaches_stage_specific_augmentation_engines():
     ) -> Literal["train", "val", "test"]:
         loader = LuxonisLoader.__new__(LuxonisLoader)
         loader.view = view
-        return loader._get_augmentation_pipeline_stage()
+        return cast(
+            Literal["train", "val", "test"],
+            loader._get_augmentation_pipeline_stage(),
+        )
 
     preprocessing = PreprocessingConfig(
         augmentations=[


### PR DESCRIPTION
## Purpose
Relied on `feat/show-applied-augmentations` to manually test using `--list-augmentations` (that's why the target branch is `feat/show-applied-augmentations`, and also relies on a release of LuxonisML with a version bump

When `apply_on_stages` is not specified, the default behavior remains (no augmentation added to val):

```
augmentations:
  - name: Defocus
    params:
      p: 0.9
  - name: Sharpen
    params:
      p: 0.9
  - name: VerticalFlip
```

<img width="797" height="398" alt="val_before_apply_on_stages" src="https://github.com/user-attachments/assets/551ea8c3-ad7b-438a-85d3-1f87ca846d80" />

With the following config:

```
augmentations:
  - name: Defocus
    apply_on_stages: ["train", "val"]
    params:
      p: 0.9
  - name: Sharpen
    params:
      p: 0.9
  - name: VerticalFlip
```

Augmentations are added to val:

<img width="794" height="398" alt="val_after_apply_on_stages" src="https://github.com/user-attachments/assets/f9e89bd6-6f87-4e08-b2b1-1eb2a013cb60" />


## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
