### PR TITLE
Replaced `LuxonisDataset.dataset_name` with `LuxonisDataset.identifier`

### DIFF
--- a/tests/integration/backbone_model_utils.py
+++ b/tests/integration/backbone_model_utils.py
@@ -70,7 +70,7 @@ def prepare_predefined_model_config(
     # Apply dataset-specific overrides
     if config_name == "embeddings_model":
         opts |= {
-            "loader.params.dataset_name": test_datasets.embedding_dataset.dataset_name,
+            "loader.params.dataset_name": test_datasets.embedding_dataset.identifier,
             "trainer.batch_size": 16,
             "trainer.preprocessing.train_image_size": [48, 64],
         }

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -62,7 +62,7 @@ def test_tune(
 def test_weights_loading(cifar10_dataset: LuxonisDataset, opts: Params):
     config_file = "configs/classification_light_model.yaml"
     opts |= {
-        "loader.params.dataset_name": cifar10_dataset.dataset_name,
+        "loader.params.dataset_name": cifar10_dataset.identifier,
     }
 
     model = LuxonisModel(config_file, opts)
@@ -129,7 +129,7 @@ def test_precision_fallback_to_bf16_on_cpu(
     cifar10_dataset: LuxonisDataset, opts: Params
 ):
     opts |= {
-        "loader.params.dataset_name": cifar10_dataset.dataset_name,
+        "loader.params.dataset_name": cifar10_dataset.identifier,
         "trainer.precision": "16-mixed",
         "trainer.accelerator": "cpu",
     }

--- a/tests/integration/test_remove_on_export.py
+++ b/tests/integration/test_remove_on_export.py
@@ -6,7 +6,7 @@ from luxonis_train.core import LuxonisModel
 
 
 def test_train_only_heads(coco_dataset: LuxonisDataset, opts: Params):
-    opts |= {"loader.params.dataset_name": coco_dataset.dataset_name}
+    opts |= {"loader.params.dataset_name": coco_dataset.identifier}
 
     model = LuxonisModel(get_config(), opts)
     results = model.test(finalize_tracker=False)

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -52,7 +52,7 @@ def test_scheduler(
     opts: Params, coco_dataset: LuxonisDataset, scheduler_config: ParamValue
 ):
     opts |= {
-        "loader.params.dataset_name": coco_dataset.dataset_name,
+        "loader.params.dataset_name": coco_dataset.identifier,
         "trainer.scheduler": scheduler_config,
     }
     model = LuxonisModel("configs/detection_light_model.yaml", opts)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

`dataset_name` is an implementation specific attribute of `LuxonisDataset`. The `BaseDataset` API offers the `identifier` property instead. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated integration tests with revised dataset configuration references across multiple test suites to ensure proper test execution and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->