### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,7 +186,7 @@ jobs:
           flags: ${{ matrix.suite }}
 
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload coverage results to Codecov
         if: matrix.os == 'ubuntu-t4-4core'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/update-cov-report.yaml
+++ b/.github/workflows/update-cov-report.yaml
@@ -25,7 +25,7 @@ jobs:
           workflow: ci.yaml
 
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** added a new **[commit](https://github.com/codecov/codecov-action/commit/fb8b3582c8e4def4969c97caa2f19720cb33a72f)** to **[v7.0.0](https://github.com/codecov/codecov-action/releases/tag/v7.0.0)** Tag on 2026-06-07T01:43:45Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codecov GitHub Action to a newer version across CI/CD workflows for improved coverage reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->