### PR TITLE
Emit an .onnx.tar.xz in the output dir after the AIMET process

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -1139,7 +1139,7 @@ class LuxonisModel:
             path = self._exported_models["onnx"]
 
         path = Path(path)
-        executable_paths = [path]
+        executable_paths: list[PathType] = [path]
 
         external_data_path = path.with_name(f"{path.name}.data")
         if external_data_path.exists():

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -1139,6 +1139,11 @@ class LuxonisModel:
             path = self._exported_models["onnx"]
 
         path = Path(path)
+        executable_paths = [str(path)]
+
+        external_data_path = path.with_name(f"{path.name}.data")
+        if external_data_path.exists():
+            executable_paths.append(str(external_data_path))
 
         executable_fname = path.name
         archive_name += path.suffix
@@ -1199,7 +1204,7 @@ class LuxonisModel:
             archive_name=archive_name,
             save_path=str(archive_save_directory),
             cfg_dict=cfg_dict,
-            executables_paths=[str(path)],  # TODO: what if more executables?
+            executables_paths=executable_paths,
         ).make_archive()
 
         logger.info(f"NN Archive saved to {archive_path}")
@@ -1604,6 +1609,10 @@ class LuxonisModel:
             (save_dir / self.cfg.model.name).with_suffix(".onnx"),
             input_names=input_names,
             output_names=output_names,
+        )
+        self._archive(
+            path=(save_dir / self.cfg.model.name).with_suffix(".onnx"),
+            save_dir=save_dir,
         )
 
         table = []

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -1139,11 +1139,11 @@ class LuxonisModel:
             path = self._exported_models["onnx"]
 
         path = Path(path)
-        executable_paths = [str(path)]
+        executable_paths = [path]
 
         external_data_path = path.with_name(f"{path.name}.data")
         if external_data_path.exists():
-            executable_paths.append(str(external_data_path))
+            executable_paths.append(external_data_path)
 
         executable_fname = path.name
         archive_name += path.suffix

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -1018,6 +1018,7 @@ class LuxonisLightningModule(pl.LightningModule):
             elif callback.name == "AIMETCallback":
                 artifact_keys.add(f"{model_name}.onnx")
                 artifact_keys.add(f"{model_name}.onnx.data")
+                artifact_keys.add(f"{model_name}.onnx.tar.xz")
                 artifact_keys.add(f"{model_name}.encodings")
             elif callback.name == "TrainingProgressCallback":
                 metric_keys.update(

--- a/tests/integration/test_predefined_models.py
+++ b/tests/integration/test_predefined_models.py
@@ -1,3 +1,4 @@
+import tarfile
 from pathlib import Path
 
 import cv2
@@ -79,6 +80,13 @@ def test_predefined_models(
         assert (save_dir / f"{config_name}.encodings").exists()
         assert (save_dir / f"{config_name}.onnx").exists()
         assert (save_dir / f"{config_name}.onnx.data").exists()
+        archive_path = save_dir / f"{config_name}.onnx.tar.xz"
+        assert archive_path.exists()
+        with tarfile.open(archive_path) as tar:
+            archive_entries = set(tar.getnames())
+        assert "config.json" in archive_entries
+        assert f"{config_name}.onnx" in archive_entries
+        assert f"{config_name}.onnx.data" in archive_entries
 
     if config_name != "embeddings_model":
         with subtests.test("infer"):


### PR DESCRIPTION
## Purpose
The goal is to have a pipeline with AIMET that emulates the standard .ckpt -> onnx NNArchive -> device NNArchive. The AIMET process returned an .onnx, a .data file and a .encodings file. With these changes, there is an .onnx NNArchive saved in the aimet output directory that has the `config.json`, the `.onnx` and the `.onnx.data`, which later on (with changes to `modelconverter`) be able to be used alongside the `.encodings` to generate a device-specific NNArchive.

This also follows the standard export + archive flow where a .onnx is generated and then archived with a `config.json`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
