### PR TITLE
Upload logs and config to tracker on test() runs as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,8 @@ model = LuxonisModel("configs/detection_light_model.yaml")
 model.test(weights="path/to/checkpoint.ckpt")
 ```
 
+If you plan to continue using the same `LuxonisModel` run after testing, for example to call `export()` or `archive()`, use `model.test(..., finalize_tracker=False)` to keep the tracker run open.
+
 The testing process can be started automatically at the end of the training by using the `TestOnTrainEnd` callback.
 To learn more about callbacks, see [Callbacks](https://github.com/luxonis/luxonis-train/blob/main/luxonis_train/callbacks/README.md).
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ model = LuxonisModel("configs/detection_light_model.yaml")
 model.test(weights="path/to/checkpoint.ckpt")
 ```
 
-If you plan to continue using the same `LuxonisModel` run after testing, for example to call `export()` or `archive()`, use `model.test(..., finalize_tracker=False)` to keep the tracker run open.
+If you plan to continue using the same `LuxonisModel` run after testing, for example to call `export()` or `archive()`, use `model.test(..., finalize_tracker=False)` to keep the tracker run open and call `model.finalize_run()` once the full sequence is complete.
 
 The testing process can be started automatically at the end of the training by using the `TestOnTrainEnd` callback.
 To learn more about callbacks, see [Callbacks](https://github.com/luxonis/luxonis-train/blob/main/luxonis_train/callbacks/README.md).

--- a/luxonis_train/callbacks/test_on_train_end.py
+++ b/luxonis_train/callbacks/test_on_train_end.py
@@ -38,7 +38,11 @@ class TestOnTrainEnd(NeedsCheckpoint):
 
         device_before = pl_module.device
 
-        pl_module.core.test(weights=checkpoint, view=self.view)
+        pl_module.core.test(
+            weights=checkpoint,
+            view=self.view,
+            finalize_tracker=False,
+        )
 
         # .test() moves pl_module to "cpu", we move it back to original device after
         pl_module.to(device_before)

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -409,8 +409,7 @@ class LuxonisModel:
             status = "failed"
             raise
         finally:
-            self._upload_run_metadata()
-            self.tracker._finalize(status)
+            self.finalize_run(status)
 
     def train(
         self,
@@ -674,7 +673,8 @@ class LuxonisModel:
         @param finalize_tracker: If True, uploads final run metadata and
             finalizes the tracker after testing. Set to False only when
             the current run is expected to continue with additional
-            actions such as export or archive.
+            actions such as export or archive, in which case the caller
+            is responsible for eventually calling L{finalize_run()}.
         """
         weights = self.resolve_weights(weights)
         loader = self.pytorch_loaders[view]
@@ -691,9 +691,8 @@ class LuxonisModel:
                 status = "failed"
                 raise
             finally:
-                self._upload_run_metadata()
                 if finalize_tracker:
-                    self.tracker._finalize(status)
+                    self.finalize_run(status)
 
         if new_thread:  # pragma: no cover
             self.thread = threading.Thread(
@@ -702,6 +701,15 @@ class LuxonisModel:
             )
             return self.thread.start()
         return _run_test()
+
+    def finalize_run(self, status: str = "success") -> None:
+        """Upload run metadata and finalize the tracker.
+
+        @type status: str
+        @param status: Final run status passed to the tracker.
+        """
+        self._upload_run_metadata()
+        self.tracker._finalize(status)
 
     def _upload_run_metadata(self) -> None:
         self.tracker.upload_artifact(self.log_file, typ="logs")

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -409,8 +409,7 @@ class LuxonisModel:
             status = "failed"
             raise
         finally:
-            self.tracker.upload_artifact(self.log_file, typ="logs")
-            self.tracker.upload_artifact(self.config_file, typ="config")
+            self._upload_run_metadata()
             self.tracker._finalize(status)
 
     def train(
@@ -635,6 +634,7 @@ class LuxonisModel:
         new_thread: Literal[False] = ...,
         view: Literal["train", "test", "val"] = "test",
         weights: PathType | dict[str, Any] | None = ...,
+        finalize_tracker: bool = True,
     ) -> Mapping[str, float]: ...
 
     @overload
@@ -643,6 +643,7 @@ class LuxonisModel:
         new_thread: Literal[True] = ...,
         view: Literal["train", "test", "val"] = "test",
         weights: PathType | dict[str, Any] | None = ...,
+        finalize_tracker: bool = True,
     ) -> None: ...
 
     @typechecked
@@ -651,6 +652,7 @@ class LuxonisModel:
         new_thread: bool = False,
         view: Literal["train", "val", "test"] = "test",
         weights: PathType | dict[str, Any] | None = None,
+        finalize_tracker: bool = True,
     ) -> Mapping[str, float] | None:
         """Runs testing.
 
@@ -668,19 +670,42 @@ class LuxonisModel:
             the configuration file will be used. The current weights of
             the model will be temporarily replaced with the weights from
             the specified checkpoint.
+        @type finalize_tracker: bool
+        @param finalize_tracker: If True, uploads final run metadata and
+            finalizes the tracker after testing. Set to False only when
+            the current run is expected to continue with additional
+            actions such as export or archive.
         """
         weights = self.resolve_weights(weights)
         loader = self.pytorch_loaders[view]
 
-        with replace_weights(self.lightning_module, weights):
-            if new_thread:  # pragma: no cover
-                self.thread = threading.Thread(
-                    target=self.pl_trainer.test,
-                    args=(self.lightning_module, loader),
-                    daemon=True,
-                )
-                return self.thread.start()
-            return self.pl_trainer.test(self.lightning_module, loader)[0]
+        def _run_test() -> Mapping[str, float]:
+            status = "success"
+            try:
+                with replace_weights(self.lightning_module, weights):
+                    return self.pl_trainer.test(self.lightning_module, loader)[
+                        0
+                    ]
+            except Exception:  # pragma: no cover
+                logger.exception("Encountered an exception during testing.")
+                status = "failed"
+                raise
+            finally:
+                self._upload_run_metadata()
+                if finalize_tracker:
+                    self.tracker._finalize(status)
+
+        if new_thread:  # pragma: no cover
+            self.thread = threading.Thread(
+                target=_run_test,
+                daemon=True,
+            )
+            return self.thread.start()
+        return _run_test()
+
+    def _upload_run_metadata(self) -> None:
+        self.tracker.upload_artifact(self.log_file, typ="logs")
+        self.tracker.upload_artifact(self.config_file, typ="config")
 
     def infer(
         self,

--- a/tests/integration/test_combinations.py
+++ b/tests/integration/test_combinations.py
@@ -150,7 +150,7 @@ def test_combinations(
         model.train()
 
     with subtests.test("test"):
-        model.test()
+        model.test(finalize_tracker=False)
 
     with subtests.test("export"):
         model.export()

--- a/tests/integration/test_combinations.py
+++ b/tests/integration/test_combinations.py
@@ -157,3 +157,5 @@ def test_combinations(
 
     with subtests.test("archive"):
         model.archive()
+
+    model.finalize_run()

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -65,7 +65,7 @@ def test_weights_loading(cifar10_dataset: LuxonisDataset, opts: Params):
     }
 
     model = LuxonisModel(config_file, opts)
-    test_results = model.test()
+    test_results = model.test(finalize_tracker=False)
     assert test_results == model.test(
         weights={"state_dict": model.lightning_module.state_dict()}
     )
@@ -98,7 +98,7 @@ def test_checkpoint(
             ],
         },  # type: ignore
     )
-    model.test()
+    model.test(finalize_tracker=False)
 
     ckpt = model.get_checkpoint()
     check_ckpt(ckpt)

--- a/tests/integration/test_custom_model.py
+++ b/tests/integration/test_custom_model.py
@@ -160,6 +160,8 @@ def test_custom_model(opts: Params, tmp_path: Path, subtests: SubTests):
             == len(model.pytorch_loaders["val"].dataset) * 2  # type: ignore
         )
 
+    model.finalize_run()
+
 
 def sort_by_name(config: dict, keys: list[str]) -> None:
     for key in keys:

--- a/tests/integration/test_custom_model.py
+++ b/tests/integration/test_custom_model.py
@@ -120,7 +120,7 @@ def test_custom_model(opts: Params, tmp_path: Path, subtests: SubTests):
         model.train()
 
     with subtests.test("test"):
-        model.test(view="val")
+        model.test(view="val", finalize_tracker=False)
 
     with subtests.test("export"):
         model.export()

--- a/tests/integration/test_mlflow_logging.py
+++ b/tests/integration/test_mlflow_logging.py
@@ -240,6 +240,35 @@ def test_mlflow_logging(xor_dataset: LuxonisDataset, subtests: SubTests):
         assert "test/epoch_duration_sec" in all_mlflow_logging_keys["metrics"]
 
 
+@pytest.mark.timeout(TIMEOUT)
+def test_mlflow_logging_on_standalone_test(xor_dataset: LuxonisDataset):
+    model = LuxonisModel(
+        get_config(),
+        {
+            "loader.params.dataset_name": xor_dataset.identifier,
+            "tracker.run_name": "xor_test_only_run",
+        },
+    )
+
+    model.test()
+
+    client = mlflow.tracking.MlflowClient()
+    experiments = mlflow.search_experiments()
+    experiment_id = experiments[0].experiment_id
+    run_id = client.search_runs(
+        experiment_ids=[experiment_id],
+        order_by=["start_time desc"],
+        filter_string='tags.mlflow.runName="xor_test_only_run"',
+    )[0].info.run_id
+
+    all_artifacts = list_artifacts(client, run_id)
+    run = client.get_run(run_id)
+
+    assert "luxonis_train.log" in all_artifacts
+    assert "training_config.yaml" in all_artifacts
+    assert run.info.status == "FINISHED"
+
+
 def get_config(trainer_overrides: Params | None = None) -> Params:
     trainer_cfg: Params = {
         "precision": "16-mixed",

--- a/tests/integration/test_remove_on_export.py
+++ b/tests/integration/test_remove_on_export.py
@@ -15,6 +15,7 @@ def test_train_only_heads(coco_dataset: LuxonisDataset, opts: Params):
     is_in_results = any(name_to_check in key for key in results)
 
     model.export()
+    model.finalize_run()
 
     sess = rt.InferenceSession(
         model.run_save_dir / "export" / f"{model.cfg.model.name}.onnx"

--- a/tests/integration/test_remove_on_export.py
+++ b/tests/integration/test_remove_on_export.py
@@ -9,7 +9,7 @@ def test_train_only_heads(coco_dataset: LuxonisDataset, opts: Params):
     opts |= {"loader.params.dataset_name": coco_dataset.dataset_name}
 
     model = LuxonisModel(get_config(), opts)
-    results = model.test()
+    results = model.test(finalize_tracker=False)
 
     name_to_check = "aux_segmentation_head"
     is_in_results = any(name_to_check in key for key in results)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Now logs and config are uploaded when `.test()` is ran in standalone
- Added optional `finalize_tracker=True` parameter to `.test()` to use in case test is not the only thing being called in the sequence (e.g. `TestOnTrainEnd` checkpoint inside the `.train()` run)

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `finalize_tracker` parameter to the test method, allowing the tracker to remain open for subsequent operations like `export()` or `archive()`.

* **Documentation**
  * Updated Testing section with guidance on using `finalize_tracker=False` to preserve tracker state during test operations.

* **Tests**
  * Added integration test validating standalone test execution with MLflow logging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->