### PR TITLE
Fix GracefulInterrupt to only save resume checkpoint on `fit` stage

### DIFF
--- a/luxonis_train/callbacks/graceful_interrupt.py
+++ b/luxonis_train/callbacks/graceful_interrupt.py
@@ -3,6 +3,7 @@ import signal
 import sys
 from pathlib import Path
 from types import FrameType
+from typing import Any
 
 import lightning.pytorch as pl
 from loguru import logger
@@ -29,6 +30,7 @@ class GracefulInterruptCallback(pl.Callback):
         self._interrupted = False
         self._trainer: pl.Trainer | None = None
         self._main_pid = os.getpid()
+        self._signal_handlers: dict[int, Any] = {}
 
     def setup(
         self,
@@ -38,13 +40,29 @@ class GracefulInterruptCallback(pl.Callback):
     ) -> None:
         self._trainer = trainer
 
-        if (
-            os.getpid() == self._main_pid
-        ):  # to avoid problem with multiple workers
-            signal.signal(signal.SIGINT, self._handle_signal)
-            signal.signal(signal.SIGTERM, self._handle_signal)
+        if stage != "fit":
+            return
+
+        if os.getpid() == self._main_pid:
+            for signum in (signal.SIGINT, signal.SIGTERM):
+                self._signal_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, self._handle_signal)
 
         logger.info("Added GracefulInterrupt callback")
+
+    def teardown(
+        self,
+        trainer: pl.Trainer,
+        pl_module: "lxt.LuxonisLightningModule",
+        stage: str | None = None,
+    ) -> None:
+        if stage != "fit":
+            return
+
+        if os.getpid() == self._main_pid:
+            for signum, handler in self._signal_handlers.items():
+                signal.signal(signum, handler)
+            self._signal_handlers.clear()
 
     def _handle_signal(self, signum: int, frame: FrameType | None) -> None:
         if os.getpid() != self._main_pid:

--- a/tests/unittests/test_callbacks/test_graceful_interrupt.py
+++ b/tests/unittests/test_callbacks/test_graceful_interrupt.py
@@ -1,0 +1,58 @@
+import signal
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from luxonis_train.callbacks.graceful_interrupt import (
+    GracefulInterruptCallback,
+)
+
+
+def test_graceful_interrupt_ignores_non_fit_stages(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    signal_calls: list[tuple[int, object]] = []
+    monkeypatch.setattr(
+        signal,
+        "signal",
+        lambda signum, handler: signal_calls.append((signum, handler)),
+    )
+
+    callback = GracefulInterruptCallback(tmp_path)
+    callback.setup(Mock(), Mock(), stage="predict")
+
+    assert signal_calls == []
+    assert callback._signal_handlers == {}
+
+
+def test_graceful_interrupt_restores_handlers_after_fit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    original_handlers = {
+        signal.SIGINT: object(),
+        signal.SIGTERM: object(),
+    }
+    signal_calls: list[tuple[int, object]] = []
+
+    monkeypatch.setattr(signal, "getsignal", original_handlers.__getitem__)
+    monkeypatch.setattr(
+        signal,
+        "signal",
+        lambda signum, handler: signal_calls.append((signum, handler)),
+    )
+
+    callback = GracefulInterruptCallback(tmp_path)
+    trainer = Mock()
+    pl_module = Mock()
+
+    callback.setup(trainer, pl_module, stage="fit")
+    callback.teardown(trainer, pl_module, stage="fit")
+
+    assert signal_calls == [
+        (signal.SIGINT, callback._handle_signal),
+        (signal.SIGTERM, callback._handle_signal),
+        (signal.SIGINT, original_handlers[signal.SIGINT]),
+        (signal.SIGTERM, original_handlers[signal.SIGTERM]),
+    ]
+    assert callback._signal_handlers == {}


### PR DESCRIPTION
## Purpose
When I was running `luxonis_train infer --config <config> --weights <weights>` I noticed that I could press on Ctrl + C and it would save the resume checkpoint, which shouldn't happen because we are in the `predict` stage. This is because I didn't limit the GracefulInterruptCallback to be only functional during the `fit` stage.

New `teardown`: restore the old signal handlers

Tests in `test_graceful_interrupt.py`: if the stage is `predict` then test that no signal handlers are registered, if the stage is `fit` then test that the GracefulInterruptCallback registers its own SIGINT and SIGTERM handlers and that `teardown` restores the original handlers.

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation


## AI Usage
Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES
