### PR TITLE
Export YOLO head strides metadata

### DIFF
--- a/luxonis_train/nodes/heads/base_detection_head.py
+++ b/luxonis_train/nodes/heads/base_detection_head.py
@@ -74,6 +74,7 @@ class BaseDetectionHead(BaseHead):
             "iou_threshold": self.iou_thres,
             "conf_threshold": self.conf_thres,
             "max_det": self.max_det,
+            "strides": self.stride.tolist(),
         }
 
     def get_output_names(self, default: list[str]) -> list[str]:


### PR DESCRIPTION
## Purpose

Support YOLO-like models with non-default head stride layouts, including `n_heads = 4`.

Previously, `YOLOExtendedParser` relied on hard-coded fallback strides. For archives with 4 output heads, this could silently ignore the extra stride scale.

## Specification

* `YOLOExtendedParser` now reads `strides` from NNArchive head metadata when present.
* Added stride validation for explicit metadata values.
* Preserved legacy fallback behavior when `strides` is not present:

  * default YOLO fallback: `[8, 16, 32]`
  * tiny YOLO fallback: `[16, 32]`

## Dependencies & Potential Impact

Backward compatibility is preserved for existing NNArchives without stride metadata.

Archives with invalid explicit stride metadata now fail fast with a clear error instead of being parsed with an incorrect stride configuration.

## Deployment Plan

No special deployment steps required.

Rollback: revert this parser change to return to the previous fallback-only behavior.

## Testing & Validation

Validated with task-specific NNArchives generated from `luxonis-train`.

Cases validated:

* 4 heads: `metadata.strides = [4, 8, 16, 32]`
* 2 heads: `metadata.strides = [16, 32]`
* 3 heads with offset `attach_index`: `metadata.strides = [4, 8, 16]`

Existing `depthai-nodes` E2E validation:

* Converted the generated archives to RVC2 via HubAI.
* Ran `tests/end_to_end/test_e2e.py::test_pipelines` on a real RVC2 device.
* Result: `3 passed in 44.71s`.

Existing YOLO parser coverage also passed.

## AI Usage

Assisted-by: ChatGPT

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES