### PR TITLE
Tracker parameters now include 'save_directory'

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -52,6 +52,7 @@ from luxonis_train.typing import View
 from luxonis_train.utils import (
     DatasetMetadata,
     LuxonisTrackerPL,
+    get_tracker_init_params,
     setup_logging,
 )
 from luxonis_train.utils.general import safe_download
@@ -172,7 +173,7 @@ class LuxonisModel:
             rank=rank_zero_only.rank,
             mlflow_tracking_uri=self.environ.MLFLOW_TRACKING_URI,
             _auto_finalize=False,
-            **self.cfg.tracker.model_dump(),
+            **get_tracker_init_params(self.cfg.tracker),
         )
 
         self.run_save_dir = (
@@ -874,7 +875,7 @@ class LuxonisModel:
         def _objective(trial: optuna.trial.Trial) -> float:
             """Objective function used to optimize Optuna study."""
             cfg_tracker = self.cfg.tracker
-            tracker_params = cfg_tracker.model_dump()
+            tracker_params = get_tracker_init_params(cfg_tracker)
             tracker_params["run_name"] = (
                 tracker_params["run_name"] or self.tracker.run_name
             )
@@ -1015,7 +1016,7 @@ class LuxonisModel:
         all_augs = [a.name for a in self.cfg_preprocessing.augmentations]
         rank = rank_zero_only.rank
         cfg_tracker = self.cfg.tracker
-        tracker_params = cfg_tracker.model_dump()
+        tracker_params = get_tracker_init_params(cfg_tracker)
         # NOTE: wandb doesn't allow multiple concurrent runs, handle this separately
         tracker_params["is_wandb"] = False
         tracker_params["run_name"] = (
@@ -1088,7 +1089,7 @@ class LuxonisModel:
                 rank=rank_zero_only.rank,
                 _auto_finalize=True,
                 **(
-                    self.cfg.tracker.model_dump()
+                    get_tracker_init_params(self.cfg.tracker)
                     | {"run_name": self.parent_tracker.run_name}
                 ),
             )

--- a/luxonis_train/utils/__init__.py
+++ b/luxonis_train/utils/__init__.py
@@ -43,7 +43,7 @@ from .spatial_transforms import (
     transform_keypoints,
     transform_masks,
 )
-from .tracker import LuxonisTrackerPL
+from .tracker import LuxonisTrackerPL, get_tracker_init_params
 
 __all__ = [
     "CHECKPOINT_FILTERED_STATE_DICT_PATTERN",
@@ -67,6 +67,7 @@ __all__ = [
     "get_center_keypoints",
     "get_sigmas",
     "get_signature",
+    "get_tracker_init_params",
     "get_with_default",
     "infer_upscale_factor",
     "insert_class",

--- a/luxonis_train/utils/tracker.py
+++ b/luxonis_train/utils/tracker.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from lightning.pytorch.loggers.logger import Logger
 from lightning.pytorch.utilities import rank_zero_only
 from luxonis_ml.tracker import LuxonisTracker
@@ -38,3 +40,9 @@ class LuxonisTrackerPL(LuxonisTracker, Logger):
         if self.is_wandb:
             wandb_status = 0 if status == "success" else 1
             self.experiment["wandb"].finish(wandb_status)
+
+
+def get_tracker_init_params(cfg_tracker: Any) -> dict[str, Any]:
+    tracker_params = cfg_tracker.model_dump()
+    tracker_params["save_directory"] = cfg_tracker.save_directory
+    return tracker_params

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -2,6 +2,7 @@ import sqlite3
 import sys
 from pathlib import Path
 from typing import Any, Literal
+from uuid import uuid4
 
 import pytest
 import torch
@@ -135,3 +136,27 @@ def test_precision_fallback_to_bf16_on_cpu(
 
     model = LuxonisModel("configs/classification_light_model.yaml", opts)
     model.test()
+
+
+def test_custom_tracker_save_directory_does_not_create_default_output_dir(
+    tmp_path: Path, opts: Params
+):
+    run_name = f"save-dir-regression-{uuid4().hex}"
+    custom_save_dir = tmp_path / "custom-save-directory"
+
+    model = LuxonisModel(
+        "configs/complex_model.yaml",
+        opts
+        | {
+            "loader.params.dataset_name": "invalid_dataset_name",
+            "model.nodes.6.name": "ClassificationHead",
+            "tracker.save_directory": str(custom_save_dir),
+            "tracker.run_name": run_name,
+        },
+        allow_empty_dataset=True,
+    )
+
+    assert model.tracker.save_directory == custom_save_dir
+    assert model.run_save_dir == custom_save_dir / run_name
+    assert model.run_save_dir.exists()
+    assert not (Path("output") / run_name).exists()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`save_directory` is generally ommited from model_dump() so that dump doesn't include local paths. But for Tracker object init we want to have it so that we can set custom save directory correctly.
Before this fix setting custom `tracker.save_directory` would result in having one run in the set `save_directory` but also always one empty folder in the default `output/` folder.
<img width="269" height="208" alt="Screenshot from 2026-06-11 13-12-52" src="https://github.com/user-attachments/assets/9d507af0-26cf-4d9f-a341-42a76a9584b0" />

After the fix we only get new directory at `save_directory` location, no more empty dir in the `output/`
<img width="269" height="208" alt="Screenshot from 2026-06-11 13-16-04" src="https://github.com/user-attachments/assets/e7949158-c04d-40fb-9ed1-12884d175b15" />


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized tracker initialization across the application for improved code consistency.

* **Tests**
  * Added integration test to ensure custom tracker save directory configurations are properly respected during model initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->