### PR TITLE
Fix: AIMET disabling PTQ, warnings

### DIFF
--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -752,7 +752,7 @@ class AIMETConfig(BaseModelExtraForbid):
     sequential_mse: bool = False
     adaround: AdaroundConfig = Field(default_factory=AdaroundConfig)
 
-    epochs: PositiveInt = 20
+    epochs: NonNegativeInt = 20
     optimizer: ConfigItem = Field(
         default_factory=lambda: ConfigItem(name="SGD", params={"lr": 1e-5})
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,9 +147,10 @@ reportMatchNotExhaustive = "error"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--disable-warnings -vv --basetemp=tests/tmp/"
-markers = [
-  "unit: mark a test as a unit test",
-  "integration: mark a test as an integration test",
+filterwarnings = [
+  "ignore::DeprecationWarning",
+  "ignore::PendingDeprecationWarning",
+  "ignore::FutureWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes disabling PTQ by setting `epochs` to 0.
Suppresses emitted AIMET warnings during tests.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Changed `PositiveInt` to `NonNegativeInt`
- Added `filterwarnings` to `pytest`
- Removed unused `markers` 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training configuration now allows zero epochs for greater flexibility in experiment setup.

* **Chores**
  * Updated test configuration to suppress deprecation and future warnings during test runs for cleaner test output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->