### PR TITLE
`resume_training` false with weights set loads weights but resets optimizer/scheduler, `strict_weights_loading` argument

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -55,15 +55,14 @@ The `Model` section is a crucial part of the configuration and **must always be 
 
 ### Configuration Options
 
-| Key                      | Type   | Default Value | Description                                                                                                                                                                            |
-| ------------------------ | ------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                   | `str`  | `"model"`     | Name of the model                                                                                                                                                                      |
-| `weights`                | `path` | `None`        | Path to a checkpoint file containing all model states, including weights, optimizer, and scheduler                                                                                     |
-| `strict_weights_loading` | `bool` | `False`       | Require strict compatibility for model weights when loading checkpoints. Missing loss/visualizer/metric checkpoint state is still allowed where those keys are intentionally filtered. |
-| `nodes`                  | `list` | `[]`          | List of nodes (see [Nodes](#nodes))                                                                                                                                                    |
-| `outputs`                | `list` | `[]`          | List of output nodes. If not specified, they are inferred from `nodes`                                                                                                                 |
-| `predefined_model`       | `dict` | `None`        | Dictionary specifying the predefined model name and its parameters                                                                                                                     |
-| `params`                 | `dict` | `{}`          | Parameters for the predefined model                                                                                                                                                    |
+| Key                | Type   | Default Value | Description                                                                                        |
+| ------------------ | ------ | ------------- | -------------------------------------------------------------------------------------------------- |
+| `name`             | `str`  | `"model"`     | Name of the model                                                                                  |
+| `weights`          | `path` | `None`        | Path to a checkpoint file containing all model states, including weights, optimizer, and scheduler |
+| `nodes`            | `list` | `[]`          | List of nodes (see [Nodes](#nodes))                                                                |
+| `outputs`          | `list` | `[]`          | List of output nodes. If not specified, they are inferred from `nodes`                             |
+| `predefined_model` | `dict` | `None`        | Dictionary specifying the predefined model name and its parameters                                 |
+| `params`           | `dict` | `{}`          | Parameters for the predefined model                                                                |
 
 ### Nodes
 
@@ -245,6 +244,7 @@ Here you can change everything related to actual training of the model.
 | `n_validation_batches`             | `PositiveInt \| None`                          | `None`                                 | Limits the number of validation/test batches and makes the val/test loaders deterministic                                                                                                                                                                   |
 | `smart_cfg_auto_populate`          | `bool`                                         | `True`                                 | Automatically populate sensible default values for missing config fields and log warnings. See [Trainer Tips](#trainer-tips) for more details                                                                                                               |
 | `resume_training`                  | `bool`                                         | `False`                                | Whether to resume training from a checkpoint. See [Trainer Tips](#trainer-tips) for more details                                                                                                                                                            |
+| `strict_weights_loading`           | `bool`                                         | `False`                                | Require strict compatibility for model weights when loading checkpoints. Missing loss/visualizer/metric checkpoint state is still allowed where those keys are intentionally filtered.                                                                      |
 | `preprocessing`                    | `dict`                                         | `{}`                                   | Configuration for image preprocessing and augmentations. [See preprocessing](#preprocessing) for more details                                                                                                                                               |
 | `callbacks`                        | `list`                                         | `[]`                                   | List of callback configurations to use during training. See [Callbacks](#callbacks) section for details and examples                                                                                                                                        |
 | `optimizer`                        | `dict`                                         | `{"name": "Adam", "params": {}}`       | What optimizer to use for training. See [Optimizer](#optimizer) section for details and examples                                                                                                                                                            |

--- a/configs/README.md
+++ b/configs/README.md
@@ -55,14 +55,15 @@ The `Model` section is a crucial part of the configuration and **must always be 
 
 ### Configuration Options
 
-| Key                | Type   | Default Value | Description                                                                                        |
-| ------------------ | ------ | ------------- | -------------------------------------------------------------------------------------------------- |
-| `name`             | `str`  | `"model"`     | Name of the model                                                                                  |
-| `weights`          | `path` | `None`        | Path to a checkpoint file containing all model states, including weights, optimizer, and scheduler |
-| `nodes`            | `list` | `[]`          | List of nodes (see [Nodes](#nodes))                                                                |
-| `outputs`          | `list` | `[]`          | List of output nodes. If not specified, they are inferred from `nodes`                             |
-| `predefined_model` | `dict` | `None`        | Dictionary specifying the predefined model name and its parameters                                 |
-| `params`           | `dict` | `{}`          | Parameters for the predefined model                                                                |
+| Key                      | Type   | Default Value | Description                                                                                                                                                                            |
+| ------------------------ | ------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                   | `str`  | `"model"`     | Name of the model                                                                                                                                                                      |
+| `weights`                | `path` | `None`        | Path to a checkpoint file containing all model states, including weights, optimizer, and scheduler                                                                                     |
+| `strict_weights_loading` | `bool` | `False`       | Require strict compatibility for model weights when loading checkpoints. Missing loss/visualizer/metric checkpoint state is still allowed where those keys are intentionally filtered. |
+| `nodes`                  | `list` | `[]`          | List of nodes (see [Nodes](#nodes))                                                                                                                                                    |
+| `outputs`                | `list` | `[]`          | List of output nodes. If not specified, they are inferred from `nodes`                                                                                                                 |
+| `predefined_model`       | `dict` | `None`        | Dictionary specifying the predefined model name and its parameters                                                                                                                     |
+| `params`                 | `dict` | `{}`          | Parameters for the predefined model                                                                                                                                                    |
 
 ### Nodes
 
@@ -447,8 +448,9 @@ training_strategy:
   ##### 1. **Fine-Tuning with Custom Configuration Example**
 
   - Set `resume_training: false`.
+  - Provide `model.weights` or pass `--weights` to initialize the model from an existing checkpoint.
   - Override the previous learning rate (LR), e.g., use `0.1` instead of `0.001`.
-  - Training starts fresh with the new LR, resetting the scheduler/optimizer (can use different ones).
+  - Training starts from the provided weights but with a fresh training state, resetting the scheduler/optimizer/epoch count (and can use different optimizer settings).
 
   ##### 2. **Resume Training Continuously Example**
 

--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -2,6 +2,7 @@ rich_logging: true
 
 model:
   name: model
+  strict_weights_loading: false
   nodes: []
   outputs: []
 

--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -2,7 +2,6 @@ rich_logging: true
 
 model:
   name: model
-  strict_weights_loading: false
   nodes: []
   outputs: []
 
@@ -58,6 +57,7 @@ trainer:
   epochs: 100
   overfit_batches: 0
   resume_training: false
+  strict_weights_loading: false
 
   n_workers: 4
   validation_interval: 5

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -117,7 +117,6 @@ class ModelConfig(BaseModelExtraForbid):
         PredefinedModelConfig | None, Field(exclude=True)
     ] = None
     weights: Annotated[FilePath | None, Field(exclude=True)] = None
-    strict_weights_loading: bool = False
     nodes: list[NodeConfig] = []
     outputs: list[str] = []
 
@@ -512,6 +511,7 @@ class TrainerConfig(BaseModelExtraForbid):
     epochs: PositiveInt = 100
     overfit_batches: NonNegativeInt = 0
     resume_training: bool = False
+    strict_weights_loading: bool = False
     n_workers: NonNegativeInt = 4
     validation_interval: Literal[-1] | PositiveInt = 5
     run_validation_after_first_epoch: bool = False

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -117,6 +117,7 @@ class ModelConfig(BaseModelExtraForbid):
         PredefinedModelConfig | None, Field(exclude=True)
     ] = None
     weights: Annotated[FilePath | None, Field(exclude=True)] = None
+    strict_weights_loading: bool = False
     nodes: list[NodeConfig] = []
     outputs: list[str] = []
 

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -146,6 +146,8 @@ class LuxonisModel:
             self.cfg = Config.get_config(cfg, opts)
 
         self.allow_empty_dataset = allow_empty_dataset
+        self._weights_provided_during_init = weights is not None
+        self._weights_provided_in_config = self.cfg.model.weights is not None
         self.weights = weights or self.cfg.model.weights
 
         self.cfg_preprocessing = self.cfg.trainer.preprocessing
@@ -1290,7 +1292,6 @@ class LuxonisModel:
     def resolve_weights(
         self, weights: PathType | dict[str, Any] | None
     ) -> PathType | dict[str, Any] | None:
-
         if isinstance(weights, dict):
             return weights
 
@@ -1299,8 +1300,12 @@ class LuxonisModel:
                 return self.weights
             return safe_download(self.weights)
 
-        logger.warning(
-            "Weights provided on the command line, but config weights are set. "
-            "Ignoring weights provided in config or during LuxonisModel initialization."
-        )
+        if (
+            self._weights_provided_in_config
+            and not self._weights_provided_during_init
+        ):
+            logger.warning(
+                "Weights provided on the command line, but config weights are set. "
+                "Ignoring weights provided in config."
+            )
         return safe_download(weights)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -432,11 +432,12 @@ class LuxonisModel:
                 "Training will start from scratch."
             )
         elif weights and self.cfg.trainer.resume_training is False:
-            logger.warning(
-                "Weights argument was given but resume_training is not set to True. "
-                "Training will start from scratch."
-                "To resume training from the given checkpoint, set resume_training to True."
+            logger.info(
+                "Weights argument was given and resume_training is set to False. "
+                "Training will start from the provided weights while resetting "
+                "optimizer, scheduler, and epoch state."
             )
+            self.lightning_module.load_checkpoint(weights)
 
         resume_weights = weights if self.cfg.trainer.resume_training else None
 

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -25,7 +25,10 @@ from luxonis_train.config import Config
 from luxonis_train.nodes import BaseNode
 from luxonis_train.typing import Labels, Packet
 from luxonis_train.utils import DatasetMetadata, LuxonisTrackerPL
-from luxonis_train.utils.checkpoint import filter_checkpoint_state_dict
+from luxonis_train.utils.checkpoint import (
+    CHECKPOINT_FILTERED_STATE_DICT_PATTERN,
+    filter_checkpoint_state_dict,
+)
 
 from .luxonis_output import LuxonisOutput
 from .utils import (
@@ -167,9 +170,41 @@ class LuxonisLightningModule(pl.LightningModule):
 
         In case resume_training is active, allow loading in a non-strict
         manner to allow loss, visualizer and metric nodes to be absent.
+        When strict weight loading is enabled, only those filtered
+        attached-module keys may be missing or unexpected.
         """
         if self.cfg.trainer.resume_training:
-            return super().load_state_dict(state_dict, strict=False)
+            incompatible = super().load_state_dict(state_dict, strict=False)
+            if not self.cfg.model.strict_weights_loading:
+                return incompatible
+
+            missing_keys = [
+                key
+                for key in incompatible.missing_keys
+                if not CHECKPOINT_FILTERED_STATE_DICT_PATTERN.match(key)
+            ]
+            unexpected_keys = [
+                key
+                for key in incompatible.unexpected_keys
+                if not CHECKPOINT_FILTERED_STATE_DICT_PATTERN.match(key)
+            ]
+
+            if missing_keys or unexpected_keys:
+                raise RuntimeError(
+                    "Error(s) in loading state_dict for "
+                    f"{self.__class__.__name__}:\n"
+                    + (
+                        f"\tMissing key(s): {', '.join(missing_keys)}.\n"
+                        if missing_keys
+                        else ""
+                    )
+                    + (
+                        f"\tUnexpected key(s): {', '.join(unexpected_keys)}.\n"
+                        if unexpected_keys
+                        else ""
+                    )
+                )
+            return _IncompatibleKeys([], [])
         return super().load_state_dict(state_dict, strict=strict)
 
     @property
@@ -586,6 +621,7 @@ class LuxonisLightningModule(pl.LightningModule):
 
         state_dict = ckpt["state_dict"]
         ver = Version.parse(ckpt.get("version", "0.3.0"))
+        strict_weights_loading = self.cfg.model.strict_weights_loading
 
         old_order = ckpt.get("execution_order")
         new_order = get_model_execution_order(self)
@@ -604,6 +640,8 @@ class LuxonisLightningModule(pl.LightningModule):
                 logger.error(
                     f"Failed to load checkpoint for node '{node_name}'"
                 )
+                if strict_weights_loading:
+                    raise
                 if old_order is None:
                     logger.error(
                         "Execution order not found in the checkpoint. "

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -174,7 +174,14 @@ class LuxonisLightningModule(pl.LightningModule):
         attached-module keys may be missing or unexpected.
         """
         if self.cfg.trainer.resume_training:
-            incompatible = super().load_state_dict(state_dict, strict=False)
+            filtered_state_dict = (
+                filter_checkpoint_state_dict(state_dict)
+                if self.cfg.trainer.strict_weights_loading
+                else state_dict
+            )
+            incompatible = super().load_state_dict(
+                filtered_state_dict, strict=False
+            )
             if not self.cfg.trainer.strict_weights_loading:
                 return incompatible
 

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -175,7 +175,7 @@ class LuxonisLightningModule(pl.LightningModule):
         """
         if self.cfg.trainer.resume_training:
             incompatible = super().load_state_dict(state_dict, strict=False)
-            if not self.cfg.model.strict_weights_loading:
+            if not self.cfg.trainer.strict_weights_loading:
                 return incompatible
 
             missing_keys = [
@@ -621,7 +621,7 @@ class LuxonisLightningModule(pl.LightningModule):
 
         state_dict = ckpt["state_dict"]
         ver = Version.parse(ckpt.get("version", "0.3.0"))
-        strict_weights_loading = self.cfg.model.strict_weights_loading
+        strict_weights_loading = self.cfg.trainer.strict_weights_loading
 
         old_order = ckpt.get("execution_order")
         new_order = get_model_execution_order(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,30 @@ def dinov3_weights() -> Path:
     return LuxonisFileSystem.download(remote_path, dest=dest_dir)
 
 
+@pytest.fixture(scope="session")
+def strict_loading_original_ckpt() -> Path:
+    checkpoint_name = "original_ckpt.ckpt"
+    dest_dir = Path("tests", "data", "checkpoints")
+    remote_path = f"gs://luxonis-test-bucket/luxonis-train-test-data/checkpoints/{checkpoint_name}"
+    return LuxonisFileSystem.download(remote_path, dest=dest_dir)
+
+
+@pytest.fixture(scope="session")
+def strict_loading_modified_model_ckpt() -> Path:
+    checkpoint_name = "modified_model_ckpt.ckpt"
+    dest_dir = Path("tests", "data", "checkpoints")
+    remote_path = f"gs://luxonis-test-bucket/luxonis-train-test-data/checkpoints/{checkpoint_name}"
+    return LuxonisFileSystem.download(remote_path, dest=dest_dir)
+
+
+@pytest.fixture(scope="session")
+def strict_loading_modified_attached_modules_ckpt() -> Path:
+    checkpoint_name = "modified_attached_modules_ckpt.ckpt"
+    dest_dir = Path("tests", "data", "checkpoints")
+    remote_path = f"gs://luxonis-test-bucket/luxonis-train-test-data/checkpoints/{checkpoint_name}"
+    return LuxonisFileSystem.download(remote_path, dest=dest_dir)
+
+
 class LuxonisTestDataset(LuxonisDataset):
     def __init__(self, *args, source_path: Path, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/integration/test_resume_training.py
+++ b/tests/integration/test_resume_training.py
@@ -1,29 +1,38 @@
 from pathlib import Path
 from unittest.mock import Mock
 
+import pytest
+import torch
 from luxonis_ml.data import LuxonisDataset
 from luxonis_ml.typing import Params
 
 from luxonis_train.core import LuxonisModel
 
 
-def test_resume_training_with_ema_does_not_crash(
-    parking_lot_dataset: LuxonisDataset, opts: Params, tmp_path: Path
-):
-    config_file = "configs/detection_light_model.yaml"
-    save_dir = tmp_path / "save-directory"
-
-    train_opts = opts | {
-        "loader.params.dataset_name": parking_lot_dataset.identifier,
+def _get_detection_light_train_opts(
+    dataset_name: str,
+    save_dir: Path,
+    *,
+    batch_size: int = 2,
+    epochs: int = 1,
+    overfit_batches: int = 1,
+    resume_training: bool = False,
+    strict_weights_loading: bool = False,
+) -> Params:
+    return {
+        "loader.params.dataset_name": dataset_name,
         "loader.train_view": "train",
         "loader.val_view": "train",
         "loader.test_view": "train",
         "model.predefined_model.params.task_name": "vehicles",
-        "trainer.overfit_batches": 1,
+        "trainer.overfit_batches": overfit_batches,
         "trainer.seed": 42,
         "trainer.deterministic": "warn",
-        "trainer.epochs": 1,
+        "trainer.epochs": epochs,
         "trainer.validation_interval": 1,
+        "trainer.batch_size": batch_size,
+        "trainer.resume_training": resume_training,
+        "trainer.strict_weights_loading": strict_weights_loading,
         "tracker.save_directory": str(save_dir),
         "trainer.callbacks": [
             {
@@ -39,57 +48,39 @@ def test_resume_training_with_ema_does_not_crash(
         ],
     }
 
-    model = LuxonisModel(config_file, train_opts)
-    model.train()
 
-    ckpt_path = model.get_best_metric_checkpoint_path()
-    assert ckpt_path, "No checkpoint found after initial training"
+def test_resume_training_with_ema_does_not_crash(
+    parking_lot_dataset: LuxonisDataset,
+    strict_loading_original_ckpt: Path,
+    tmp_path: Path,
+):
+    config_file = "configs/detection_light_model.yaml"
+    checkpoint = torch.load(
+        strict_loading_original_ckpt, map_location="cpu", weights_only=False
+    )
+    resume_opts = _get_detection_light_train_opts(
+        parking_lot_dataset.identifier,
+        tmp_path / "save-directory",
+        batch_size=4,
+        epochs=int(checkpoint.get("epoch", 0)) + 2,
+        overfit_batches=1,
+        resume_training=True,
+    )
 
-    resume_opts = train_opts | {
-        "trainer.resume_training": True,
-        "trainer.epochs": 2,
-    }
     resumed_model = LuxonisModel(config_file, resume_opts)
-    resumed_model.train(weights=ckpt_path)
+    resumed_model.train(weights=strict_loading_original_ckpt)
 
 
 def test_training_with_weights_without_resume_loads_checkpoint_only(
-    parking_lot_dataset: LuxonisDataset, opts: Params, tmp_path: Path
+    parking_lot_dataset: LuxonisDataset,
+    strict_loading_original_ckpt: Path,
+    tmp_path: Path,
 ):
     config_file = "configs/detection_light_model.yaml"
-    save_dir = tmp_path / "save-directory"
-
-    train_opts = opts | {
-        "loader.params.dataset_name": parking_lot_dataset.identifier,
-        "loader.train_view": "train",
-        "loader.val_view": "train",
-        "loader.test_view": "train",
-        "model.predefined_model.params.task_name": "vehicles",
-        "trainer.overfit_batches": 1,
-        "trainer.seed": 42,
-        "trainer.deterministic": "warn",
-        "trainer.epochs": 1,
-        "trainer.validation_interval": 1,
-        "tracker.save_directory": str(save_dir),
-        "trainer.callbacks": [
-            {
-                "name": "EMACallback",
-                "active": True,
-                "params": {"decay": 0.9999},
-            },
-            {"name": "TestOnTrainEnd", "active": False},
-            {"name": "ExportOnTrainEnd", "active": False},
-            {"name": "ArchiveOnTrainEnd", "active": False},
-            {"name": "ConvertOnTrainEnd", "active": False},
-            {"name": "UploadCheckpoint", "active": False},
-        ],
-    }
-
-    model = LuxonisModel(config_file, train_opts)
-    model.train()
-
-    ckpt_path = model.get_best_metric_checkpoint_path()
-    assert ckpt_path, "No checkpoint found after initial training"
+    train_opts = _get_detection_light_train_opts(
+        parking_lot_dataset.identifier,
+        tmp_path / "save-directory",
+    )
 
     fresh_model = LuxonisModel(config_file, train_opts)
     original_load_checkpoint = fresh_model.lightning_module.load_checkpoint
@@ -98,12 +89,79 @@ def test_training_with_weights_without_resume_loads_checkpoint_only(
     )
     fresh_model._train = Mock()
 
-    fresh_model.train(weights=ckpt_path)
+    fresh_model.train(weights=strict_loading_original_ckpt)
 
     fresh_model.lightning_module.load_checkpoint.assert_called_once()
     assert fresh_model.lightning_module.load_checkpoint.call_args is not None
     assert Path(
         fresh_model.lightning_module.load_checkpoint.call_args.args[0]
-    ) == Path(ckpt_path)
+    ) == Path(strict_loading_original_ckpt)
     assert fresh_model._train.call_args is not None
     assert fresh_model._train.call_args.args[0] is None
+
+
+def test_training_with_unexpected_checkpoint_key_fails_when_strict(
+    parking_lot_dataset: LuxonisDataset,
+    strict_loading_modified_model_ckpt: Path,
+    tmp_path: Path,
+):
+    config_file = "configs/detection_light_model.yaml"
+    train_opts = _get_detection_light_train_opts(
+        parking_lot_dataset.identifier,
+        tmp_path / "strict-save-directory",
+        batch_size=4,
+        epochs=1,
+        overfit_batches=1,
+        strict_weights_loading=True,
+    )
+
+    model = LuxonisModel(config_file, train_opts)
+
+    with pytest.raises(RuntimeError, match="Unexpected key\\(s\\)"):
+        model.train(weights=strict_loading_modified_model_ckpt)
+
+
+def test_training_with_unexpected_checkpoint_key_succeeds_when_not_strict(
+    parking_lot_dataset: LuxonisDataset,
+    strict_loading_modified_model_ckpt: Path,
+    tmp_path: Path,
+):
+    config_file = "configs/detection_light_model.yaml"
+    train_opts = _get_detection_light_train_opts(
+        parking_lot_dataset.identifier,
+        tmp_path / "nonstrict-save-directory",
+        batch_size=4,
+        epochs=1,
+        overfit_batches=1,
+        strict_weights_loading=False,
+    )
+
+    model = LuxonisModel(config_file, train_opts)
+    model.train(weights=strict_loading_modified_model_ckpt)
+
+
+def test_strict_resume_loading_ignores_attached_module_checkpoint_keys(
+    parking_lot_dataset: LuxonisDataset,
+    strict_loading_modified_attached_modules_ckpt: Path,
+    tmp_path: Path,
+):
+    config_file = "configs/detection_light_model.yaml"
+    train_opts = _get_detection_light_train_opts(
+        parking_lot_dataset.identifier,
+        tmp_path / "attached-modules-save-directory",
+        resume_training=True,
+        strict_weights_loading=True,
+    )
+    model = LuxonisModel(config_file, train_opts)
+    checkpoint = torch.load(
+        strict_loading_modified_attached_modules_ckpt,
+        map_location="cpu",
+        weights_only=False,
+    )
+
+    incompatible = model.lightning_module.load_state_dict(
+        checkpoint["state_dict"], strict=True
+    )
+
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []

--- a/tests/integration/test_resume_training.py
+++ b/tests/integration/test_resume_training.py
@@ -100,8 +100,10 @@ def test_training_with_weights_without_resume_loads_checkpoint_only(
 
     fresh_model.train(weights=ckpt_path)
 
-    fresh_model.lightning_module.load_checkpoint.assert_called_once_with(
-        ckpt_path
-    )
+    fresh_model.lightning_module.load_checkpoint.assert_called_once()
+    assert fresh_model.lightning_module.load_checkpoint.call_args is not None
+    assert Path(
+        fresh_model.lightning_module.load_checkpoint.call_args.args[0]
+    ) == Path(ckpt_path)
     assert fresh_model._train.call_args is not None
     assert fresh_model._train.call_args.args[0] is None

--- a/tests/integration/test_resume_training.py
+++ b/tests/integration/test_resume_training.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import Mock
 
 from luxonis_ml.data import LuxonisDataset
 from luxonis_ml.typing import Params
@@ -50,3 +51,57 @@ def test_resume_training_with_ema_does_not_crash(
     }
     resumed_model = LuxonisModel(config_file, resume_opts)
     resumed_model.train(weights=ckpt_path)
+
+
+def test_training_with_weights_without_resume_loads_checkpoint_only(
+    parking_lot_dataset: LuxonisDataset, opts: Params, tmp_path: Path
+):
+    config_file = "configs/detection_light_model.yaml"
+    save_dir = tmp_path / "save-directory"
+
+    train_opts = opts | {
+        "loader.params.dataset_name": parking_lot_dataset.identifier,
+        "loader.train_view": "train",
+        "loader.val_view": "train",
+        "loader.test_view": "train",
+        "model.predefined_model.params.task_name": "vehicles",
+        "trainer.overfit_batches": 1,
+        "trainer.seed": 42,
+        "trainer.deterministic": "warn",
+        "trainer.epochs": 1,
+        "trainer.validation_interval": 1,
+        "tracker.save_directory": str(save_dir),
+        "trainer.callbacks": [
+            {
+                "name": "EMACallback",
+                "active": True,
+                "params": {"decay": 0.9999},
+            },
+            {"name": "TestOnTrainEnd", "active": False},
+            {"name": "ExportOnTrainEnd", "active": False},
+            {"name": "ArchiveOnTrainEnd", "active": False},
+            {"name": "ConvertOnTrainEnd", "active": False},
+            {"name": "UploadCheckpoint", "active": False},
+        ],
+    }
+
+    model = LuxonisModel(config_file, train_opts)
+    model.train()
+
+    ckpt_path = model.get_best_metric_checkpoint_path()
+    assert ckpt_path, "No checkpoint found after initial training"
+
+    fresh_model = LuxonisModel(config_file, train_opts)
+    original_load_checkpoint = fresh_model.lightning_module.load_checkpoint
+    fresh_model.lightning_module.load_checkpoint = Mock(
+        wraps=original_load_checkpoint
+    )
+    fresh_model._train = Mock()
+
+    fresh_model.train(weights=ckpt_path)
+
+    fresh_model.lightning_module.load_checkpoint.assert_called_once_with(
+        ckpt_path
+    )
+    assert fresh_model._train.call_args is not None
+    assert fresh_model._train.call_args.args[0] is None


### PR DESCRIPTION
## Purpose
- New model-side config item `strict_weights_loading` that fails immediately if any part of the model state dict is different.
- If `resume_training` is set to False and weights are passed, then the weights are still loaded but the optimizer/scheduler states are taken from the config. Previously this combination of `resume_training` and weights being passed would create a fresh model instead of loading the weights.
- If `resume_training` is set to True, then the behavior is unchanged (from #326)
- Small bug fix: passing CLI weights would warn `Weights provided on the command line, but config weights are set. " "Ignoring weights provided in config or during LuxonisModel initialization` even if the config weights were not set, this has been patched. I had to add `self._weights_provided_during_init` and `self._weights_provided_in_config` attributes because one level lower (in `resolve_weights`) it has no indication of which weights came from the config or the CLI.

## Specification

## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
- Training a model from the [DetectionModel](https://github.com/luxonis/luxonis-train/blob/main/configs/detection_light_model.yaml) config then creating a new checkpoint from this model with an extra key `repvgg_encoder.scale_layer.conv.weight.__unexpected__` crashed quickly on `train` and `infer` if `strict_weights_loading` is set to True:
<img width="589" height="39" alt="strict_true" src="https://github.com/user-attachments/assets/30ee2ad4-38ad-41fd-81e4-80b9b3a8b4b4" />

- If `strict_weights_loading` is set to False (default), training and inference continue even with mis-matching state dicts:
<img width="889" height="119" alt="strict_false" src="https://github.com/user-attachments/assets/8d12748f-34a7-4bc9-b828-83151ca83f5d" />

- `resume_training` set to False and weights are passed: starts from epoch 0 again with only the checkpoint loaded but not the surrounding (optimizer/scheduler/epoch count etc) state.
<img width="889" height="33" alt="resume_training_false_warn" src="https://github.com/user-attachments/assets/354d82a8-99b6-4a69-a1c1-5cd1621f46fc" />
<img width="581" height="17" alt="resume_training_false" src="https://github.com/user-attachments/assets/2db70338-cc13-4b3d-8b4d-0490ceb387e5" />


## AI Usage
Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES
