### PR TITLE
Correct ONNX NNArchive output names after QAT process

### DIFF
--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -1521,20 +1521,19 @@ class LuxonisModel:
 
         pre_quant_test = quant_eval_trainer.test(model, self.val_loader)[0]
 
-        dummy_inputs = {
+        dummy_inputs_dict = {
             input_name: torch.randn([1, *shape]).to(model.device)
             for shapes in model.nodes.loader_input_shapes.values()
             for input_name, shape in shapes.items()
         }
 
-        if len(dummy_inputs) > 1:
+        if len(dummy_inputs_dict) > 1:
             raise NotImplementedError(
                 "Quantization is not yet supported for models "
                 "with multiple inputs."
             )
-        input_names = list(dummy_inputs.keys())
-        output_names = model._get_output_onnx_names(deepcopy(dummy_inputs))
-        dummy_inputs = next(iter(dummy_inputs.values()))
+        input_names = list(dummy_inputs_dict.keys())
+        dummy_inputs = next(iter(dummy_inputs_dict.values()))
         ptq_loader = get_ptq_calibration_loader(
             val_dataset=self.loaders["val"],
             collate_fn=self.loaders["val"].collate_fn,
@@ -1604,6 +1603,9 @@ class LuxonisModel:
         qat_test = quant_eval_trainer.test(model, self.val_loader)[0]
 
         model.set_export_mode(mode=True)
+        output_names = model._get_output_onnx_names(
+            deepcopy(dummy_inputs_dict)
+        )
 
         sim.onnx.export(
             dummy_inputs,

--- a/luxonis_train/core/core.py
+++ b/luxonis_train/core/core.py
@@ -68,6 +68,7 @@ from .utils.export_utils import (
     get_preprocessing,
     hubai_export,
     make_initializers_unique,
+    rename_onnx_outputs,
     replace_weights,
     try_onnx_simplify,
 )
@@ -1609,6 +1610,10 @@ class LuxonisModel:
             (save_dir / self.cfg.model.name).with_suffix(".onnx"),
             input_names=input_names,
             output_names=output_names,
+        )
+        rename_onnx_outputs(
+            (save_dir / self.cfg.model.name).with_suffix(".onnx"),
+            output_names,
         )
         self._archive(
             path=(save_dir / self.cfg.model.name).with_suffix(".onnx"),

--- a/luxonis_train/core/utils/export_utils.py
+++ b/luxonis_train/core/utils/export_utils.py
@@ -1,4 +1,3 @@
-import json
 import os
 import shutil
 from collections.abc import Generator
@@ -64,41 +63,13 @@ def rename_onnx_outputs(onnx_path: PathType, output_names: list[str]) -> None:
 
     onnx_path = Path(onnx_path)
     model = onnx.load(str(onnx_path))
-    actual_outputs = []
-    for output in model.graph.output:
-        shape = [dim.dim_value for dim in output.type.tensor_type.shape.dim]
-        actual_outputs.append(
-            {
-                "name": output.name,
-                "shape": shape,
-                "dtype": onnx.TensorProto.DataType.Name(
-                    output.type.tensor_type.elem_type
-                ),
-            }
-        )
-
-    logger.info(f"Requested ONNX output names: {output_names}")
-    logger.info(f"Actual exported ONNX outputs: {actual_outputs}")
-
-    debug_path = onnx_path.with_suffix(".output_debug.json")
-    debug_path.write_text(
-        json.dumps(
-            {
-                "requested_output_names": output_names,
-                "actual_outputs": actual_outputs,
-            },
-            indent=2,
-        )
-    )
-    logger.info(f"Wrote ONNX output debug info to {debug_path}")
 
     if len(model.graph.output) != len(output_names):
-        logger.error(
+        raise ValueError(
             "Number of requested output names does not match the number "
             f"of ONNX graph outputs: {len(output_names)} != "
-            f"{len(model.graph.output)}. Skipping output rename."
+            f"{len(model.graph.output)}."
         )
-        return
 
     for output, new_name in zip(model.graph.output, output_names, strict=True):
         output.name = new_name

--- a/luxonis_train/core/utils/export_utils.py
+++ b/luxonis_train/core/utils/export_utils.py
@@ -58,6 +58,38 @@ def try_onnx_simplify(onnx_path: PathType) -> None:
     logger.info(f"ONNX model saved to {onnx_path}")
 
 
+def rename_onnx_outputs(onnx_path: PathType, output_names: list[str]) -> None:
+    import onnx
+
+    onnx_path = Path(onnx_path)
+    model = onnx.load(str(onnx_path))
+
+    if len(model.graph.output) != len(output_names):
+        raise ValueError(
+            "Number of requested output names does not match the number "
+            f"of ONNX graph outputs: {len(output_names)} != "
+            f"{len(model.graph.output)}."
+        )
+
+    for output, new_name in zip(model.graph.output, output_names, strict=True):
+        output.name = new_name
+
+    external_data_path = onnx_path.with_name(f"{onnx_path.name}.data")
+    if external_data_path.exists():
+        external_data_path.unlink()
+        onnx.save(
+            model,
+            str(onnx_path),
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=external_data_path.name,
+            size_threshold=0,
+            convert_attribute=False,
+        )
+    else:
+        onnx.save(model, str(onnx_path))
+
+
 def get_preprocessing(
     cfg: PreprocessingConfig, log_label: str | None = None
 ) -> tuple[

--- a/luxonis_train/core/utils/export_utils.py
+++ b/luxonis_train/core/utils/export_utils.py
@@ -71,8 +71,21 @@ def rename_onnx_outputs(onnx_path: PathType, output_names: list[str]) -> None:
             f"{len(model.graph.output)}."
         )
 
-    for output, new_name in zip(model.graph.output, output_names, strict=True):
-        output.name = new_name
+    old_to_new = {
+        output.name: new_name
+        for output, new_name in zip(
+            model.graph.output, output_names, strict=True
+        )
+    }
+
+    for node in model.graph.node:
+        for i, name in enumerate(node.output):
+            if name in old_to_new:
+                node.output[i] = old_to_new[name]
+
+    for output in model.graph.output:
+        if output.name in old_to_new:
+            output.name = old_to_new[output.name]
 
     external_data_path = onnx_path.with_name(f"{onnx_path.name}.data")
     if external_data_path.exists():
@@ -88,6 +101,8 @@ def rename_onnx_outputs(onnx_path: PathType, output_names: list[str]) -> None:
         )
     else:
         onnx.save(model, str(onnx_path))
+
+    onnx.checker.check_model(str(onnx_path))
 
 
 def get_preprocessing(

--- a/luxonis_train/core/utils/export_utils.py
+++ b/luxonis_train/core/utils/export_utils.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 from collections.abc import Generator
@@ -63,13 +64,41 @@ def rename_onnx_outputs(onnx_path: PathType, output_names: list[str]) -> None:
 
     onnx_path = Path(onnx_path)
     model = onnx.load(str(onnx_path))
+    actual_outputs = []
+    for output in model.graph.output:
+        shape = [dim.dim_value for dim in output.type.tensor_type.shape.dim]
+        actual_outputs.append(
+            {
+                "name": output.name,
+                "shape": shape,
+                "dtype": onnx.TensorProto.DataType.Name(
+                    output.type.tensor_type.elem_type
+                ),
+            }
+        )
+
+    logger.info(f"Requested ONNX output names: {output_names}")
+    logger.info(f"Actual exported ONNX outputs: {actual_outputs}")
+
+    debug_path = onnx_path.with_suffix(".output_debug.json")
+    debug_path.write_text(
+        json.dumps(
+            {
+                "requested_output_names": output_names,
+                "actual_outputs": actual_outputs,
+            },
+            indent=2,
+        )
+    )
+    logger.info(f"Wrote ONNX output debug info to {debug_path}")
 
     if len(model.graph.output) != len(output_names):
-        raise ValueError(
+        logger.error(
             "Number of requested output names does not match the number "
             f"of ONNX graph outputs: {len(output_names)} != "
-            f"{len(model.graph.output)}."
+            f"{len(model.graph.output)}. Skipping output rename."
         )
+        return
 
     for output, new_name in zip(model.graph.output, output_names, strict=True):
         output.name = new_name


### PR DESCRIPTION
## Purpose
In the quantization path, output names were being computed before export mode was enabled, which caused the exported ONNX to keep intermediate /<model>/... names instead (like ../EfficientBBoxHead/..) of the expected output{i}_yolov6r2 names. The fix computes output names after set_export_mode(True) to align AIMET exports with the normal ONNX export path and the generated NN archive metadata.

Correct ONNX NNArchive output names after the fix:
<img width="348" height="395" alt="after_correct" src="https://github.com/user-attachments/assets/fed60b68-6767-456a-8cc1-c03f2ee39709" />

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
Assisted-by: CODEX

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ONNX export during quantization so output tensor names are preserved and written into the exported model.
  * Strengthened handling of model inputs during quantization, with clearer enforcement of the single-input limitation.
  * Added safer model file rewriting when external ONNX data files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->