### PR TITLE
Feat/concurrency group

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,11 @@ name: CI
 on:
   workflow_dispatch:
     inputs:
+      cancel_in_progress:
+        description: "Cancel an in-progress run in the same concurrency group"
+        required: false
+        type: boolean
+        default: true
       concurrency_group:
         description: "Optional concurrency group for an external caller"
         required: false
@@ -17,6 +22,11 @@ on:
         default: main
   workflow_call:
     inputs:
+      cancel_in_progress:
+        description: "Cancel an in-progress run in the same concurrency group"
+        required: false
+        type: boolean
+        default: true
       concurrency_group:
         description: "Optional concurrency group for an external caller"
         required: false
@@ -54,7 +64,7 @@ on:
 concurrency:
   # External callers can provide an isolated concurrency group.
   group: ${{ inputs.concurrency_group || format('{0}-{1}', github.workflow, github.ref) }}
-  cancel-in-progress: ${{ !inputs.concurrency_group }}
+  cancel-in-progress: ${{ inputs.cancel_in_progress || !inputs.concurrency_group }}
 
 permissions:
   pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,10 @@ name: CI
 on:
   workflow_dispatch:
     inputs:
+      concurrency_group:
+        description: "Optional concurrency group for an external caller"
+        required: false
+        default: ""
       ml_ref:
         description: "luxonis-ml version (branch/tag/SHA)"
         required: false
@@ -13,6 +17,11 @@ on:
         default: main
   workflow_call:
     inputs:
+      concurrency_group:
+        description: "Optional concurrency group for an external caller"
+        required: false
+        type: string
+        default: ""
       ml_ref:
         description: "luxonis-ml version (branch/tag/SHA)"
         required: false
@@ -43,8 +52,9 @@ on:
       - "!**/*.md"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # External callers can provide an isolated concurrency group.
+  group: ${{ inputs.concurrency_group || format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: ${{ !inputs.concurrency_group }}
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Prevent BOM-triggered Luxonis Train CI runs from being cancelled by concurrency collisions.

## Changes

- Add optional `concurrency_group` and `cancel_in_progress` inputs to the reusable CI workflow.
- Keep direct Train CI cancellation behavior unchanged.
- Let external callers use an isolated, stable concurrency group so only the latest compatibility run for a branch is kept.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
