### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/add-metadata.yaml
+++ b/.github/workflows/add-metadata.yaml
@@ -24,6 +24,6 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Labeler
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
+        uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d
         with:
           configuration-path: .github/labeler.yaml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/labeler](https://github.com/actions/labeler)** added a new **[commit](https://github.com/actions/labeler/commit/b8dd2d9be0f68b860e7dae5dae7d772984eacd6d)** to **[v6.2.0](https://github.com/actions/labeler/releases/tag/v6.2.0)** Tag on 2026-07-06T16:58:15Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated labeling workflow to use a newer pinned action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->