### PR TITLE
Fix `per_class_metrics` for predefined models and increase coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,27 +131,6 @@ jobs:
             --junitxml=junit.xml \
             -o junit_family=legacy
 
-      - name: Upload test results to Codecov
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          flags: config
-
-      - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          flags: config
-
-      - name: Upload coverage as artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: coverage-config
-          path: coverage.xml
-          overwrite: true
-
   tests:
     needs:
       - config-test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,14 +115,42 @@ jobs:
         run: |
           pip install "luxonis-ml[utils] @ git+https://github.com/luxonis/luxonis-ml.git@main"
 
+      - name: Install dependencies for config test
+        run: |
+          pip install pytest-cov semver~=3.0
+          pip install -e . --no-deps
+
       - name: Test config without dependencies
         run: |
-          pip install semver~=3.0 pydantic-extra-types~=2.10
-          pip install -e . --no-deps
-          python -c 'from luxonis_train.config import Config; \
-                     from pathlib import Path; \
-                     [Config.get_config(p)
-                       for p in Path("configs").rglob("*.yaml")]'
+          pytest -x tests/unittests/test_config.py \
+            --confcutdir=tests/unittests \
+            --cov=luxonis_train/config \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=100 \
+            --junitxml=junit.xml \
+            -o junit_family=legacy
+
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          flags: config
+
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          flags: config
+
+      - name: Upload coverage as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: coverage-config
+          path: coverage.xml
+          overwrite: true
 
   tests:
     needs:

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -852,7 +852,7 @@ class Config(LuxonisConfig):
                 "Expected a boolean."
             )
 
-        with suppress(ModuleNotFoundError):
+        with suppress(ImportError):
             from luxonis_train.utils import setup_logging
 
             setup_logging(use_rich=use_rich)

--- a/luxonis_train/config/predefined_models/base_predefined_model.py
+++ b/luxonis_train/config/predefined_models/base_predefined_model.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
-from typing import Final, Literal
+from typing import Literal
 
-from loguru import logger
 from luxonis_ml.typing import Kwargs, Params, check_type
 from typeguard import typechecked
 from typing_extensions import override
@@ -15,10 +14,6 @@ from luxonis_train.config import (
 from luxonis_train.config.config import FreezingConfig
 from luxonis_train.registry import MODELS
 from luxonis_train.variants import VariantBase
-
-PER_CLASS_OVERRIDES: Final[dict[str, dict[str, str]]] = {
-    "MeanAveragePrecision": {"per_class_metrics": "class_metrics"},
-}
 
 
 class BasePredefinedModel(VariantBase, registry=MODELS, register=False):
@@ -212,26 +207,11 @@ class SimplePredefinedModel(BasePredefinedModel):
         return nodes
 
     def _generate_metrics(self) -> list[MetricModuleConfig]:
-        if self._per_class_metrics is None:
-            return [
-                MetricModuleConfig(
-                    name=metric,
-                    params=self._metrics_params,
-                    is_main_metric=metric == self._main_metric,
-                )
-                for metric in self._metrics
-            ]
-
         metrics = []
-        applied_per_class_override = False
-
         for metric in self._metrics:
             metric_params = dict(self._metrics_params)
-            aliases = PER_CLASS_OVERRIDES.get(metric, {})
-            param_name = aliases.get("per_class_metrics")
-            if param_name is not None:
-                metric_params[param_name] = self._per_class_metrics
-                applied_per_class_override = True
+            if self._per_class_metrics is not None:
+                metric_params["per_class_metrics"] = self._per_class_metrics
 
             metrics.append(
                 MetricModuleConfig(
@@ -239,13 +219,6 @@ class SimplePredefinedModel(BasePredefinedModel):
                     params=metric_params,
                     is_main_metric=metric == self._main_metric,
                 )
-            )
-
-        if self._metrics and not applied_per_class_override:
-            logger.warning(
-                "Ignoring `per_class_metrics` for predefined model metrics "
-                f"{self._metrics} because none of them support a per-class "
-                "override."
             )
 
         return metrics

--- a/luxonis_train/config/predefined_models/base_predefined_model.py
+++ b/luxonis_train/config/predefined_models/base_predefined_model.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Literal
+from typing import Final, Literal
 
 from loguru import logger
 from luxonis_ml.typing import Kwargs, Params, check_type
@@ -13,8 +13,12 @@ from luxonis_train.config import (
     NodeConfig,
 )
 from luxonis_train.config.config import FreezingConfig
-from luxonis_train.registry import METRICS, MODELS, NODES
+from luxonis_train.registry import MODELS
 from luxonis_train.variants import VariantBase
+
+PER_CLASS_OVERRIDES: Final[dict[str, dict[str, str]]] = {
+    "MeanAveragePrecision": {"per_class_metrics": "class_metrics"},
+}
 
 
 class BasePredefinedModel(VariantBase, registry=MODELS, register=False):
@@ -218,14 +222,12 @@ class SimplePredefinedModel(BasePredefinedModel):
                 for metric in self._metrics
             ]
 
-        task = NODES.get(self._head).task
         metrics = []
         applied_per_class_override = False
 
         for metric in self._metrics:
             metric_params = dict(self._metrics_params)
-            metric_cls = METRICS.get(metric)
-            aliases = metric_cls.get_predefined_model_params_aliases(task)
+            aliases = PER_CLASS_OVERRIDES.get(metric, {})
             param_name = aliases.get("per_class_metrics")
             if param_name is not None:
                 metric_params[param_name] = self._per_class_metrics

--- a/luxonis_train/config/predefined_models/segmentation_model.py
+++ b/luxonis_train/config/predefined_models/segmentation_model.py
@@ -38,7 +38,7 @@ class SegmentationModel(SimplePredefinedModel):
         if not isinstance(remove_aux_on_export, bool):
             raise TypeError(
                 "The `aux_head_params.remove_on_export` parameter "
-                f"must be a boolean. Got `{self._remove_aux_on_export}`."
+                f"must be a boolean. Got `{remove_aux_on_export}`."
             )
         self._remove_aux_on_export = remove_aux_on_export
 

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -579,7 +579,7 @@ def _translate_predefined_metric_params(
         return params
 
     per_class_metrics = params.pop("per_class_metrics")
-    if not per_class_metrics:
+    if per_class_metrics is None:
         return params
 
     task = None

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeVar
 
@@ -10,7 +11,7 @@ from lightning.pytorch.callbacks import (
     ModelCheckpoint,
 )
 from loguru import logger
-from luxonis_ml.typing import ConfigItem, check_type
+from luxonis_ml.typing import ConfigItem, Params, check_type
 from luxonis_ml.utils import traverse_graph
 from luxonis_ml.utils.registry import Registry
 from torch import Size, Tensor, nn
@@ -557,10 +558,47 @@ def _init_attached_module(
 ) -> tuple[str, T]:
     Module = registry.get(cfg.name)
     module_name = cfg.identifier
-    module = Module(**cfg.params, node=node, **kwargs)
+    params = dict(cfg.params)
+    if registry is METRICS:
+        params = _translate_predefined_metric_params(
+            node, cfg.name, Module, params
+        )
+    module = Module(**params, node=node, **kwargs)
     if module_name == "ConfusionMatrix":
         module_name = "mcc"
     return module_name, module
+
+
+def _translate_predefined_metric_params(
+    node: BaseNode,
+    metric_name: str,
+    Module: type[Any],
+    params: Params,
+) -> Params:
+    if "per_class_metrics" not in params:
+        return params
+
+    per_class_metrics = params.pop("per_class_metrics")
+    if not per_class_metrics:
+        return params
+
+    task = None
+    with suppress(RuntimeError):
+        task = node.task
+
+    aliases = Module.get_predefined_model_params_aliases(task)
+    param_name = aliases.get("per_class_metrics")
+    if param_name is None:
+        task_name = task.name if task is not None else "unknown"
+        logger.warning(
+            "Ignoring `per_class_metrics` for metric "
+            f"'{metric_name}' on task '{task_name}' because it does not "
+            "support a per-class override."
+        )
+        return params
+
+    params[param_name] = per_class_metrics
+    return params
 
 
 A = TypeVar("A", BaseLoss, BaseMetric, BaseVisualizer)

--- a/luxonis_train/nodes/backbones/efficientrep/efficientrep.py
+++ b/luxonis_train/nodes/backbones/efficientrep/efficientrep.py
@@ -137,7 +137,7 @@ class EfficientRep(BaseNode):
 
     @override
     def get_weights_url(self) -> str:
-        return "{github}/efficientrep_{variant}_coco.ckpt"
+        return f"{{github}}/efficientrep_{self.variant[0]}_coco.ckpt"
 
     @staticmethod
     @override

--- a/luxonis_train/nodes/heads/efficient_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_bbox_head.py
@@ -150,7 +150,7 @@ class EfficientBBoxHead(BaseDetectionHead):
 
     @override
     def get_weights_url(self) -> str:
-        return "{github}/efficientbbox_head_{variant}_coco.ckpt"
+        return f"{{github}}/efficientbbox_head_{self.variant[0]}_coco.ckpt"
 
     @property
     @override

--- a/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
+++ b/luxonis_train/nodes/necks/reppan_neck/reppan_neck.py
@@ -206,7 +206,7 @@ class RepPANNeck(BaseNode):
 
     @override
     def get_weights_url(self) -> str:
-        return "{github}/reppanneck_{variant}_coco.ckpt"
+        return f"{{github}}/reppanneck_{self.variant[0]}_coco.ckpt"
 
     @override
     @staticmethod

--- a/luxonis_train/variants.py
+++ b/luxonis_train/variants.py
@@ -126,10 +126,15 @@ def add_variant_aliases(
             "small": ["s"],
             "medium": ["m"],
             "large": ["l"],
+            "t": ["tiny"],
+            "n": ["nano"],
+            "s": ["small"],
+            "m": ["medium"],
+            "l": ["large"],
         }
-    else:
-        for alias, names in aliases.items():
-            for name in names:
+    for name, als in aliases.items():
+        if name in variants:
+            for alias in als:
                 variants[alias] = variants[name]
 
     return variants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,8 +159,8 @@ omit = [
   "**/_remote_module_non_scriptable.py",
   # These are not related to our `config.py`,
   # see https://github.com/nedbat/coveragepy/issues/1653
-  "config.py",
-  "config-3.py",
+  "./config.py",
+  "./config-3.py",
 ]
 parallel = true
 concurrency = ["multiprocessing"]

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -483,7 +483,13 @@ def test_convert_callback_deactivates_export_and_archive(
     cfg = Config.get_config(
         cast(
             Params,
-            BASE_MODEL_CFG | {"trainer": {"callbacks": callbacks_input}},
+            BASE_MODEL_CFG
+            | {
+                "trainer": {
+                    "smart_cfg_auto_populate": False,
+                    "callbacks": callbacks_input,
+                }
+            },
         )
     )
 

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -825,7 +825,8 @@ def test_simple_predefined_model_branches():
     assert nodes[1].freezing.active is True
     assert nodes[2].freezing.lr_after_unfreeze == 0.1
     assert nodes[2].task_name == "task"
-    assert nodes[2].metrics[0].params["class_metrics"] is True
+    assert nodes[2].metrics[0].params["per_class_metrics"] is True
+    assert nodes[2].metrics[1].params["per_class_metrics"] is True
     assert nodes[2].metrics[1].params["torchmetrics_task"] == "multiclass"
     assert nodes[2].metrics[1].is_main_metric is True
     assert nodes[2].metrics[2].name == "ConfusionMatrix"
@@ -866,18 +867,6 @@ def test_simple_predefined_model_branches():
         ConcreteSimplePredefinedModel._get_freezing({"freezing": "bad"})
 
     assert ConcreteSimplePredefinedModel._get_freezing({}).active is False
-
-
-def test_simple_predefined_model_per_class_no_override():
-    model = ConcreteSimplePredefinedModel(
-        backbone="Backbone",
-        head="Head",
-        loss="Loss",
-        metrics="Accuracy",
-        per_class_metrics=True,
-    )
-
-    assert model.nodes[-1].metrics[0].params == {}
 
 
 def test_ocr_recognition_model_alphabets_and_overrides():

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -1,21 +1,69 @@
+# pyright: reportArgumentType=false, reportCallIssue=false, reportAttributeAccessIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+import sys
 from pathlib import Path
-from typing import Any, Literal, cast
+from types import ModuleType
+from typing import Any
 
 import pytest
-from luxonis_ml.data import AlbumentationsEngine, LuxonisDataset
-from luxonis_ml.data.loaders.luxonis_loader import LuxonisLoader
 from luxonis_ml.typing import Params
+from pydantic import ValidationError
 
-from luxonis_train.config.config import (
-    AugmentationConfig,
+from luxonis_train.config import (
+    AttachedModuleConfig,
+    BasePredefinedModel,
     Config,
-    PreprocessingConfig,
+    ExportConfig,
+    LossModuleConfig,
+    MetricModuleConfig,
+    NodeConfig,
+    TrainerConfig,
 )
+from luxonis_train.config.config import (
+    ArchiveConfig,
+    AugmentationConfig,
+    BlobconverterExportConfig,
+    FreezingConfig,
+    HubAIExportConfig,
+    LoaderConfig,
+    ModelConfig,
+    NormalizeAugmentationConfig,
+    OnnxExportConfig,
+    PredefinedModelConfig,
+    PreprocessingConfig,
+    StorageConfig,
+    TrackerConfig,
+    TunerConfig,
+    _validate_quantization_mode,
+)
+from luxonis_train.config.predefined_models import (
+    AnomalyDetectionModel,
+    ClassificationModel,
+    DetectionModel,
+    FOMOModel,
+    InstanceSegmentationModel,
+    KeypointDetectionModel,
+    OCRRecognitionModel,
+    SegmentationModel,
+)
+from luxonis_train.config.predefined_models.base_predefined_model import (
+    SimplePredefinedModel,
+)
+
+BASE_MODEL_CFG: Params = {
+    "model": {"nodes": [{"name": "Backbone"}]},
+    "trainer": {"smart_cfg_auto_populate": False},
+}
+
+
+class ConcreteSimplePredefinedModel(SimplePredefinedModel):
+    @staticmethod
+    def get_variants() -> tuple[str, dict[str, Params]]:
+        return "default", {"default": {}}
 
 
 @pytest.mark.parametrize(
-    "path",
-    Path("configs").glob("*.yaml"),
+    "path", sorted(Path("configs").glob("*.yaml")), ids=lambda path: path.name
 )
 def test_config_load(path: Path):
     cfg = Config.get_config(path)
@@ -25,296 +73,351 @@ def test_config_load(path: Path):
     assert cfg.loader is not None
 
 
-def test_smart_cfg_auto_populate(coco_dataset: LuxonisDataset):
-    cfg = {
-        "model": {
-            "name": "test_auto_populate",
-            "predefined_model": {
-                "name": "DetectionModel",
-                "params": {
-                    "loss_params": {
-                        "iou_type": "siou",
-                        "iout_loss_weight": 14,
-                        "class_loss_weight": 1,
-                    }
-                },
-            },
-        },
-        "trainer": {
-            "batch_size": 2,
-            "epochs": 10,
-            "scheduler": {"name": "CosineAnnealingLR"},
-            "preprocessing": {
-                "train_image_size": [128, 128],
-                "augmentations": [{"name": "Mosaic4"}],
-            },
-        },
-        "loader": {"params": {"dataset_name": coco_dataset.identifier}},
-    }
-
-    cfg = Config.get_config(cfg)
-
-    assert cfg.trainer.scheduler is not None
-    scheduler_params = cfg.trainer.scheduler.params
-    assert scheduler_params["T_max"] == cfg.trainer.epochs
-
-    augmentations = cfg.trainer.preprocessing.augmentations[0].params
-    img_width, img_height = cfg.trainer.preprocessing.train_image_size
-    assert augmentations["out_width"] == img_width
-    assert augmentations["out_height"] == img_height
-
-    batch_size = cfg.trainer.batch_size
-    grad_accumulation = 64 // batch_size
-
-    assert cfg.model.predefined_model is not None
-    loss_params = cfg.model.predefined_model.params["loss_params"]
-    expected_iou_weight = 2.5 * grad_accumulation
-    expected_class_weight = 1.0 * grad_accumulation
-    assert isinstance(loss_params, dict)
-
-    assert loss_params["iou_loss_weight"] == expected_iou_weight
-    assert loss_params["class_loss_weight"] == expected_class_weight
-
-
-def test_smart_cfg_auto_populate_validation_batch_limit():
-    cfg = Config.get_config(
-        cast(
-            Params,
-            {
-                "model": {"nodes": [{"name": "ResNet"}]},
-                "loader": {
-                    "train_view": "train",
-                    "val_view": "train",
-                    "test_view": "train",
-                },
-            },
-        )
+def test_public_config_exports_are_importable():
+    assert AttachedModuleConfig(name="Metric", alias="alias").identifier == (
+        "alias"
     )
-    assert cfg.trainer.n_validation_batches == 10
-
-    cfg = Config.get_config(
-        cast(
-            Params,
-            {
-                "model": {"nodes": [{"name": "ResNet"}]},
-                "loader": {
-                    "train_view": "train",
-                    "val_view": "train",
-                    "test_view": "train",
-                },
-                "trainer": {"n_validation_batches": -1},
-            },
-        )
-    )
-    assert cfg.trainer.n_validation_batches == -1
+    assert BasePredefinedModel.__name__ == "BasePredefinedModel"
+    assert ExportConfig().quantization_mode == "INT8_STANDARD"
+    assert LossModuleConfig(name="loss", weight=0).identifier == "loss"
+    assert MetricModuleConfig(name="metric").is_main_metric is False
+    assert NodeConfig(name="node", alias="alias").identifier == "alias"
+    assert TrainerConfig().optimizer.name == "Adam"
+    assert ArchiveConfig().upload_to_run is True
+    assert BlobconverterExportConfig().version == "2022.1"
+    assert OnnxExportConfig().opset_version == 16
+    assert TrackerConfig().is_tensorboard is True
+    assert TunerConfig().storage.active is True
+    assert StorageConfig(active=False).active is False
+    assert NormalizeAugmentationConfig().active is True
+    assert PredefinedModelConfig(name="DetectionModel").variant == "default"
+    assert FreezingConfig(active=True).active is True
 
 
-def test_config_dump(coco_dataset: LuxonisDataset, tmp_path: Path):
+def test_config_dump_roundtrip_without_dataset_fixture(tmp_path: Path):
     model_config_path = Path("configs", "detection_light_model.yaml")
     temp_config_path = tmp_path / "config.yaml"
 
-    config = Config.get_config(model_config_path)
-    config.save_data(temp_config_path)
+    cfg = Config.get_config(
+        model_config_path,
+        {"loader.params": {"dataset_name": "coco_test"}},
+    )
+    cfg.save_data(temp_config_path)
 
-    opts: Params = {
-        "loader.params.dataset_name": coco_dataset.identifier,
-    }
+    cfg1 = Config.get_config(temp_config_path).model_dump()
+    cfg2 = Config.get_config(
+        model_config_path,
+        {"loader.params": {"dataset_name": "coco_test"}},
+    ).model_dump()
 
-    cfg1 = Config.get_config(temp_config_path, opts).model_dump()
-    cfg2 = Config.get_config(model_config_path, opts).model_dump()
-
-    assert cfg1 == cfg2, "Model configs are not the same"
+    assert cfg1 == cfg2
+    assert "ENVIRON" not in cfg.model_dump()
+    assert "ENVIRON" not in cfg.model_dump_json()
     assert "Normalize" not in [
         aug["name"]
         for aug in cfg1["trainer"]["preprocessing"]["augmentations"]
     ]
 
 
-def test_explicit_dataset_type(tmp_path: Path):
-    model_config_path = Path("configs", "detection_light_model.yaml")
-    temp_config_path = tmp_path / "config.yaml"
-
-    cfg1 = Config.get_config(
-        model_config_path,
-        {
-            "loader.params": {
-                "dataset_name": "coco_test",
-                "dataset_type": "coco",
-            },
-        },
-    )
-    cfg1.save_data(temp_config_path)
-
-    cfg2 = Config.get_config(temp_config_path)
-    assert (
-        cfg1.loader.params["dataset_type"]
-        == cfg2.loader.params["dataset_type"]
-    )
-
-
-def test_augmentation_apply_on_stages_defaults_to_train():
-    cfg = Config.get_config(
-        cast(
-            Params,
-            {
-                "model": {"nodes": [{"name": "ResNet"}]},
-                "trainer": {
-                    "preprocessing": {"augmentations": [{"name": "Defocus"}]}
-                },
-            },
-        )
-    )
-
-    assert cfg.trainer.preprocessing.augmentations[0].apply_on_stages == [
-        "train"
-    ]
-
-
-def test_get_active_augmentations_preserves_apply_on_stages():
-    cfg = Config.get_config(
-        cast(
-            Params,
-            {
-                "model": {"nodes": [{"name": "ResNet"}]},
-                "trainer": {
-                    "preprocessing": {
-                        "augmentations": [
-                            {
-                                "name": "Defocus",
-                                "apply_on_stages": ["train", "test"],
-                            }
-                        ]
-                    }
-                },
-            },
-        )
-    )
-
-    active_augmentations = cfg.trainer.preprocessing.get_active_augmentations()
-
-    assert active_augmentations[0].apply_on_stages == ["train", "test"]
-
-
-def test_apply_on_stages_reaches_stage_specific_augmentation_engines():
-    def get_transform_names(wrapped_transform: Any) -> list[str]:
-        if wrapped_transform is None:
-            return []
-        return next(
-            (
-                [type(item).__name__ for item in cell.cell_contents.transforms]
-                for cell in wrapped_transform.__closure__
-                if hasattr(cell.cell_contents, "transforms")
-            ),
-            [],
-        )
-
-    def resolve_pipeline_stage(
-        view: list[str],
-    ) -> Literal["train", "val", "test"]:
-        loader = LuxonisLoader.__new__(LuxonisLoader)
-        loader.view = view
-        return cast(
-            Literal["train", "val", "test"],
-            loader._get_augmentation_pipeline_stage(),
-        )
-
-    preprocessing = PreprocessingConfig(
-        augmentations=[
-            AugmentationConfig(
-                name="HorizontalFlip",
-                params={"p": 1.0},
-                apply_on_stages=["train"],
-            ),
-            AugmentationConfig(
-                name="Defocus",
-                params={"p": 1.0},
-                apply_on_stages=["train", "val"],
-            ),
+def test_model_node_validation_linearizes_heads_and_outputs():
+    model = ModelConfig(
+        nodes=[
+            {"name": "Backbone"},
+            {"name": "Neck"},
+            {"name": "FirstHead"},
+            {"name": "SecondHead"},
         ]
     )
-    engine_config = [
-        augmentation.model_dump(exclude={"active"})
-        for augmentation in preprocessing.get_active_augmentations()
+
+    assert [node.inputs for node in model.nodes] == [
+        [],
+        ["Backbone"],
+        ["Neck"],
+        ["Neck"],
     ]
+    assert model.outputs == ["FirstHead", "SecondHead"]
 
-    expected = {
-        "train": {
-            "spatial": ["HorizontalFlip"],
-            "pixel": ["Defocus", "Normalize"],
-        },
-        "val": {
-            "spatial": [],
-            "pixel": ["Defocus", "Normalize"],
-        },
-        "test": {
-            "spatial": [],
-            "pixel": ["Normalize"],
-        },
-    }
 
-    for loader_name, view in {
-        "train": ["train"],
-        "val": ["val"],
-        "test": ["test"],
-    }.items():
-        engine = AlbumentationsEngine(
-            256,
-            256,
-            {"/classification": "classification"},
-            {"/classification": 1},
-            ["image"],
-            engine_config,
-            pipeline_stage=resolve_pipeline_stage(view),
+def test_model_node_validation_rejects_missing_name():
+    with pytest.raises(ValueError, match="does not specify"):
+        ModelConfig(nodes=[{}])
+
+
+def test_model_config_accepts_existing_node_instances():
+    node = NodeConfig(name="Backbone")
+    assert ModelConfig(nodes=[node]).nodes == [node]
+
+
+def test_model_config_rejects_invalid_graph_and_names():
+    with pytest.raises(ValueError, match="not acyclic"):
+        ModelConfig(
+            nodes=[
+                {"name": "A", "inputs": ["B"]},
+                {"name": "B", "inputs": ["A"]},
+            ]
         )
 
-        actual = {
-            "spatial": get_transform_names(engine.spatial_transform),
-            "pixel": get_transform_names(engine.pixel_transform),
-        }
+    with pytest.raises(ValueError, match="contain a '/'"):
+        ModelConfig(nodes=[{"name": "Invalid/Node"}])
 
-        assert actual == expected[loader_name]
-
-
-def test_config_invalid():
-    cfg: Params = {
-        "model": {
-            "nodes": [
-                {"name": "ResNet"},
+    with pytest.raises(ValueError, match="contain a '/'"):
+        ModelConfig(
+            nodes=[
                 {
-                    "name": "SegmentationHead",
-                    "metrics": [
-                        {
-                            "name": "Accuracy",
-                            "is_main_metric": True,
-                        },
-                        {
-                            "name": "JaccardIndex",
-                            "is_main_metric": True,
-                        },
-                    ],
-                },
+                    "name": "Head",
+                    "metrics": [{"name": "Invalid/Metric"}],
+                }
             ]
-        },
-    }
+        )
+
+    with pytest.raises(ValueError, match="contain a '/'"):
+        ModelConfig(
+            nodes=[
+                {
+                    "name": "Head",
+                    "metrics": [{"name": "Metric", "alias": "Invalid/Alias"}],
+                }
+            ]
+        )
+
+
+def test_model_config_no_outputs_guard(monkeypatch: pytest.MonkeyPatch):
+    import luxonis_train.config.config as config_module
+
+    monkeypatch.setattr(config_module, "is_acyclic", lambda graph: True)
+    model = ModelConfig.model_construct(
+        nodes=[NodeConfig(name="A", inputs=["A"])],
+        outputs=[],
+    )
+
+    with pytest.raises(ValueError, match="No outputs"):
+        model.check_graph()
+
+
+def test_model_config_main_metric_and_duplicate_name_handling():
+    model = ModelConfig(
+        nodes=[
+            {
+                "name": "Head",
+                "alias": "dup",
+                "losses": [
+                    {"name": "dup"},
+                    {"name": "Other", "alias": "dup"},
+                ],
+                "metrics": [
+                    {"name": "Accuracy"},
+                    {"name": "Accuracy"},
+                ],
+            }
+        ]
+    )
+
+    node = model.nodes[0]
+    assert node.losses[0].alias == "dup_dup"
+    assert node.losses[1].alias == "dup_0"
+    assert node.metrics[0].is_main_metric is True
+    assert node.metrics[1].alias == "Accuracy_dup"
+
+    nested_node = NodeConfig.model_construct(name="dup", alias=None)
+    node_with_node_module = NodeConfig.model_construct(
+        name="dup",
+        alias=None,
+        losses=[nested_node],
+        metrics=[],
+        visualizers=[],
+    )
+    model = ModelConfig.model_construct(
+        nodes=[node_with_node_module], outputs=["dup"]
+    )
+    model.check_unique_names()
+    assert nested_node.alias == "dup_0"
+
     with pytest.raises(ValueError, match="Only one main metric"):
-        Config.get_config(cfg)
+        ModelConfig(
+            nodes=[
+                {
+                    "name": "Head",
+                    "metrics": [
+                        {"name": "Accuracy", "is_main_metric": True},
+                        {"name": "JaccardIndex", "is_main_metric": True},
+                    ],
+                }
+            ]
+        )
+
+
+def test_head_nodes_uses_lazy_nodes_import(monkeypatch: pytest.MonkeyPatch):
+    class FakeBaseHead:
+        pass
+
+    class FakeOutput(FakeBaseHead):
+        pass
+
+    fake_nodes = ModuleType("luxonis_train.nodes")
+    fake_nodes.BaseHead = FakeBaseHead
+    monkeypatch.setitem(sys.modules, "luxonis_train.nodes", fake_nodes)
+
+    import luxonis_train.config.config as config_module
+
+    monkeypatch.setitem(
+        config_module.NODES._module_dict, "FakeOutput", FakeOutput
+    )
+
+    model = ModelConfig(
+        nodes=[
+            {"name": "FakeOutput"},
+            {"name": "OtherNode"},
+        ]
+    )
+
+    assert [node.name for node in model.head_nodes] == ["FakeOutput"]
+
+
+def test_loader_config_validation_and_serialization():
+    cfg = LoaderConfig(
+        name="DummyLoader",
+        train_view="train",
+        val_view=["val"],
+        test_view="test",
+        params={
+            "dataset_type": "coco",
+            "n_classes": 3,
+            "n_keypoints": 2,
+            "class_names": ["a", "b", "c"],
+            "kept": True,
+        },
+    )
+
+    dumped = cfg.model_dump()
+    assert dumped["name"] == "LuxonisLoaderTorch"
+    assert dumped["params"] == {"dataset_type": "coco", "kept": True}
+    assert cfg.train_view == ["train"]
+    assert cfg.test_view == ["test"]
+
+    with pytest.raises(TypeError, match="dataset_type"):
+        LoaderConfig(params={"dataset_type": 1})
+
+    with pytest.raises(ValueError, match="not supported"):
+        LoaderConfig(params={"dataset_type": "unknown"})
+
+    with pytest.raises(TypeError, match="train_view"):
+        LoaderConfig(train_view=1)
+
+
+def test_preprocessing_normalization_and_resizing():
+    cfg = PreprocessingConfig(
+        train_image_size=(128, 256),
+        augmentations=[
+            AugmentationConfig(name="Normalize", params={"mean": [0]}),
+            AugmentationConfig(
+                name="Resize",
+                params={"height": 1, "width": 2},
+                use_for_resizing=True,
+            ),
+            AugmentationConfig(name="Inactive", active=False),
+            AugmentationConfig(
+                name="Active", apply_on_stages=["train", "val"]
+            ),
+        ],
+    )
+
+    assert cfg.normalize.params == {"mean": [0]}
+    resize = next(aug for aug in cfg.augmentations if aug.name == "Resize")
+    assert resize.params == {"height": 128, "width": 256, "p": 1.0}
+    assert [aug.name for aug in cfg.get_active_augmentations()] == [
+        "Resize",
+        "Active",
+        "Normalize",
+    ]
+    assert cfg.get_active_augmentations()[1].apply_on_stages == [
+        "train",
+        "val",
+    ]
+    assert "Normalize" not in [
+        aug["name"] for aug in cfg.model_dump()["augmentations"]
+    ]
+
+    assert (
+        PreprocessingConfig(
+            normalize=NormalizeAugmentationConfig(active=False)
+        ).augmentations
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    ("trainer", "expected"),
+    [
+        (
+            TrainerConfig(
+                epochs=7,
+                scheduler={"name": "CosineAnnealingLR"},
+            ),
+            {"T_max": 7},
+        ),
+        (
+            TrainerConfig(
+                epochs=7,
+                scheduler={
+                    "name": "CosineAnnealingLR",
+                    "params": {"T_max": 3},
+                },
+            ),
+            {"T_max": 3},
+        ),
+    ],
+)
+def test_trainer_scheduler_validation(
+    trainer: TrainerConfig, expected: dict[str, int]
+):
+    assert trainer.scheduler.params == expected
+
+
+def test_trainer_validation_branches(monkeypatch: pytest.MonkeyPatch):
+    trainer = TrainerConfig(
+        seed=1,
+        deterministic=None,
+        overfit_batches=1,
+        validation_interval=10,
+        epochs=2,
+        callbacks=[
+            {"name": "Later"},
+            {"name": "EMACallback"},
+            {
+                "name": "GradientAccumulationScheduler",
+                "params": {"scheduling": {"1": 2, "x": 3}},
+            },
+        ],
+    )
+
+    assert trainer.deterministic is True
+    assert trainer.validation_interval == 2
+    assert [callback.name for callback in trainer.callbacks[:2]] == [
+        "EMACallback",
+        "Later",
+    ]
+    assert trainer.callbacks[2].params["scheduling"] == {1: 2, "x": 3}
+
+    trainer = TrainerConfig(
+        callbacks=[
+            {
+                "name": "GradientAccumulationScheduler",
+                "params": {"scheduling": ["not", "mapping"]},
+            }
+        ]
+    )
+    assert trainer.callbacks[0].params["scheduling"] == ["not", "mapping"]
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert TrainerConfig(n_workers=4).n_workers == 0
 
 
 @pytest.mark.parametrize(
     ("callbacks_input", "expected_active"),
     [
-        (
-            [{"name": "ConvertOnTrainEnd"}],
-            {"ConvertOnTrainEnd": True},
-        ),
-        (
-            [{"name": "ExportOnTrainEnd"}],
-            {"ExportOnTrainEnd": True},
-        ),
-        (
-            [{"name": "ArchiveOnTrainEnd"}],
-            {"ArchiveOnTrainEnd": True},
-        ),
+        ([{"name": "ConvertOnTrainEnd"}], {"ConvertOnTrainEnd": True}),
+        ([{"name": "ExportOnTrainEnd"}], {"ExportOnTrainEnd": True}),
+        ([{"name": "ArchiveOnTrainEnd"}], {"ArchiveOnTrainEnd": True}),
         (
             [{"name": "ExportOnTrainEnd"}, {"name": "ArchiveOnTrainEnd"}],
             {"ExportOnTrainEnd": True, "ArchiveOnTrainEnd": True},
@@ -351,26 +454,457 @@ def test_config_invalid():
 def test_convert_callback_deactivates_export_and_archive(
     callbacks_input: list[Params], expected_active: dict[str, bool]
 ):
-    """Test that ConvertOnTrainEnd deactivates ExportOnTrainEnd and
-    ArchiveOnTrainEnd.
-    """
     cfg = Config.get_config(
-        cast(
-            Params,
-            {
-                "model": {"nodes": [{"name": "ResNet"}]},
-                "trainer": {"callbacks": callbacks_input},
-            },
-        )
+        BASE_MODEL_CFG | {"trainer": {"callbacks": callbacks_input}}
     )
 
     callbacks_by_name = {cb.name: cb for cb in cfg.trainer.callbacks}
 
     for callback_name, should_be_active in expected_active.items():
-        assert callback_name in callbacks_by_name, (
-            f"Callback '{callback_name}' not found in config"
+        assert callbacks_by_name[callback_name].active == should_be_active
+
+
+def test_export_config_validation():
+    assert _validate_quantization_mode("fp16") == "FP16_STANDARD"
+    assert ExportConfig(data_type="fp32").quantization_mode == "FP32_STANDARD"
+    assert ExportConfig(
+        scale_values=1, mean_values=[2, 3, 4]
+    ).scale_values == [
+        1,
+        1,
+        1,
+    ]
+    assert HubAIExportConfig(active=True, platform="rvc4").platform == "rvc4"
+
+    with pytest.raises(ValueError, match="Invalid quantization_mode"):
+        ExportConfig(quantization_mode="bad")
+
+    with pytest.raises(ValueError, match="platform"):
+        HubAIExportConfig(active=True)
+
+    with pytest.raises(NotImplementedError, match="Hailo"):
+        HubAIExportConfig(platform="hailo")
+
+
+def test_config_validators_and_storage(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRES_USER", "user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "pass")
+    monkeypatch.setenv("POSTGRES_HOST", "host")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DB", "db")
+
+    cfg = Config.get_config(
+        {
+            "ENVIRON": {},
+            "model": {"nodes": [{"name": "Backbone"}]},
+            "trainer": {"smart_cfg_auto_populate": False},
+            "tuner": {"storage": {"backend": "postgresql"}},
+        }
+    )
+
+    assert cfg.tuner.storage.username == "user"
+    assert cfg.tuner.storage.password is not None
+    assert cfg.tuner.storage.password.get_secret_value() == "pass"
+    assert cfg.tuner.storage.host == "host"
+    assert cfg.tuner.storage.port == 5432
+    assert cfg.tuner.storage.database == "db"
+
+    assert Config.get_config(BASE_MODEL_CFG).tuner.storage.database == (
+        "study_local.db"
+    )
+
+    with pytest.raises(TypeError, match="rich_logging"):
+        Config.get_config({"rich_logging": "yes"})
+
+    fake_utils = ModuleType("luxonis_train.utils")
+    calls: list[bool] = []
+
+    def setup_logging(*, use_rich: bool) -> None:
+        calls.append(use_rich)
+
+    fake_utils.setup_logging = setup_logging
+    monkeypatch.setitem(sys.modules, "luxonis_train.utils", fake_utils)
+    Config.get_config(BASE_MODEL_CFG | {"rich_logging": False})
+    assert calls == [False]
+
+    constructed = Config.model_construct(tuner=None)
+    assert constructed.check_tune_storage() is constructed
+
+
+def test_config_get_config_handles_string_mlflow_paths(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import luxonis_train.config.config as config_module
+
+    class FakeFileSystem:
+        def __init__(self, path: str):
+            self.path = path
+            self.is_mlflow = True
+            self.experiment_id = "experiment"
+            self.run_id = "run"
+
+        @staticmethod
+        def download(path: str, cache: Path) -> dict[str, Any]:
+            return {
+                "model": {"nodes": [{"name": "Backbone"}]},
+                "trainer": {"smart_cfg_auto_populate": False},
+            }
+
+    monkeypatch.setattr(config_module, "LuxonisFileSystem", FakeFileSystem)
+
+    cfg = Config.get_config("mlflow://config.yaml")
+
+    assert cfg.tracker.project_id == "experiment"
+    assert cfg.tracker.run_id == "run"
+
+
+def test_smart_cfg_auto_populate_without_dataset_fixture():
+    cfg = Config.get_config(
+        {
+            "model": {
+                "name": "test_auto_populate",
+                "predefined_model": {
+                    "name": "DetectionModel",
+                    "params": {
+                        "loss_params": {
+                            "iou_type": "siou",
+                            "iou_loss_weight": 14,
+                            "class_loss_weight": 1,
+                        }
+                    },
+                },
+            },
+            "trainer": {
+                "batch_size": 2,
+                "epochs": 10,
+                "scheduler": {"name": "CosineAnnealingLR"},
+                "preprocessing": {
+                    "train_image_size": [128, 128],
+                    "augmentations": [{"name": "Mosaic4"}],
+                },
+            },
+            "loader": {"params": {"dataset_name": "coco_test"}},
+        }
+    )
+
+    assert cfg.trainer.scheduler.params["T_max"] == 10
+    assert (
+        cfg.trainer.preprocessing.augmentations[0].params["out_width"] == 128
+    )
+    assert (
+        cfg.trainer.preprocessing.augmentations[0].params["out_height"] == 128
+    )
+    assert cfg.trainer.accumulate_grad_batches == 32
+    assert cfg.model.predefined_model is not None
+    loss_params = cfg.model.predefined_model.params["loss_params"]
+    assert loss_params["iou_loss_weight"] == 80.0
+    assert loss_params["class_loss_weight"] == 32
+    assert [cb.name for cb in cfg.trainer.callbacks] == [
+        "UploadCheckpoint",
+        "TestOnTrainEnd",
+        "ConvertOnTrainEnd",
+    ]
+
+
+def test_smart_cfg_auto_populate_validation_batch_limit():
+    cfg = Config.get_config(
+        {
+            "model": {"nodes": [{"name": "Backbone"}]},
+            "loader": {
+                "train_view": "train",
+                "val_view": "train",
+                "test_view": "train",
+            },
+        }
+    )
+    assert cfg.trainer.n_validation_batches == 10
+
+    cfg = Config.get_config(
+        {
+            "model": {"nodes": [{"name": "Backbone"}]},
+            "loader": {
+                "train_view": "train",
+                "val_view": "train",
+                "test_view": "train",
+            },
+            "trainer": {"n_validation_batches": -1},
+        }
+    )
+    assert cfg.trainer.n_validation_batches == -1
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_weights"),
+    [
+        (
+            "InstanceSegmentationModel",
+            {
+                "bbox_loss_weight": 240.0,
+                "class_loss_weight": 16.0,
+                "dfl_loss_weight": 48.0,
+            },
+        ),
+        (
+            "KeypointDetectionModel",
+            {
+                "iou_loss_weight": 240.0,
+                "class_loss_weight": 16.0,
+                "regr_kpts_loss_weight": 384,
+                "vis_kpts_loss_weight": 32,
+            },
+        ),
+    ],
+)
+def test_smart_cfg_auto_populate_predefined_schedules(
+    model_name: str, expected_weights: dict[str, float]
+):
+    cfg = Config.get_config(
+        {
+            "model": {"predefined_model": {"name": model_name}},
+            "trainer": {
+                "batch_size": 2,
+                "callbacks": [
+                    {
+                        "name": "GradientAccumulationScheduler",
+                        "params": {"scheduling": {}},
+                    }
+                ],
+            },
+        }
+    )
+
+    assert cfg.model.predefined_model is not None
+    assert cfg.model.predefined_model.params["loss_params"] == expected_weights
+    assert cfg.trainer.callbacks[0].params["scheduling"] == {
+        0: 1,
+        1: 16,
+        2: 32,
+    }
+
+
+def test_smart_cfg_auto_populate_rejects_invalid_loss_params():
+    predefined_model = PredefinedModelConfig.model_construct(
+        name="DetectionModel", params={"loss_params": ["bad"]}
+    )
+    cfg = Config.model_construct(
+        model=ModelConfig.model_construct(predefined_model=predefined_model),
+        trainer=TrainerConfig(batch_size=2),
+        loader=LoaderConfig(),
+    )
+
+    with pytest.raises(ValueError, match="loss_params"):
+        cfg.smart_auto_populate()
+
+
+def test_predefined_model_loading_can_exclude_attachments():
+    cfg = Config.get_config(
+        {
+            "model": {
+                "predefined_model": {
+                    "name": "DetectionModel",
+                    "include_losses": False,
+                    "include_metrics": False,
+                    "include_visualizers": False,
+                }
+            },
+            "trainer": {"smart_cfg_auto_populate": False},
+        }
+    )
+
+    head = cfg.model.nodes[-1]
+    assert head.losses == []
+    assert head.metrics == []
+    assert head.visualizers == []
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "expected_default", "expected_nodes"),
+    [
+        (AnomalyDetectionModel, "light", ["RecSubNet", "DiscSubNetHead"]),
+        (ClassificationModel, "light", ["ResNet", "ClassificationHead"]),
+        (
+            DetectionModel,
+            "light",
+            ["EfficientRep", "RepPANNeck", "EfficientBBoxHead"],
+        ),
+        (FOMOModel, "light", ["EfficientRep", "FOMOHead"]),
+        (
+            InstanceSegmentationModel,
+            "light",
+            ["EfficientRep", "RepPANNeck", "PrecisionSegmentBBoxHead"],
+        ),
+        (
+            KeypointDetectionModel,
+            "light",
+            ["EfficientRep", "RepPANNeck", "EfficientKeypointBBoxHead"],
+        ),
+        (
+            OCRRecognitionModel,
+            "light",
+            ["PPLCNetV3", "SVTRNeck", "OCRCTCHead"],
+        ),
+    ],
+)
+def test_predefined_model_defaults_and_variants(
+    model_cls: type[SimplePredefinedModel],
+    expected_default: str,
+    expected_nodes: list[str],
+):
+    default, variants = model_cls.get_variants()
+    model = model_cls(variant="default")
+
+    assert default == expected_default
+    assert expected_default in variants
+    assert [node.name for node in model.nodes] == expected_nodes
+
+
+def test_simple_predefined_model_branches():
+    model = ConcreteSimplePredefinedModel(
+        backbone="Backbone",
+        neck="Neck",
+        head="Head",
+        loss="Loss",
+        metrics=["MeanAveragePrecision", "Accuracy"],
+        main_metric="Accuracy",
+        visualizer="Visualizer",
+        confusion_matrix_available=True,
+        backbone_params={"freezing": {"unfreeze_after": 1}},
+        neck_params={"freezing": FreezingConfig(active=True)},
+        head_params={"freezing": {"lr_after_unfreeze": 0.1}},
+        metrics_params={"shared": True},
+        visualizer_params={"alpha": 1},
+        confusion_matrix_params={"normalize": True},
+        task_name="task",
+        torchmetrics_task="multiclass",
+        per_class_metrics=True,
+    )
+
+    nodes = model.nodes
+    assert [node.name for node in nodes] == ["Backbone", "Neck", "Head"]
+    assert nodes[0].freezing.active is True
+    assert nodes[1].freezing.active is True
+    assert nodes[2].freezing.lr_after_unfreeze == 0.1
+    assert nodes[2].task_name == "task"
+    assert nodes[2].metrics[0].params["class_metrics"] is True
+    assert nodes[2].metrics[1].params["torchmetrics_task"] == "multiclass"
+    assert nodes[2].metrics[1].is_main_metric is True
+    assert nodes[2].metrics[2].name == "ConfusionMatrix"
+    assert nodes[2].visualizers[0].params == {"alpha": 1}
+
+    without_neck = ConcreteSimplePredefinedModel(
+        backbone="Backbone",
+        neck="Neck",
+        use_neck=False,
+        head="Head",
+        loss="Loss",
+        metrics="Metric",
+        visualizer=None,
+        confusion_matrix_available=True,
+        enable_confusion_matrix=False,
+    )
+    assert [node.name for node in without_neck.nodes] == ["Backbone", "Head"]
+    assert without_neck.nodes[-1].inputs == ["Backbone"]
+    assert without_neck.nodes[-1].visualizers == []
+    assert (
+        without_neck.generate_nodes(
+            include_losses=False,
+            include_metrics=False,
+            include_visualizers=False,
+        )[-1].losses
+        == []
+    )
+
+    with pytest.raises(ValueError, match="exactly one metric"):
+        ConcreteSimplePredefinedModel(
+            backbone="Backbone",
+            head="Head",
+            loss="Loss",
+            metrics=["A", "B"],
         )
-        assert callbacks_by_name[callback_name].active == should_be_active, (
-            f"Callback '{callback_name}' expected active={should_be_active}, "
-            f"got active={callbacks_by_name[callback_name].active}"
-        )
+
+    with pytest.raises(ValueError, match="freezing"):
+        ConcreteSimplePredefinedModel._get_freezing({"freezing": "bad"})
+
+    assert ConcreteSimplePredefinedModel._get_freezing({}).active is False
+
+
+def test_simple_predefined_model_per_class_no_override():
+    model = ConcreteSimplePredefinedModel(
+        backbone="Backbone",
+        head="Head",
+        loss="Loss",
+        metrics="Accuracy",
+        per_class_metrics=True,
+    )
+
+    assert model.nodes[-1].metrics[0].params == {}
+
+
+def test_ocr_recognition_model_alphabets_and_overrides():
+    model = OCRRecognitionModel(
+        alphabet="numeric",
+        max_text_len=10,
+        ignore_unknown=False,
+    )
+    head = model.nodes[-1]
+    assert model.nodes[0].params["max_text_len"] == 10
+    assert head.params["alphabet"] == list("0123456789")
+    assert head.params["ignore_unknown"] is False
+
+    custom = OCRRecognitionModel(
+        alphabet=["x"],
+        backbone_params={"max_text_len": 5},
+        head_params={"alphabet": ["y"], "ignore_unknown": True},
+    )
+    assert custom.nodes[0].params["max_text_len"] == 5
+    assert custom.nodes[-1].params["alphabet"] == ["y"]
+    assert custom.nodes[-1].params["ignore_unknown"] is True
+
+    assert OCRRecognitionModel._generate_alphabet("ascii")[0] == " "
+    assert OCRRecognitionModel._generate_alphabet(["a", "b"]) == ["a", "b"]
+
+    with pytest.raises(ValueError, match="Invalid alphabet"):
+        OCRRecognitionModel._generate_alphabet("bad")
+
+
+def test_segmentation_model_auxiliary_head_branches():
+    model = SegmentationModel()
+    assert [node.name for node in model.nodes] == [
+        "DDRNet",
+        "DDRNetSegmentationHead",
+        "DDRNetSegmentationHead",
+    ]
+    assert model.nodes[-1].alias == "DDRNetSegmentationHead_aux"
+    assert model.nodes[-1].remove_on_export is True
+    assert model.nodes[-1].losses[0].weight == 0.4
+    assert model.nodes[1].params["attach_index"] == -1
+    assert model.nodes[2].params["attach_index"] == -2
+
+    assert [
+        node.name for node in SegmentationModel(use_aux_head=False).nodes
+    ] == [
+        "DDRNet",
+        "DDRNetSegmentationHead",
+    ]
+
+    keep_aux = SegmentationModel(aux_head_params={"use_aux_heads": False})
+    assert keep_aux.nodes[-1].remove_on_export is False
+
+    with pytest.raises(TypeError, match="must be a boolean"):
+        SegmentationModel(aux_head_params={"use_aux_heads": "bad"})
+
+
+def test_pydantic_validation_errors_are_raised():
+    with pytest.raises(ValidationError):
+        ExportConfig(blobconverter={"version": "bad"})
+
+    with pytest.raises(ValidationError):
+        TrainerConfig(batch_size=0)
+
+    with pytest.raises(ValidationError):
+        AugmentationConfig(apply_on_stages=["invalid"])
+
+
+def test_simple_config_model_has_no_outputs_when_empty():
+    model = ModelConfig()
+    assert model.outputs == []

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from luxonis_ml.typing import Params
@@ -118,13 +118,15 @@ def test_config_dump_roundtrip_without_dataset_fixture(tmp_path: Path):
 
 
 def test_model_node_validation_linearizes_heads_and_outputs():
-    model = ModelConfig(
-        nodes=[
-            {"name": "Backbone"},
-            {"name": "Neck"},
-            {"name": "FirstHead"},
-            {"name": "SecondHead"},
-        ]
+    model = ModelConfig.model_validate(
+        {
+            "nodes": [
+                {"name": "Backbone"},
+                {"name": "Neck"},
+                {"name": "FirstHead"},
+                {"name": "SecondHead"},
+            ]
+        }
     )
 
     assert [node.inputs for node in model.nodes] == [
@@ -138,7 +140,7 @@ def test_model_node_validation_linearizes_heads_and_outputs():
 
 def test_model_node_validation_rejects_missing_name():
     with pytest.raises(ValueError, match="does not specify"):
-        ModelConfig(nodes=[{}])
+        ModelConfig.model_validate({"nodes": [{}]})
 
 
 def test_model_config_accepts_existing_node_instances():
@@ -148,34 +150,42 @@ def test_model_config_accepts_existing_node_instances():
 
 def test_model_config_rejects_invalid_graph_and_names():
     with pytest.raises(ValueError, match="not acyclic"):
-        ModelConfig(
-            nodes=[
-                {"name": "A", "inputs": ["B"]},
-                {"name": "B", "inputs": ["A"]},
-            ]
+        ModelConfig.model_validate(
+            {
+                "nodes": [
+                    {"name": "A", "inputs": ["B"]},
+                    {"name": "B", "inputs": ["A"]},
+                ]
+            }
         )
 
     with pytest.raises(ValueError, match="contain a '/'"):
-        ModelConfig(nodes=[{"name": "Invalid/Node"}])
+        ModelConfig.model_validate({"nodes": [{"name": "Invalid/Node"}]})
 
     with pytest.raises(ValueError, match="contain a '/'"):
-        ModelConfig(
-            nodes=[
-                {
-                    "name": "Head",
-                    "metrics": [{"name": "Invalid/Metric"}],
-                }
-            ]
+        ModelConfig.model_validate(
+            {
+                "nodes": [
+                    {
+                        "name": "Head",
+                        "metrics": [{"name": "Invalid/Metric"}],
+                    }
+                ]
+            }
         )
 
     with pytest.raises(ValueError, match="contain a '/'"):
-        ModelConfig(
-            nodes=[
-                {
-                    "name": "Head",
-                    "metrics": [{"name": "Metric", "alias": "Invalid/Alias"}],
-                }
-            ]
+        ModelConfig.model_validate(
+            {
+                "nodes": [
+                    {
+                        "name": "Head",
+                        "metrics": [
+                            {"name": "Metric", "alias": "Invalid/Alias"}
+                        ],
+                    }
+                ]
+            }
         )
 
 
@@ -189,25 +199,27 @@ def test_model_config_no_outputs_guard(monkeypatch: pytest.MonkeyPatch):
     )
 
     with pytest.raises(ValueError, match="No outputs"):
-        model.check_graph()
+        cast(Any, model).check_graph()
 
 
 def test_model_config_main_metric_and_duplicate_name_handling():
-    model = ModelConfig(
-        nodes=[
-            {
-                "name": "Head",
-                "alias": "dup",
-                "losses": [
-                    {"name": "dup"},
-                    {"name": "Other", "alias": "dup"},
-                ],
-                "metrics": [
-                    {"name": "Accuracy"},
-                    {"name": "Accuracy"},
-                ],
-            }
-        ]
+    model = ModelConfig.model_validate(
+        {
+            "nodes": [
+                {
+                    "name": "Head",
+                    "alias": "dup",
+                    "losses": [
+                        {"name": "dup"},
+                        {"name": "Other", "alias": "dup"},
+                    ],
+                    "metrics": [
+                        {"name": "Accuracy"},
+                        {"name": "Accuracy"},
+                    ],
+                }
+            ]
+        }
     )
 
     node = model.nodes[0]
@@ -227,20 +239,22 @@ def test_model_config_main_metric_and_duplicate_name_handling():
     model = ModelConfig.model_construct(
         nodes=[node_with_node_module], outputs=["dup"]
     )
-    model.check_unique_names()
+    cast(Any, model).check_unique_names()
     assert nested_node.alias == "dup_0"
 
     with pytest.raises(ValueError, match="Only one main metric"):
-        ModelConfig(
-            nodes=[
-                {
-                    "name": "Head",
-                    "metrics": [
-                        {"name": "Accuracy", "is_main_metric": True},
-                        {"name": "JaccardIndex", "is_main_metric": True},
-                    ],
-                }
-            ]
+        ModelConfig.model_validate(
+            {
+                "nodes": [
+                    {
+                        "name": "Head",
+                        "metrics": [
+                            {"name": "Accuracy", "is_main_metric": True},
+                            {"name": "JaccardIndex", "is_main_metric": True},
+                        ],
+                    }
+                ]
+            }
         )
 
 
@@ -252,7 +266,7 @@ def test_head_nodes_uses_lazy_nodes_import(monkeypatch: pytest.MonkeyPatch):
         pass
 
     fake_nodes = ModuleType("luxonis_train.nodes")
-    fake_nodes.BaseHead = FakeBaseHead
+    cast(Any, fake_nodes).BaseHead = FakeBaseHead
     monkeypatch.setitem(sys.modules, "luxonis_train.nodes", fake_nodes)
 
     import luxonis_train.config.config as config_module
@@ -261,29 +275,33 @@ def test_head_nodes_uses_lazy_nodes_import(monkeypatch: pytest.MonkeyPatch):
         config_module.NODES._module_dict, "FakeOutput", FakeOutput
     )
 
-    model = ModelConfig(
-        nodes=[
-            {"name": "FakeOutput"},
-            {"name": "OtherNode"},
-        ]
+    model = ModelConfig.model_validate(
+        {
+            "nodes": [
+                {"name": "FakeOutput"},
+                {"name": "OtherNode"},
+            ]
+        }
     )
 
     assert [node.name for node in model.head_nodes] == ["FakeOutput"]
 
 
 def test_loader_config_validation_and_serialization():
-    cfg = LoaderConfig(
-        name="DummyLoader",
-        train_view="train",
-        val_view=["val"],
-        test_view="test",
-        params={
-            "dataset_type": "coco",
-            "n_classes": 3,
-            "n_keypoints": 2,
-            "class_names": ["a", "b", "c"],
-            "kept": True,
-        },
+    cfg = LoaderConfig.model_validate(
+        {
+            "name": "DummyLoader",
+            "train_view": "train",
+            "val_view": ["val"],
+            "test_view": "test",
+            "params": {
+                "dataset_type": "coco",
+                "n_classes": 3,
+                "n_keypoints": 2,
+                "class_names": ["a", "b", "c"],
+                "kept": True,
+            },
+        }
     )
 
     dumped = cfg.model_dump()
@@ -299,24 +317,26 @@ def test_loader_config_validation_and_serialization():
         LoaderConfig(params={"dataset_type": "unknown"})
 
     with pytest.raises(TypeError, match="train_view"):
-        LoaderConfig(train_view=1)
+        LoaderConfig.model_validate({"train_view": 1})
 
 
 def test_preprocessing_normalization_and_resizing():
-    cfg = PreprocessingConfig(
-        train_image_size=(128, 256),
-        augmentations=[
-            AugmentationConfig(name="Normalize", params={"mean": [0]}),
-            AugmentationConfig(
-                name="Resize",
-                params={"height": 1, "width": 2},
-                use_for_resizing=True,
-            ),
-            AugmentationConfig(name="Inactive", active=False),
-            AugmentationConfig(
-                name="Active", apply_on_stages=["train", "val"]
-            ),
-        ],
+    cfg = PreprocessingConfig.model_validate(
+        {
+            "train_image_size": (128, 256),
+            "augmentations": [
+                AugmentationConfig(name="Normalize", params={"mean": [0]}),
+                AugmentationConfig(
+                    name="Resize",
+                    params={"height": 1, "width": 2},
+                    use_for_resizing=True,
+                ),
+                AugmentationConfig(name="Inactive", active=False),
+                AugmentationConfig(
+                    name="Active", apply_on_stages=["train", "val"]
+                ),
+            ],
+        }
     )
 
     assert cfg.normalize.params == {"mean": [0]}
@@ -347,19 +367,23 @@ def test_preprocessing_normalization_and_resizing():
     ("trainer", "expected"),
     [
         (
-            TrainerConfig(
-                epochs=7,
-                scheduler={"name": "CosineAnnealingLR"},
+            TrainerConfig.model_validate(
+                {
+                    "epochs": 7,
+                    "scheduler": {"name": "CosineAnnealingLR"},
+                }
             ),
             {"T_max": 7},
         ),
         (
-            TrainerConfig(
-                epochs=7,
-                scheduler={
-                    "name": "CosineAnnealingLR",
-                    "params": {"T_max": 3},
-                },
+            TrainerConfig.model_validate(
+                {
+                    "epochs": 7,
+                    "scheduler": {
+                        "name": "CosineAnnealingLR",
+                        "params": {"T_max": 3},
+                    },
+                }
             ),
             {"T_max": 3},
         ),
@@ -372,20 +396,22 @@ def test_trainer_scheduler_validation(
 
 
 def test_trainer_validation_branches(monkeypatch: pytest.MonkeyPatch):
-    trainer = TrainerConfig(
-        seed=1,
-        deterministic=None,
-        overfit_batches=1,
-        validation_interval=10,
-        epochs=2,
-        callbacks=[
-            {"name": "Later"},
-            {"name": "EMACallback"},
-            {
-                "name": "GradientAccumulationScheduler",
-                "params": {"scheduling": {"1": 2, "x": 3}},
-            },
-        ],
+    trainer = TrainerConfig.model_validate(
+        {
+            "seed": 1,
+            "deterministic": None,
+            "overfit_batches": 1,
+            "validation_interval": 10,
+            "epochs": 2,
+            "callbacks": [
+                {"name": "Later"},
+                {"name": "EMACallback"},
+                {
+                    "name": "GradientAccumulationScheduler",
+                    "params": {"scheduling": {"1": 2, "x": 3}},
+                },
+            ],
+        }
     )
 
     assert trainer.deterministic is True
@@ -396,13 +422,15 @@ def test_trainer_validation_branches(monkeypatch: pytest.MonkeyPatch):
     ]
     assert trainer.callbacks[2].params["scheduling"] == {1: 2, "x": 3}
 
-    trainer = TrainerConfig(
-        callbacks=[
-            {
-                "name": "GradientAccumulationScheduler",
-                "params": {"scheduling": ["not", "mapping"]},
-            }
-        ]
+    trainer = TrainerConfig.model_validate(
+        {
+            "callbacks": [
+                {
+                    "name": "GradientAccumulationScheduler",
+                    "params": {"scheduling": ["not", "mapping"]},
+                }
+            ]
+        }
     )
     assert trainer.callbacks[0].params["scheduling"] == ["not", "mapping"]
 
@@ -453,7 +481,10 @@ def test_convert_callback_deactivates_export_and_archive(
     callbacks_input: list[Params], expected_active: dict[str, bool]
 ):
     cfg = Config.get_config(
-        BASE_MODEL_CFG | {"trainer": {"callbacks": callbacks_input}}
+        cast(
+            Params,
+            BASE_MODEL_CFG | {"trainer": {"callbacks": callbacks_input}},
+        )
     )
 
     callbacks_by_name = {cb.name: cb for cb in cfg.trainer.callbacks}
@@ -464,9 +495,12 @@ def test_convert_callback_deactivates_export_and_archive(
 
 def test_export_config_validation():
     assert _validate_quantization_mode("fp16") == "FP16_STANDARD"
-    assert ExportConfig(data_type="fp32").quantization_mode == "FP32_STANDARD"
-    assert ExportConfig(
-        scale_values=1, mean_values=[2, 3, 4]
+    assert (
+        ExportConfig.model_validate({"data_type": "fp32"}).quantization_mode
+        == "FP32_STANDARD"
+    )
+    assert ExportConfig.model_validate(
+        {"scale_values": 1, "mean_values": [2, 3, 4]}
     ).scale_values == [
         1,
         1,
@@ -520,13 +554,13 @@ def test_config_validators_and_storage(monkeypatch: pytest.MonkeyPatch):
     def setup_logging(*, use_rich: bool) -> None:
         calls.append(use_rich)
 
-    fake_utils.setup_logging = setup_logging
+    cast(Any, fake_utils).setup_logging = setup_logging
     monkeypatch.setitem(sys.modules, "luxonis_train.utils", fake_utils)
     Config.get_config(BASE_MODEL_CFG | {"rich_logging": False})
     assert calls == [False]
 
     constructed = Config.model_construct(tuner=None)
-    assert constructed.check_tune_storage() is constructed
+    assert cast(Any, constructed).check_tune_storage() is constructed
 
 
 def test_config_get_config_handles_string_mlflow_paths(
@@ -594,7 +628,9 @@ def test_smart_cfg_auto_populate_without_dataset_fixture():
     )
     assert cfg.trainer.accumulate_grad_batches == 32
     assert cfg.model.predefined_model is not None
-    loss_params = cfg.model.predefined_model.params["loss_params"]
+    loss_params = cast(
+        dict[str, Any], cfg.model.predefined_model.params["loss_params"]
+    )
     assert loss_params["iou_loss_weight"] == 80.0
     assert loss_params["class_loss_weight"] == 32
     assert [cb.name for cb in cfg.trainer.callbacks] == [
@@ -744,7 +780,7 @@ def test_predefined_model_loading_can_exclude_attachments():
     ],
 )
 def test_predefined_model_defaults_and_variants(
-    model_cls: type[SimplePredefinedModel],
+    model_cls: Any,
     expected_default: str,
     expected_nodes: list[str],
 ):
@@ -767,7 +803,7 @@ def test_simple_predefined_model_branches():
         visualizer="Visualizer",
         confusion_matrix_available=True,
         backbone_params={"freezing": {"unfreeze_after": 1}},
-        neck_params={"freezing": FreezingConfig(active=True)},
+        neck_params=cast(Any, {"freezing": FreezingConfig(active=True)}),
         head_params={"freezing": {"lr_after_unfreeze": 0.1}},
         metrics_params={"shared": True},
         visualizer_params={"alpha": 1},
@@ -862,7 +898,7 @@ def test_ocr_recognition_model_alphabets_and_overrides():
     assert OCRRecognitionModel._generate_alphabet(["a", "b"]) == ["a", "b"]
 
     with pytest.raises(ValueError, match="Invalid alphabet"):
-        OCRRecognitionModel._generate_alphabet("bad")
+        OCRRecognitionModel._generate_alphabet(cast(Any, "bad"))
 
 
 def test_segmentation_model_auxiliary_head_branches():
@@ -894,13 +930,15 @@ def test_segmentation_model_auxiliary_head_branches():
 
 def test_pydantic_validation_errors_are_raised():
     with pytest.raises(ValidationError):
-        ExportConfig(blobconverter={"version": "bad"})
+        ExportConfig.model_validate({"blobconverter": {"version": "bad"}})
 
     with pytest.raises(ValidationError):
         TrainerConfig(batch_size=0)
 
     with pytest.raises(ValidationError):
-        AugmentationConfig(apply_on_stages=["invalid"])
+        AugmentationConfig.model_validate(
+            {"name": "Invalid", "apply_on_stages": ["invalid"]}
+        )
 
 
 def test_simple_config_model_has_no_outputs_when_empty():

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -1,5 +1,3 @@
-# pyright: reportArgumentType=false, reportCallIssue=false, reportAttributeAccessIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
-
 import sys
 from pathlib import Path
 from types import ModuleType

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -13,6 +13,18 @@ from luxonis_train.config.config import (
 )
 
 
+@pytest.mark.parametrize(
+    "path",
+    Path("configs").glob("*.yaml"),
+)
+def test_config_load(path: Path):
+    cfg = Config.get_config(path)
+
+    assert cfg.model is not None
+    assert cfg.trainer is not None
+    assert cfg.loader is not None
+
+
 def test_smart_cfg_auto_populate(coco_dataset: LuxonisDataset):
     cfg = {
         "model": {

--- a/tests/unittests/test_lightning_utils.py
+++ b/tests/unittests/test_lightning_utils.py
@@ -1,0 +1,47 @@
+from torch import Tensor
+
+from luxonis_train import BaseNode
+from luxonis_train.attached_modules.metrics import MeanAveragePrecision, MIoU
+from luxonis_train.lightning.utils import _translate_predefined_metric_params
+from luxonis_train.tasks import Task, Tasks
+
+
+class DummyNode(BaseNode):
+    def __init__(self, task: Task):
+        super().__init__()
+        self.task = task
+
+    def forward(self, _: Tensor) -> Tensor: ...
+
+
+def test_translate_predefined_metric_params_detection_map():
+    params = _translate_predefined_metric_params(
+        DummyNode(Tasks.BOUNDINGBOX),
+        "MeanAveragePrecision",
+        MeanAveragePrecision,
+        {"per_class_metrics": True},
+    )
+
+    assert params == {"class_metrics": True}
+
+
+def test_translate_predefined_metric_params_keypoint_map():
+    params = _translate_predefined_metric_params(
+        DummyNode(Tasks.INSTANCE_KEYPOINTS),
+        "MeanAveragePrecision",
+        MeanAveragePrecision,
+        {"per_class_metrics": True},
+    )
+
+    assert params == {}
+
+
+def test_translate_predefined_metric_params_segmentation_iou():
+    params = _translate_predefined_metric_params(
+        DummyNode(Tasks.SEGMENTATION),
+        "MIoU",
+        MIoU,
+        {"num_classes": 3, "per_class_metrics": True},
+    )
+
+    assert params == {"num_classes": 3, "per_class": True}

--- a/tests/unittests/test_lightning_utils.py
+++ b/tests/unittests/test_lightning_utils.py
@@ -45,3 +45,14 @@ def test_translate_predefined_metric_params_segmentation_iou():
     )
 
     assert params == {"num_classes": 3, "per_class": True}
+
+
+def test_translate_predefined_metric_params_segmentation_iou_false():
+    params = _translate_predefined_metric_params(
+        DummyNode(Tasks.SEGMENTATION),
+        "MIoU",
+        MIoU,
+        {"num_classes": 3, "per_class_metrics": False},
+    )
+
+    assert params == {"num_classes": 3, "per_class": False}

--- a/tests/unittests/test_variants.py
+++ b/tests/unittests/test_variants.py
@@ -1,0 +1,29 @@
+from copy import deepcopy
+
+from luxonis_train.variants import add_variant_aliases
+
+
+def test_add_variant_aliases():
+    variants = {
+        "foo": {"param1": 1},
+        "bar": {"param2": 2},
+        "large": {"param3": 3},
+    }
+    aliased_variants = add_variant_aliases(
+        deepcopy(variants), {"foo": ["f"], "bar": ["b", "baz"]}
+    )
+    assert aliased_variants == {
+        "foo": {"param1": 1},
+        "bar": {"param2": 2},
+        "f": {"param1": 1},
+        "b": {"param2": 2},
+        "baz": {"param2": 2},
+        "large": {"param3": 3},
+    }
+    yolo_aliased_variants = add_variant_aliases(variants, "yolo")
+    assert yolo_aliased_variants == {
+        "foo": {"param1": 1},
+        "bar": {"param2": 2},
+        "large": {"param3": 3},
+        "l": {"param3": 3},
+    }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Enables loading config with `per_class_metrics` without dependencies on `luxonis-train`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- `per_class_metrics` are now translated using a hardcoded static dictionary
- Improved test coverage for `luxonis_train.config` to 100%
  - 100% test coverage for the `config` module is now enforced in the CI  
- Fixed broken variant aliases and added tests for them

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: OpenAI Codex:gpt-5

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Large expansion of config-focused unit tests plus new tests for variant aliasing and metric-parameter translation.

* **Chores**
  * CI updated to run focused config tests with strict coverage; coverage paths adjusted.

* **Bug Fixes / Improvements**
  * Pretrained-weights URL formatting fixed across backbones/heads/necks.
  * Variant alias expansion refined for consistent behavior.
  * Improved handling/translation of per-class metric parameters and richer logging import resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->