### PR TITLE
Hotfix for no dependency config loading

### DIFF
--- a/luxonis_train/config/predefined_models/base_predefined_model.py
+++ b/luxonis_train/config/predefined_models/base_predefined_model.py
@@ -209,43 +209,47 @@ class SimplePredefinedModel(BasePredefinedModel):
         return nodes
 
     def _generate_metrics(self) -> list[MetricModuleConfig]:
-        if self._per_class_metrics is None:
-            return [
-                MetricModuleConfig(
-                    name=metric,
-                    params=self._metrics_params,
-                    is_main_metric=metric == self._main_metric,
-                )
-                for metric in self._metrics
-            ]
+        if self._per_class_metrics is not None:
+            try:
+                task = NODES.get(self._head).task
+                metrics = []
+                applied_per_class_override = False
 
-        with suppress(Exception):
-            task = NODES.get(self._head).task
-            metrics = []
-            applied_per_class_override = False
-
-            for metric in self._metrics:
-                metric_params = dict(self._metrics_params)
-                metric_cls = METRICS.get(metric)
-                aliases = metric_cls.get_predefined_model_params_aliases(task)
-                param_name = aliases.get("per_class_metrics")
-                if param_name is not None:
-                    metric_params[param_name] = self._per_class_metrics
-                    applied_per_class_override = True
-
-                metrics.append(
-                    MetricModuleConfig(
-                        name=metric,
-                        params=metric_params,
-                        is_main_metric=metric == self._main_metric,
+                for metric in self._metrics:
+                    metric_params = dict(self._metrics_params)
+                    metric_cls = METRICS.get(metric)
+                    aliases = metric_cls.get_predefined_model_params_aliases(
+                        task
                     )
-                )
+                    param_name = aliases.get("per_class_metrics")
+                    if param_name is not None:
+                        metric_params[param_name] = self._per_class_metrics
+                        applied_per_class_override = True
 
-            if self._metrics and not applied_per_class_override:
-                logger.warning(
-                    "Ignoring `per_class_metrics` for predefined model metrics "
-                    f"{self._metrics} because none of them support a per-class "
-                    "override."
-                )
+                    metrics.append(
+                        MetricModuleConfig(
+                            name=metric,
+                            params=metric_params,
+                            is_main_metric=metric == self._main_metric,
+                        )
+                    )
 
-            return metrics
+                if self._metrics and not applied_per_class_override:
+                    logger.warning(
+                        "Ignoring `per_class_metrics` for predefined model metrics "
+                        f"{self._metrics} because none of them support a per-class "
+                        "override."
+                    )
+                return metrics  # noqa: TRY300
+
+            except Exception:
+                logger.warning("Unable to ")
+
+        return [
+            MetricModuleConfig(
+                name=metric,
+                params=self._metrics_params,
+                is_main_metric=metric == self._main_metric,
+            )
+            for metric in self._metrics
+        ]

--- a/luxonis_train/config/predefined_models/base_predefined_model.py
+++ b/luxonis_train/config/predefined_models/base_predefined_model.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from contextlib import suppress
 from typing import Literal
 
 from loguru import logger
@@ -218,32 +219,33 @@ class SimplePredefinedModel(BasePredefinedModel):
                 for metric in self._metrics
             ]
 
-        task = NODES.get(self._head).task
-        metrics = []
-        applied_per_class_override = False
+        with suppress(Exception):
+            task = NODES.get(self._head).task
+            metrics = []
+            applied_per_class_override = False
 
-        for metric in self._metrics:
-            metric_params = dict(self._metrics_params)
-            metric_cls = METRICS.get(metric)
-            aliases = metric_cls.get_predefined_model_params_aliases(task)
-            param_name = aliases.get("per_class_metrics")
-            if param_name is not None:
-                metric_params[param_name] = self._per_class_metrics
-                applied_per_class_override = True
+            for metric in self._metrics:
+                metric_params = dict(self._metrics_params)
+                metric_cls = METRICS.get(metric)
+                aliases = metric_cls.get_predefined_model_params_aliases(task)
+                param_name = aliases.get("per_class_metrics")
+                if param_name is not None:
+                    metric_params[param_name] = self._per_class_metrics
+                    applied_per_class_override = True
 
-            metrics.append(
-                MetricModuleConfig(
-                    name=metric,
-                    params=metric_params,
-                    is_main_metric=metric == self._main_metric,
+                metrics.append(
+                    MetricModuleConfig(
+                        name=metric,
+                        params=metric_params,
+                        is_main_metric=metric == self._main_metric,
+                    )
                 )
-            )
 
-        if self._metrics and not applied_per_class_override:
-            logger.warning(
-                "Ignoring `per_class_metrics` for predefined model metrics "
-                f"{self._metrics} because none of them support a per-class "
-                "override."
-            )
+            if self._metrics and not applied_per_class_override:
+                logger.warning(
+                    "Ignoring `per_class_metrics` for predefined model metrics "
+                    f"{self._metrics} because none of them support a per-class "
+                    "override."
+                )
 
-        return metrics
+            return metrics


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Falls back to disabled per-class metrics in case of an error instead of crashing. 
This solves crashing no-dependency config loading in HubAI. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in metrics generation to gracefully manage exceptions without disrupting the application flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/luxonis-train/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->