### PR TITLE
Split tests for heavy vs light predefined models

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,7 @@ jobs:
 
     strategy:
       matrix:
-        suite: [unit, predefined, combinations, misc]
+        suite: [unit, predefined_light, predefined_heavy, combinations, misc]
 
     runs-on: ${{ matrix.suite == 'unit' && 'ubuntu-latest' || 'ubuntu-t4-4core' }}
 

--- a/.github/workflows/update-cov-report.yaml
+++ b/.github/workflows/update-cov-report.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        suite: [unit, predefined, combinations, misc]
+        suite: [unit, predefined_light, predefined_heavy, combinations, misc]
 
     steps:
       - name: Checkout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,6 +475,14 @@ def pytest_configure(config: Config):
         "markers", "predefined: mark test as a predefined model test"
     )
     config.addinivalue_line(
+        "markers",
+        "predefined_light: mark test as a light predefined model test",
+    )
+    config.addinivalue_line(
+        "markers",
+        "predefined_heavy: mark test as a heavy predefined model test",
+    )
+    config.addinivalue_line(
         "markers", "combinations: mark test as a combinations test"
     )
     config.addinivalue_line(

--- a/tests/integration/backbone_model_utils.py
+++ b/tests/integration/backbone_model_utils.py
@@ -3,13 +3,13 @@ from luxonis_ml.typing import Params
 from luxonis_train.nodes.backbones import __all__ as BACKBONES
 from tests.conftest import LuxonisTestDataset, LuxonisTestDatasets
 
-BACKBONES = [
+BACKBONES: list[str] = [
     backbone
     for backbone in BACKBONES
     if backbone not in {"PPLCNetV3", "GhostFaceNet", "RecSubNet"}
 ]
 
-PREDEFINED_MODELS = [
+PREDEFINED_MODELS: list[tuple[str, Params | None]] = [
     ("anomaly_detection_model", None),
     ("embeddings_model", None),
     ("fomo_light_model", None),

--- a/tests/integration/test_predefined_models.py
+++ b/tests/integration/test_predefined_models.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pytest
+from _pytest.mark import ParameterSet
 from luxonis_ml.data import LuxonisLoader
 from luxonis_ml.typing import Params
 from pytest_subtests import SubTests
@@ -24,6 +25,26 @@ def skip_if_no_aimet() -> None:
         pytest.skip("AIMET is not installed")
 
 
+def _predefined_model_params() -> list[ParameterSet]:
+    params = []
+    for config_name, extra_opts in PREDEFINED_MODELS:
+        marker = (
+            pytest.mark.predefined_heavy
+            if "heavy" in config_name
+            else pytest.mark.predefined_light
+        )
+        params.append(
+            pytest.param(
+                config_name,
+                extra_opts,
+                marks=marker,
+                id=config_name,
+            )
+        )
+    return params
+
+
+@pytest.mark.predefined_light
 def test_model_construction():
     cfg = "configs/detection_light_model.yaml"
     model = LuxonisModel(
@@ -41,7 +62,9 @@ def test_model_construction():
         assert not node.visualizers
 
 
-@pytest.mark.parametrize(("config_name", "extra_opts"), PREDEFINED_MODELS)
+@pytest.mark.parametrize(
+    ("config_name", "extra_opts"), _predefined_model_params()
+)
 def test_predefined_models(
     config_name: str,
     extra_opts: Params | None,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
The `predefined` suite now split into `predefined_light` and `predefined_heavy` for faster CI execution.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
