### PR TITLE
Add detection confidence curves

### DIFF
--- a/luxonis_train/attached_modules/metrics/__init__.py
+++ b/luxonis_train/attached_modules/metrics/__init__.py
@@ -6,6 +6,7 @@ from .mean_average_precision import MeanAveragePrecision
 from .mean_iou import MIoU
 from .object_keypoint_similarity import ObjectKeypointSimilarity
 from .ocr_accuracy import OCRAccuracy
+from .precision_recall_curve import PrecisionRecallCurve
 from .torchmetrics import Accuracy, F1Score, JaccardIndex, Precision, Recall
 from .utils import fix_empty_tensor, merge_bbox_kpt_targets
 
@@ -24,6 +25,7 @@ __all__ = [
     "OCRAccuracy",
     "ObjectKeypointSimilarity",
     "Precision",
+    "PrecisionRecallCurve",
     "Recall",
     "fix_empty_tensor",
     "merge_bbox_kpt_targets",

--- a/luxonis_train/attached_modules/metrics/base_metric.py
+++ b/luxonis_train/attached_modules/metrics/base_metric.py
@@ -183,7 +183,6 @@ class BaseMetric(BaseAttachedModule, Metric, register=False, registry=METRICS):
         """Build image artifacts from an already computed metric
         result.
         """
-        del values
         return {}
 
     def get_artifact_names(self) -> tuple[str, ...]:

--- a/luxonis_train/attached_modules/metrics/base_metric.py
+++ b/luxonis_train/attached_modules/metrics/base_metric.py
@@ -24,6 +24,8 @@ from luxonis_train.tasks import Task
 from luxonis_train.typing import Labels, Packet
 from luxonis_train.utils import get_signature
 
+MetricResult = Tensor | tuple[Tensor, dict[str, Tensor]] | dict[str, Tensor]
+
 
 @dataclass(kw_only=True, slots=True)
 class MetricState:
@@ -164,6 +166,29 @@ class BaseMetric(BaseAttachedModule, Metric, register=False, registry=METRICS):
               cannot be used as the main metric of the model.
         """
         return super().compute()
+
+    def get_loggable_values(
+        self,
+        values: MetricResult,
+    ) -> MetricResult:
+        """Return the subset of computed values suitable for metric
+        logging.
+        """
+        return values
+
+    def get_artifacts(
+        self,
+        values: MetricResult,
+    ) -> dict[str, Tensor]:
+        """Build image artifacts from an already computed metric
+        result.
+        """
+        del values
+        return {}
+
+    def get_artifact_names(self) -> tuple[str, ...]:
+        """Return stable artifact names emitted by this metric."""
+        return ()
 
     def __eq__(self, other: object) -> bool:
         return self is other

--- a/luxonis_train/attached_modules/metrics/precision_recall_curve.py
+++ b/luxonis_train/attached_modules/metrics/precision_recall_curve.py
@@ -1,0 +1,396 @@
+from typing import cast
+
+import torch
+from torch import Tensor
+from torchvision.ops import box_convert, box_iou
+
+from luxonis_train.tasks import Tasks
+from luxonis_train.utils import non_max_suppression
+
+from .base_metric import BaseMetric
+
+
+class PrecisionRecallCurve(BaseMetric):
+    """Compute global detection curves over a fixed confidence grid."""
+
+    supported_tasks = [Tasks.BOUNDINGBOX]
+    thresholds: Tensor
+    true_positives: Tensor
+    false_positives: Tensor
+    target_count: Tensor
+
+    def __init__(
+        self,
+        *,
+        confidence_thresholds: list[float] | None = None,
+        num_thresholds: int = 101,
+        min_confidence: float = 0.0,
+        max_confidence: float = 1.0,
+        matching_iou_threshold: float = 0.5,
+        nms_iou_threshold: float | None = None,
+        max_detections: int | None = None,
+        **kwargs,
+    ):
+        """Initialize the detection curve metric.
+
+        @type confidence_thresholds: list[float] | None
+        @param confidence_thresholds: Explicit confidence grid. When
+            omitted, a linearly spaced grid is created.
+        @type num_thresholds: int
+        @param num_thresholds: Number of points in the generated grid.
+        @type min_confidence: float
+        @param min_confidence: Minimum generated confidence threshold.
+        @type max_confidence: float
+        @param max_confidence: Maximum generated confidence threshold.
+        @type matching_iou_threshold: float
+        @param matching_iou_threshold: IoU required for a prediction to
+            match a ground-truth box.
+        @type nms_iou_threshold: float | None
+        @param nms_iou_threshold: IoU used by NMS. Defaults to the
+            attached detection head value.
+        @type max_detections: int | None
+        @param max_detections: Maximum detections retained by NMS.
+            Defaults to the attached detection head value.
+        """
+        super().__init__(**kwargs)
+
+        thresholds = self._build_thresholds(
+            confidence_thresholds=confidence_thresholds,
+            num_thresholds=num_thresholds,
+            min_confidence=min_confidence,
+            max_confidence=max_confidence,
+        )
+        self.register_buffer("thresholds", thresholds, persistent=False)
+
+        self.matching_iou_threshold = self._validate_unit_interval(
+            matching_iou_threshold,
+            "matching_iou_threshold",
+        )
+        self.nms_iou_threshold = self._resolve_nms_iou_threshold(
+            nms_iou_threshold
+        )
+        self.max_detections = self._resolve_max_detections(max_detections)
+        self.min_confidence = float(thresholds[0])
+
+        self.add_state(
+            "true_positives",
+            default=torch.zeros(len(thresholds), dtype=torch.long),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
+            "false_positives",
+            default=torch.zeros(len(thresholds), dtype=torch.long),
+            dist_reduce_fx="sum",
+        )
+        self.add_state(
+            "target_count",
+            default=torch.tensor(0, dtype=torch.long),
+            dist_reduce_fx="sum",
+        )
+
+    @staticmethod
+    def _validate_unit_interval(value: float, name: str) -> float:
+        value = float(value)
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(f"{name} must be between 0 and 1.")
+        return value
+
+    @classmethod
+    def _build_thresholds(
+        cls,
+        *,
+        confidence_thresholds: list[float] | None,
+        num_thresholds: int,
+        min_confidence: float,
+        max_confidence: float,
+    ) -> Tensor:
+        if confidence_thresholds is not None:
+            thresholds = torch.tensor(
+                confidence_thresholds,
+                dtype=torch.float32,
+            )
+            if thresholds.ndim != 1 or len(thresholds) < 2:
+                raise ValueError(
+                    "confidence_thresholds must contain at least two values."
+                )
+            if torch.any(thresholds < 0) or torch.any(thresholds > 1):
+                raise ValueError(
+                    "confidence_thresholds values must be between 0 and 1."
+                )
+            if not torch.all(thresholds[1:] > thresholds[:-1]):
+                raise ValueError(
+                    "confidence_thresholds must be strictly increasing."
+                )
+            return thresholds
+
+        if num_thresholds < 2:
+            raise ValueError("num_thresholds must be at least 2.")
+
+        min_confidence = cls._validate_unit_interval(
+            min_confidence,
+            "min_confidence",
+        )
+        max_confidence = cls._validate_unit_interval(
+            max_confidence,
+            "max_confidence",
+        )
+        if min_confidence >= max_confidence:
+            raise ValueError(
+                "min_confidence must be lower than max_confidence."
+            )
+
+        return torch.linspace(
+            min_confidence,
+            max_confidence,
+            num_thresholds,
+            dtype=torch.float32,
+        )
+
+    def _resolve_nms_iou_threshold(self, value: float | None) -> float:
+        if value is None:
+            value = cast(float, self.node.iou_thres)
+        return self._validate_unit_interval(value, "nms_iou_threshold")
+
+    def _resolve_max_detections(self, value: int | None) -> int:
+        if value is None:
+            value = cast(int, self.node.max_det)
+        if value <= 0:
+            raise ValueError("max_detections must be positive.")
+        return int(value)
+
+    def update(
+        self,
+        detections_pre_nms: Tensor,
+        target_boundingbox: Tensor,
+    ) -> None:
+        """Update curve counts from one batch of decoded candidates."""
+        target_boundingbox = target_boundingbox.to(detections_pre_nms.device)
+        predictions = non_max_suppression(
+            detections_pre_nms,
+            n_classes=self.node.n_classes,
+            conf_thres=self.min_confidence,
+            iou_thres=self.nms_iou_threshold,
+            bbox_format="xyxy",
+            max_det=self.max_detections,
+            predicts_objectness=False,
+        )
+
+        scores, true_positive = self._match_predictions(
+            predictions,
+            target_boundingbox,
+        )
+        active = scores.unsqueeze(0) >= self.thresholds.unsqueeze(1)
+
+        self.true_positives += (active & true_positive.unsqueeze(0)).sum(dim=1)
+        self.false_positives += (active & ~true_positive.unsqueeze(0)).sum(
+            dim=1
+        )
+        self.target_count += target_boundingbox.shape[0]
+
+    def _match_predictions(
+        self,
+        predictions: list[Tensor],
+        target_boundingbox: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        all_scores: list[Tensor] = []
+        all_true_positive: list[Tensor] = []
+
+        height, width = self.node.original_in_shape[-2:]
+
+        for image_index, image_predictions in enumerate(predictions):
+            if image_predictions.numel() == 0:
+                continue
+
+            image_targets = target_boundingbox[
+                target_boundingbox[:, 0].long() == image_index
+            ]
+            target_boxes, target_classes = self._prepare_targets(
+                image_targets,
+                height=height,
+                width=width,
+            )
+
+            order = torch.argsort(
+                image_predictions[:, 4],
+                descending=True,
+                stable=True,
+            )
+            image_predictions = image_predictions[order]
+
+            scores = image_predictions[:, 4]
+            prediction_boxes = image_predictions[:, :4]
+            prediction_classes = image_predictions[:, 5].long()
+            true_positive = torch.zeros(
+                len(image_predictions),
+                dtype=torch.bool,
+                device=image_predictions.device,
+            )
+            matched_targets = torch.zeros(
+                len(target_boxes),
+                dtype=torch.bool,
+                device=image_predictions.device,
+            )
+
+            for prediction_index in range(len(image_predictions)):
+                candidate_indices = torch.where(
+                    (target_classes == prediction_classes[prediction_index])
+                    & ~matched_targets
+                )[0]
+                if candidate_indices.numel() == 0:
+                    continue
+
+                ious = box_iou(
+                    prediction_boxes[prediction_index].unsqueeze(0),
+                    target_boxes[candidate_indices],
+                ).squeeze(0)
+                best_iou, best_local_index = torch.max(ious, dim=0)
+
+                if best_iou >= self.matching_iou_threshold:
+                    target_index = candidate_indices[best_local_index]
+                    matched_targets[target_index] = True
+                    true_positive[prediction_index] = True
+
+            all_scores.append(scores)
+            all_true_positive.append(true_positive)
+
+        if not all_scores:
+            return (
+                target_boundingbox.new_empty((0,)),
+                torch.empty(
+                    0,
+                    dtype=torch.bool,
+                    device=target_boundingbox.device,
+                ),
+            )
+
+        scores = torch.cat(all_scores)
+        true_positive = torch.cat(all_true_positive)
+        order = torch.argsort(scores, descending=True, stable=True)
+        return scores[order], true_positive[order]
+
+    @staticmethod
+    def _prepare_targets(
+        image_targets: Tensor,
+        *,
+        height: int,
+        width: int,
+    ) -> tuple[Tensor, Tensor]:
+        if image_targets.numel() == 0:
+            return (
+                image_targets.new_empty((0, 4)),
+                torch.empty(
+                    0,
+                    dtype=torch.long,
+                    device=image_targets.device,
+                ),
+            )
+
+        boxes = box_convert(
+            image_targets[:, 2:6],
+            in_fmt="xywh",
+            out_fmt="xyxy",
+        )
+        boxes[:, 0::2] *= width
+        boxes[:, 1::2] *= height
+        return boxes, image_targets[:, 1].long()
+
+    def compute(self) -> dict[str, Tensor]:
+        """Compute precision, recall, and F1 for every confidence
+        point.
+        """
+        true_positives = self.true_positives.float()
+        false_positives = self.false_positives.float()
+        false_negatives = (self.target_count - self.true_positives).float()
+
+        precision = torch.where(
+            true_positives + false_positives > 0,
+            true_positives / (true_positives + false_positives),
+            torch.zeros_like(true_positives),
+        )
+        recall = torch.where(
+            self.target_count > 0,
+            true_positives / (true_positives + false_negatives),
+            torch.zeros_like(true_positives),
+        )
+        f1 = torch.where(
+            precision + recall > 0,
+            2 * precision * recall / (precision + recall),
+            torch.zeros_like(precision),
+        )
+
+        best_index = torch.argmax(f1)
+
+        return {
+            "confidence": self.thresholds,
+            "precision": precision,
+            "recall": recall,
+            "f1": f1,
+            "max_f1": f1[best_index],
+            "confidence_at_max_f1": self.thresholds[best_index],
+        }
+
+    def get_loggable_values(
+        self,
+        values: dict[str, Tensor],
+    ) -> tuple[Tensor, dict[str, Tensor]]:
+        """Use maximum F1 as the primary scalar metric."""
+        return values["max_f1"], {
+            "confidence_at_max_f1": values["confidence_at_max_f1"],
+        }
+
+    def get_artifact_names(self) -> tuple[str, ...]:
+        """Return the stable name of the combined curve figure."""
+        return ("curves",)
+
+    def get_artifacts(
+        self,
+        values: dict[str, Tensor],
+    ) -> dict[str, Tensor]:
+        """Render PR, precision-confidence, and recall-confidence
+        curves.
+        """
+        from matplotlib.figure import Figure
+
+        from luxonis_train.attached_modules.visualizers.utils import (
+            figure_to_torch,
+        )
+
+        confidence = values["confidence"].detach().cpu().numpy()
+        precision = values["precision"].detach().cpu().numpy()
+        recall = values["recall"].detach().cpu().numpy()
+
+        artifact_width = 1200
+        artifact_height = 400
+        figure = Figure(
+            figsize=(artifact_width / 100, artifact_height / 100),
+            layout="constrained",
+        )
+        axes = figure.subplots(1, 3)
+
+        axes[0].plot(recall[::-1], precision[::-1])
+        axes[0].set_title("Precision-Recall")
+        axes[0].set_xlabel("Recall")
+        axes[0].set_ylabel("Precision")
+
+        axes[1].plot(confidence, precision)
+        axes[1].set_title("Precision-Confidence")
+        axes[1].set_xlabel("Confidence")
+        axes[1].set_ylabel("Precision")
+
+        axes[2].plot(confidence, recall)
+        axes[2].set_title("Recall-Confidence")
+        axes[2].set_xlabel("Confidence")
+        axes[2].set_ylabel("Recall")
+
+        for axis in axes:
+            axis.set_xlim(0, 1)
+            axis.set_ylim(0, 1)
+            axis.grid()
+
+        return {
+            "curves": figure_to_torch(
+                figure,
+                width=artifact_width,
+                height=artifact_height,
+            )
+        }

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -898,16 +898,26 @@ class LuxonisLightningModule(pl.LightningModule):
                             )
                             continue
 
-                        self.tracker.log_image(
-                            name=f"{mode}/metrics/{self.current_epoch}/"
-                            f"{formatted_node_name}/{metric_name}/"
-                            f"{artifact_name}",
-                            img=artifact.detach()
-                            .cpu()
-                            .numpy()
-                            .transpose(1, 2, 0),
-                            step=self.current_epoch,
-                        )
+                        try:
+                            image = (
+                                artifact.detach()
+                                .cpu()
+                                .numpy()
+                                .transpose(1, 2, 0)
+                            )
+                            self.tracker.log_image(
+                                name=f"{mode}/metrics/{self.current_epoch}/"
+                                f"{formatted_node_name}/{metric_name}/"
+                                f"{artifact_name}",
+                                img=image,
+                                step=self.current_epoch,
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Failed to log metric artifact "
+                                f"'{artifact_name}' from metric "
+                                f"'{metric_name}'. Skipping artifact logging."
+                            )
         self._print_results(
             stage="Validation" if mode == "val" else "Test",
             loss=self._loss_accumulators[mode]["loss"],

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -836,13 +836,13 @@ class LuxonisLightningModule(pl.LightningModule):
         for node_name, node in self.nodes.items():
             formatted_node_name = self.nodes.formatted_name(node_name)
             for metric_name, metric in node.metrics.items():
+                computed = metric.compute()
                 values = postprocess_metrics(
                     metric_name,
-                    metric.compute(),
+                    metric.get_loggable_values(computed),
                     log_sub_metrics=self.cfg.trainer.log_sub_metrics,
                 )
                 metric.reset()
-
                 if isinstance(
                     self.trainer.strategy,
                     pl.strategies.DDPStrategy,  # type: ignore
@@ -878,6 +878,36 @@ class LuxonisLightningModule(pl.LightningModule):
                             sync_dist=True,
                         )
 
+                if self.trainer.is_global_zero:
+                    try:
+                        artifacts = metric.get_artifacts(computed)
+                    except Exception:
+                        logger.exception(
+                            "Failed to generate artifacts for metric "
+                            f"'{metric_name}'. Skipping artifact logging."
+                        )
+                        artifacts = {}
+
+                    for artifact_name, artifact in artifacts.items():
+                        if artifact.dim() != 3:
+                            logger.warning(
+                                "Skipping metric artifact "
+                                f"'{artifact_name}' from metric "
+                                f"'{metric_name}': expected shape "
+                                f"[C, H, W], got {tuple(artifact.shape)}."
+                            )
+                            continue
+
+                        self.tracker.log_image(
+                            name=f"{mode}/metrics/{self.current_epoch}/"
+                            f"{formatted_node_name}/{metric_name}/"
+                            f"{artifact_name}",
+                            img=artifact.detach()
+                            .cpu()
+                            .numpy()
+                            .transpose(1, 2, 0),
+                            step=self.current_epoch,
+                        )
         self._print_results(
             stage="Validation" if mode == "val" else "Test",
             loss=self._loss_accumulators[mode]["loss"],
@@ -968,9 +998,10 @@ class LuxonisLightningModule(pl.LightningModule):
         for node_name, node in self.nodes.items():
             formatted_node_name = self.nodes.formatted_name(node_name)
             for metric_name, metric in node.metrics.items():
+                computed = metric.compute()
                 values = postprocess_metrics(
                     metric_name,
-                    metric.compute(),
+                    metric.get_loggable_values(computed),
                     log_sub_metrics=self.cfg.trainer.log_sub_metrics,
                 )
                 for sub_name in values:
@@ -990,6 +1021,19 @@ class LuxonisLightningModule(pl.LightningModule):
                         metric_keys.add(
                             f"test/metric/{formatted_node_name}/{sub_name}"
                         )
+
+                for artifact_name in metric.get_artifact_names():
+                    for epoch_idx in sorted({0, *val_eval_epochs}):
+                        artifact_keys.add(
+                            f"val/metrics/{epoch_idx}/"
+                            f"{formatted_node_name}/{metric_name}/"
+                            f"{artifact_name}.png"
+                        )
+                    artifact_keys.add(
+                        f"test/metrics/{test_eval_epoch}/"
+                        f"{formatted_node_name}/{metric_name}/"
+                        f"{artifact_name}.png"
+                    )
 
             for viz_name in node.visualizers:
                 for epoch_idx in sorted({0, *val_eval_epochs}):

--- a/luxonis_train/nodes/heads/efficient_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_bbox_head.py
@@ -115,18 +115,20 @@ class EfficientBBoxHead(BaseDetectionHead):
             self.grid_cell_offset,
             multiply_with_stride=False,
         )
-        bboxes = self._postprocess_detections(
+        detections_pre_nms = self._prepare_bbox_inference_output(
             features_list,
             class_scores,
             distributions,
             anchor_points,
             stride_tensor,
         )
+        bboxes = self._run_nms(detections_pre_nms)
         return {
             self.task.main_output: bboxes,
             "features": features_list,
             "class_scores": class_scores,
             "distributions": distributions,
+            "detections_pre_nms": detections_pre_nms,
         }
 
     @staticmethod
@@ -172,11 +174,32 @@ class EfficientBBoxHead(BaseDetectionHead):
         """Perform post-processing of the output and returns bboxs after
         NMS.
         """
+        detections_pre_nms = self._prepare_bbox_inference_output(
+            features,
+            class_scores,
+            distributions,
+            anchor_points,
+            stride_tensor,
+            tail=tail,
+        )
+        return self._run_nms(detections_pre_nms)
+
+    def _prepare_bbox_inference_output(
+        self,
+        features: list[Tensor],
+        class_scores: Tensor,
+        distributions: Tensor,
+        anchor_points: Tensor,
+        stride_tensor: Tensor,
+        *,
+        tail: list[Tensor] | None = None,
+    ) -> Tensor:
+        """Decode predictions into the tensor expected by NMS."""
         tail = tail or []
         bboxes = dist2bbox(distributions, anchor_points, out_format="xyxy")
 
         bboxes *= stride_tensor
-        output_merged = torch.cat(
+        return torch.cat(
             [
                 bboxes,
                 torch.ones(
@@ -190,8 +213,10 @@ class EfficientBBoxHead(BaseDetectionHead):
             dim=-1,
         )
 
+    def _run_nms(self, detections_pre_nms: Tensor) -> list[Tensor]:
+        """Apply NMS to decoded detection candidates."""
         return non_max_suppression(
-            output_merged,
+            detections_pre_nms,
             n_classes=self.n_classes,
             conf_thres=self.conf_thres,
             iou_thres=self.iou_thres,

--- a/luxonis_train/nodes/heads/precision_bbox_head.py
+++ b/luxonis_train/nodes/heads/precision_bbox_head.py
@@ -107,10 +107,11 @@ class PrecisionBBoxHead(BaseDetectionHead):
                 )
             }
 
+        detections_pre_nms = self._prepare_bbox_inference_output(
+            classes_list, regressions_list
+        )
         boxes = non_max_suppression(
-            self._prepare_bbox_inference_output(
-                classes_list, regressions_list
-            ),
+            detections_pre_nms,
             n_classes=self.n_classes,
             conf_thres=self.conf_thres,
             iou_thres=self.iou_thres,
@@ -122,6 +123,7 @@ class PrecisionBBoxHead(BaseDetectionHead):
         return {
             "features": features_list,
             "boundingbox": boxes,
+            "detections_pre_nms": detections_pre_nms,
         }
 
     @override

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ faster-coco-eval~=1.7
 grad-cam~=1.5
 lightning~=2.5
 luxonis-ml[data,tracker,s3,gcs,roboflow]>=0.9.0
+matplotlib~=3.10
 mlflow~=3.6
 onnxruntime~=1.23
 onnxscript~=0.5

--- a/tests/unittests/test_metrics/test_precision_recall_curve.py
+++ b/tests/unittests/test_metrics/test_precision_recall_curve.py
@@ -1,0 +1,710 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+from torch import Size, Tensor
+
+from luxonis_train.attached_modules.metrics import PrecisionRecallCurve
+from luxonis_train.lightning.luxonis_lightning import LuxonisLightningModule
+from luxonis_train.nodes import BaseNode
+from luxonis_train.nodes.heads.efficient_bbox_head import EfficientBBoxHead
+from luxonis_train.nodes.heads.precision_bbox_head import PrecisionBBoxHead
+from luxonis_train.tasks import Tasks
+from luxonis_train.typing import Packet
+from luxonis_train.utils import non_max_suppression
+from luxonis_train.utils.dataset_metadata import DatasetMetadata
+
+
+class DummyBBoxNode(BaseNode, register=False):
+    task = Tasks.BOUNDINGBOX
+    iou_thres = 0.45
+    max_det = 300
+
+    def forward(self, _: Tensor) -> Tensor:
+        raise NotImplementedError
+
+
+def make_node() -> DummyBBoxNode:
+    return DummyBBoxNode(
+        n_classes=2,
+        original_in_shape=Size([3, 100, 100]),
+        dataset_metadata=DatasetMetadata(
+            classes={"": {"class0": 0, "class1": 1}}
+        ),
+    )
+
+
+def make_metric(
+    *,
+    thresholds: list[float] | None = None,
+) -> PrecisionRecallCurve:
+    return PrecisionRecallCurve(
+        node=make_node(),
+        confidence_thresholds=thresholds or [0.0, 0.7, 0.85, 1.0],
+        matching_iou_threshold=0.5,
+        nms_iou_threshold=0.45,
+        max_detections=300,
+    )
+
+
+def make_pre_nms(
+    rows: list[tuple[float, float, float, float, float, int]],
+    *,
+    n_classes: int = 2,
+) -> Tensor:
+    output = torch.zeros(
+        (1, len(rows), 5 + n_classes),
+        dtype=torch.float32,
+    )
+    for index, (x1, y1, x2, y2, score, class_id) in enumerate(rows):
+        output[0, index, :4] = torch.tensor([x1, y1, x2, y2])
+        output[0, index, 4] = 1.0
+        output[0, index, 5 + class_id] = score
+    return output
+
+
+def test_precision_recall_curve_uses_node_nms_defaults() -> None:
+    metric = PrecisionRecallCurve(
+        node=make_node(),
+        confidence_thresholds=[0.0, 0.5, 1.0],
+    )
+
+    assert metric.nms_iou_threshold == 0.45
+    assert metric.max_detections == 300
+
+
+def test_precision_recall_curve_values() -> None:
+    metric = make_metric()
+    predictions = make_pre_nms(
+        [
+            (0, 0, 20, 10, 0.9, 0),
+            (0, 10, 20, 20, 0.8, 0),
+            (50, 50, 70, 70, 0.6, 1),
+        ]
+    )
+    targets = torch.tensor(
+        [[0, 0, 0.0, 0.0, 0.2, 0.2]],
+        dtype=torch.float32,
+    )
+
+    metric.update(predictions, targets)
+    result = metric.compute()
+
+    torch.testing.assert_close(
+        result["confidence"],
+        torch.tensor([0.0, 0.7, 0.85, 1.0]),
+    )
+    torch.testing.assert_close(
+        result["precision"],
+        torch.tensor([1 / 3, 1 / 2, 1.0, 0.0]),
+    )
+    torch.testing.assert_close(
+        result["recall"],
+        torch.tensor([1.0, 1.0, 1.0, 0.0]),
+    )
+    torch.testing.assert_close(
+        result["f1"],
+        torch.tensor([0.5, 2 / 3, 1.0, 0.0]),
+    )
+
+
+def test_precision_recall_curve_accumulates_and_resets() -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    predictions = make_pre_nms([(10, 10, 30, 30, 0.9, 0)])
+    targets = torch.tensor(
+        [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+        dtype=torch.float32,
+    )
+
+    metric.update(predictions, targets)
+    metric.update(predictions, targets)
+
+    torch.testing.assert_close(
+        metric.true_positives,
+        torch.tensor([2, 2, 0]),
+    )
+    torch.testing.assert_close(
+        metric.false_positives,
+        torch.tensor([0, 0, 0]),
+    )
+    assert int(metric.target_count) == 2
+
+    metric.reset()
+
+    torch.testing.assert_close(
+        metric.true_positives,
+        torch.zeros(3, dtype=torch.long),
+    )
+    torch.testing.assert_close(
+        metric.false_positives,
+        torch.zeros(3, dtype=torch.long),
+    )
+    assert int(metric.target_count) == 0
+
+
+@pytest.mark.parametrize(
+    ("predictions", "targets"),
+    [
+        (
+            torch.empty((1, 0, 7)),
+            torch.tensor([[0, 0, 0.1, 0.1, 0.2, 0.2]]),
+        ),
+        (
+            make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+            torch.empty((0, 6)),
+        ),
+        (
+            torch.empty((1, 0, 7)),
+            torch.empty((0, 6)),
+        ),
+    ],
+)
+def test_precision_recall_curve_empty_inputs(
+    predictions: Tensor,
+    targets: Tensor,
+) -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+
+    metric.update(predictions.float(), targets.float())
+    result = metric.compute()
+
+    assert torch.isfinite(result["precision"]).all()
+    assert torch.isfinite(result["recall"]).all()
+    assert torch.isfinite(result["f1"]).all()
+
+
+def test_precision_recall_curve_run_update_routing() -> None:
+    metric = make_metric()
+    predictions = make_pre_nms([(10, 10, 30, 30, 0.9, 0)])
+    targets = torch.tensor(
+        [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+        dtype=torch.float32,
+    )
+
+    parameters = metric.get_parameters(
+        {
+            "boundingbox": [torch.empty((0, 6))],
+            "detections_pre_nms": predictions,
+        },
+        {"/boundingbox": targets},
+    )
+
+    assert set(parameters) == {
+        "detections_pre_nms",
+        "target_boundingbox",
+    }
+
+    metric.run_update(
+        {
+            "boundingbox": [torch.empty((0, 6))],
+            "detections_pre_nms": predictions,
+        },
+        {"/boundingbox": targets},
+    )
+    assert int(metric.target_count) == 1
+
+
+def test_precision_recall_curve_runs_nms_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import luxonis_train.attached_modules.metrics.precision_recall_curve as module
+
+    calls = 0
+    original = module.non_max_suppression
+
+    def counted_nms(*args, **kwargs) -> list[Tensor]:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module, "non_max_suppression", counted_nms)
+
+    metric = make_metric()
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"confidence_thresholds": [0.5]},
+        {"confidence_thresholds": [0.5, 0.5]},
+        {"confidence_thresholds": [-0.1, 0.5]},
+        {"num_thresholds": 1},
+        {"min_confidence": 0.8, "max_confidence": 0.2},
+        {"matching_iou_threshold": 1.1},
+        {"nms_iou_threshold": -0.1},
+        {"max_detections": 0},
+    ],
+)
+def test_precision_recall_curve_rejects_invalid_configuration(
+    kwargs: dict[str, Any],
+) -> None:
+    params: dict[str, Any] = {
+        "node": make_node(),
+        "nms_iou_threshold": 0.45,
+        "max_detections": 300,
+    }
+    params.update(kwargs)
+
+    with pytest.raises(ValueError, match="must"):
+        PrecisionRecallCurve(**params)
+
+
+class DummyNodes(dict[str, object]):
+    def formatted_name(self, name: str) -> str:
+        return name
+
+
+class DummyTracker:
+    def __init__(self) -> None:
+        self.images: list[dict[str, object]] = []
+
+    def log_image(
+        self,
+        name: str,
+        img: object,
+        step: int,
+    ) -> None:
+        self.images.append({"name": name, "img": img, "step": step})
+
+    def log_matrix(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise AssertionError("Matrix logging should not be used for curves.")
+
+
+def make_epoch_end_harness(
+    metric: PrecisionRecallCurve,
+    *,
+    is_global_zero: bool,
+    log_sub_metrics: bool = True,
+) -> SimpleNamespace:
+    tracker = DummyTracker()
+    logged: list[tuple[str, Tensor, bool]] = []
+
+    def log(name: str, value: Tensor, sync_dist: bool) -> None:
+        logged.append((name, value, sync_dist))
+
+    def print_results(**kwargs: object) -> None:
+        del kwargs
+
+    node = SimpleNamespace(
+        metrics={"PrecisionRecallCurve": metric},
+        losses={},
+        visualizers={},
+    )
+    cfg = SimpleNamespace(
+        trainer=SimpleNamespace(
+            log_sub_metrics=log_sub_metrics,
+            n_log_images=0,
+            validation_interval=1,
+            epochs=2,
+            run_validation_after_first_epoch=False,
+            callbacks=[],
+        ),
+        exporter=SimpleNamespace(name=None),
+        model=SimpleNamespace(name="dummy"),
+    )
+
+    return SimpleNamespace(
+        _loss_accumulators={"val": {"loss": torch.tensor(0.0)}},
+        nodes=DummyNodes({"head": node}),
+        cfg=cfg,
+        trainer=SimpleNamespace(
+            strategy=object(),
+            is_global_zero=is_global_zero,
+        ),
+        device=torch.device("cpu"),
+        progress_bar=SimpleNamespace(),
+        tracker=tracker,
+        current_epoch=3,
+        log=log,
+        _print_results=print_results,
+        _n_logged_images=0,
+        _sequentially_logged_visualizations=[],
+        _needs_vis_buffering=True,
+        _class_log_counts=[],
+        _logged=logged,
+    )
+
+
+def test_precision_recall_curve_separates_scalars_and_artifact() -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+
+    computed = metric.compute()
+    primary, submetrics = metric.get_loggable_values(computed)
+    artifacts = metric.get_artifacts(computed)
+
+    assert set(computed) == {
+        "confidence",
+        "precision",
+        "recall",
+        "f1",
+        "max_f1",
+        "confidence_at_max_f1",
+    }
+    torch.testing.assert_close(primary, computed["max_f1"])
+    assert set(submetrics) == {"confidence_at_max_f1"}
+    assert all(value.ndim == 0 for value in submetrics.values())
+    assert metric.get_artifact_names() == ("curves",)
+    assert set(artifacts) == {"curves"}
+    assert artifacts["curves"].ndim == 3
+    assert artifacts["curves"].shape[0] == 3
+    assert artifacts["curves"].dtype == torch.uint8
+
+
+def test_evaluation_epoch_end_logs_curve_once_and_resets() -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+    harness = make_epoch_end_harness(metric, is_global_zero=True)
+
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness), "val"
+    )
+
+    metric_logs = [
+        name
+        for name, _, _ in harness._logged
+        if name.startswith("val/metric/")
+    ]
+    assert metric_logs == [
+        "val/metric/head/PrecisionRecallCurve",
+        "val/metric/head/confidence_at_max_f1",
+    ]
+    assert len(harness.tracker.images) == 1
+    assert harness.tracker.images[0]["name"] == (
+        "val/metrics/3/head/PrecisionRecallCurve/curves"
+    )
+    assert int(metric.target_count) == 0
+    torch.testing.assert_close(
+        metric.true_positives,
+        torch.zeros(3, dtype=torch.long),
+    )
+
+
+def test_evaluation_epoch_end_logs_primary_without_submetrics() -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+    harness = make_epoch_end_harness(
+        metric,
+        is_global_zero=True,
+        log_sub_metrics=False,
+    )
+
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness), "val"
+    )
+
+    metric_logs = [
+        name
+        for name, _, _ in harness._logged
+        if name.startswith("val/metric/")
+    ]
+    assert metric_logs == ["val/metric/head/PrecisionRecallCurve"]
+    assert len(harness.tracker.images) == 1
+    assert int(metric.target_count) == 0
+
+
+def test_evaluation_epoch_end_skips_artifact_on_nonzero_rank() -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+    harness = make_epoch_end_harness(metric, is_global_zero=False)
+
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness), "val"
+    )
+
+    assert harness.tracker.images == []
+    assert int(metric.target_count) == 0
+
+
+def test_evaluation_epoch_end_skips_invalid_artifact_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+
+    def invalid_artifacts(
+        values: dict[str, Tensor],
+    ) -> dict[str, Tensor]:
+        del values
+        return {"curves": torch.zeros((10, 10))}
+
+    monkeypatch.setattr(metric, "get_artifacts", invalid_artifacts)
+    harness = make_epoch_end_harness(metric, is_global_zero=True)
+
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness), "val"
+    )
+
+    metric_logs = [
+        name
+        for name, _, _ in harness._logged
+        if name.startswith("val/metric/")
+    ]
+    assert metric_logs == [
+        "val/metric/head/PrecisionRecallCurve",
+        "val/metric/head/confidence_at_max_f1",
+    ]
+    assert harness.tracker.images == []
+    assert int(metric.target_count) == 0
+
+
+def test_evaluation_epoch_end_skips_artifact_generation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+
+    def failing_artifacts(
+        values: dict[str, Tensor],
+    ) -> dict[str, Tensor]:
+        del values
+        raise RuntimeError("artifact rendering failed")
+
+    monkeypatch.setattr(metric, "get_artifacts", failing_artifacts)
+    harness = make_epoch_end_harness(metric, is_global_zero=True)
+
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness), "val"
+    )
+
+    metric_logs = [
+        name
+        for name, _, _ in harness._logged
+        if name.startswith("val/metric/")
+    ]
+    assert metric_logs == [
+        "val/metric/head/PrecisionRecallCurve",
+        "val/metric/head/confidence_at_max_f1",
+    ]
+    assert harness.tracker.images == []
+    assert int(metric.target_count) == 0
+
+
+def test_mlflow_keys_classify_curve_as_image_artifact() -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    harness = make_epoch_end_harness(metric, is_global_zero=True)
+
+    keys = LuxonisLightningModule.get_mlflow_logging_keys(
+        cast(LuxonisLightningModule, harness)
+    )
+
+    assert "val/metric/head/PrecisionRecallCurve" in keys["metrics"]
+    assert "val/metric/head/confidence_at_max_f1" in keys["metrics"]
+    assert (
+        "val/metrics/0/head/PrecisionRecallCurve/curves.png"
+        in keys["artifacts"]
+    )
+    assert (
+        "test/metrics/2/head/PrecisionRecallCurve/curves.png"
+        in keys["artifacts"]
+    )
+    assert not any(
+        name.endswith(("/precision", "/recall", "/confidence", "/f1"))
+        for name in keys["metrics"]
+    )
+
+
+_REAL_BATCH_SIZE = 2
+_REAL_IMAGE_HEIGHT = 64
+_REAL_IMAGE_WIDTH = 64
+_REAL_N_CLASSES = 2
+_REAL_FEATURE_SHAPES = (
+    Size([_REAL_BATCH_SIZE, 16, 8, 8]),
+    Size([_REAL_BATCH_SIZE, 32, 4, 4]),
+    Size([_REAL_BATCH_SIZE, 64, 2, 2]),
+)
+
+
+class _RealEfficientBBoxHead(EfficientBBoxHead, register=False):
+    task = Tasks.BOUNDINGBOX
+    original_in_shape = cast(
+        Any, Size([3, _REAL_IMAGE_HEIGHT, _REAL_IMAGE_WIDTH])
+    )
+    n_classes = cast(Any, _REAL_N_CLASSES)
+
+    @property
+    def input_shapes(self) -> list[Packet[Size]]:
+        return [{"features": list(_REAL_FEATURE_SHAPES)}]
+
+    @property
+    def in_sizes(self) -> list[Size]:
+        return list(_REAL_FEATURE_SHAPES)
+
+
+class _RealPrecisionBBoxHead(PrecisionBBoxHead, register=False):
+    task = Tasks.BOUNDINGBOX
+    original_in_shape = cast(
+        Any, Size([3, _REAL_IMAGE_HEIGHT, _REAL_IMAGE_WIDTH])
+    )
+    n_classes = cast(Any, _REAL_N_CLASSES)
+
+    @property
+    def input_shapes(self) -> list[Packet[Size]]:
+        return [{"features": list(_REAL_FEATURE_SHAPES)}]
+
+    @property
+    def in_sizes(self) -> list[Size]:
+        return list(_REAL_FEATURE_SHAPES)
+
+
+def _make_real_features(seed: int) -> list[Tensor]:
+    generator = torch.Generator().manual_seed(seed)
+    return [
+        torch.randn(shape, generator=generator)
+        for shape in _REAL_FEATURE_SHAPES
+    ]
+
+
+@pytest.mark.parametrize(
+    ("head_cls", "seed"),
+    [
+        (_RealEfficientBBoxHead, 1301),
+        (_RealPrecisionBBoxHead, 1302),
+    ],
+)
+def test_real_bbox_head_to_precision_recall_curve_e2e(
+    head_cls: type[EfficientBBoxHead | PrecisionBBoxHead],
+    seed: int,
+) -> None:
+    torch.manual_seed(seed)
+
+    head = head_cls(
+        n_heads=3,
+        conf_thres=0.0,
+        iou_thres=0.45,
+        max_det=50,
+        dataset_metadata=DatasetMetadata(
+            classes={"": {"class0": 0, "class1": 1}}
+        ),
+        task_name="",
+    )
+    head.eval()
+
+    with torch.inference_mode():
+        packet = head(_make_real_features(seed))
+
+    assert {"boundingbox", "detections_pre_nms"} <= set(packet)
+
+    detections_pre_nms = packet["detections_pre_nms"]
+    boundingbox = packet["boundingbox"]
+
+    assert isinstance(detections_pre_nms, Tensor)
+    assert isinstance(boundingbox, list)
+    assert detections_pre_nms.shape == (
+        _REAL_BATCH_SIZE,
+        sum(shape[-2] * shape[-1] for shape in _REAL_FEATURE_SHAPES),
+        5 + _REAL_N_CLASSES,
+    )
+    assert len(boundingbox) == _REAL_BATCH_SIZE
+
+    replay = non_max_suppression(
+        detections_pre_nms,
+        n_classes=head.n_classes,
+        conf_thres=head.conf_thres,
+        iou_thres=head.iou_thres,
+        bbox_format="xyxy",
+        max_det=head.max_det,
+        predicts_objectness=False,
+    )
+    for actual, expected in zip(boundingbox, replay, strict=True):
+        torch.testing.assert_close(actual, expected)
+
+    image_index, detection = next(
+        (index, detections[0])
+        for index, detections in enumerate(boundingbox)
+        if detections.numel() > 0
+    )
+    x1, y1, x2, y2 = detection[:4]
+    score = float(detection[4])
+    class_id = float(detection[5])
+
+    target = detection.new_tensor(
+        [
+            [
+                float(image_index),
+                class_id,
+                float(x1) / _REAL_IMAGE_WIDTH,
+                float(y1) / _REAL_IMAGE_HEIGHT,
+                float(x2 - x1) / _REAL_IMAGE_WIDTH,
+                float(y2 - y1) / _REAL_IMAGE_HEIGHT,
+            ]
+        ]
+    )
+    interior_score = min(max(score, 1e-6), 1.0 - 1e-6)
+
+    metric = PrecisionRecallCurve(
+        node=head,
+        confidence_thresholds=[0.0, interior_score, 1.0],
+        matching_iou_threshold=0.5,
+    )
+    labels = {f"{head.task_name}/boundingbox": target}
+
+    parameters = metric.get_parameters(packet, labels)
+    assert set(parameters) == {
+        "detections_pre_nms",
+        "target_boundingbox",
+    }
+
+    metric.run_update(packet, labels)
+    computed = metric.compute()
+    primary, submetrics = metric.get_loggable_values(computed)
+    artifacts = metric.get_artifacts(computed)
+
+    assert float(computed["max_f1"]) > 0
+    torch.testing.assert_close(primary, computed["max_f1"])
+    assert set(submetrics) == {"confidence_at_max_f1"}
+    assert all(value.numel() == 1 for value in submetrics.values())
+
+    artifact = artifacts["curves"]
+    assert artifact.ndim == 3
+    assert artifact.shape[0] == 3
+    assert artifact.dtype == torch.uint8

--- a/tests/unittests/test_metrics/test_precision_recall_curve.py
+++ b/tests/unittests/test_metrics/test_precision_recall_curve.py
@@ -529,6 +529,50 @@ def test_evaluation_epoch_end_skips_artifact_generation_failure(
     assert int(metric.target_count) == 0
 
 
+def test_evaluation_epoch_end_skips_tracker_image_logging_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+    harness = make_epoch_end_harness(metric, is_global_zero=True)
+
+    def failing_log_image(
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        del args, kwargs
+        raise RuntimeError("tracker image logging failed")
+
+    monkeypatch.setattr(
+        harness.tracker,
+        "log_image",
+        failing_log_image,
+    )
+
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness),
+        "val",
+    )
+
+    metric_logs = [
+        name
+        for name, _, _ in harness._logged
+        if name.startswith("val/metric/")
+    ]
+    assert metric_logs == [
+        "val/metric/head/PrecisionRecallCurve",
+        "val/metric/head/confidence_at_max_f1",
+    ]
+    assert harness.tracker.images == []
+    assert int(metric.target_count) == 0
+
+
 def test_mlflow_keys_classify_curve_as_image_artifact() -> None:
     metric = make_metric(thresholds=[0.0, 0.5, 1.0])
     harness = make_epoch_end_harness(metric, is_global_zero=True)


### PR DESCRIPTION
# Add precision-recall and confidence curves for detection

## Purpose

Add confidence-based evaluation curves for bounding-box detection in `luxonis-train`.

The new metric provides:

* precision-recall
* precision-confidence
* recall-confidence

The current detection metrics operate on post-NMS detections produced at a fixed confidence threshold. That is sufficient for scalar metrics such as mAP, but it does not provide the decoded candidates needed to evaluate how precision and recall change across confidence thresholds.

This PR adds an opt-in `PrecisionRecallCurve` metric and exposes decoded pre-NMS detections from the supported bounding-box heads during evaluation.

## Specification

### Detection-head output

Updated:

* `EfficientBBoxHead`
* `PrecisionBBoxHead`

Both heads now expose:

* the existing post-NMS `boundingbox` output
* a new decoded `detections_pre_nms` tensor during evaluation

Training and export output contracts remain unchanged.

For `EfficientBBoxHead`, decoding and NMS are separated into:

* `_prepare_bbox_inference_output()`
* `_run_nms()`

The existing `_postprocess_detections()` behavior is preserved as a wrapper around those two steps.

### PrecisionRecallCurve metric

Added an opt-in `PrecisionRecallCurve` metric for bounding-box detection.

The metric:

* supports an explicit confidence grid or a generated linear grid
* runs NMS once at the minimum configured confidence threshold
* reuses the retained detections across the confidence grid
* performs class-aware, score-ordered, one-to-one matching
* uses a configurable matching IoU threshold
* defaults NMS IoU and maximum detections to the attached detection head values
* accumulates true positives, false positives, and target counts with distributed sum reduction

The metric computes:

* precision for each confidence threshold
* recall for each confidence threshold
* F1 for each confidence threshold
* maximum F1
* confidence threshold at maximum F1

`max_f1` is exposed as the primary scalar under the metric name.

`confidence_at_max_f1` is exposed as a submetric.

### Metric artifacts

Extended the metric interface with generic hooks for:

* filtering values intended for scalar logging
* generating image artifacts from computed metric results
* declaring stable artifact names

`PrecisionRecallCurve` logs one RGB image containing:

* precision-recall
* precision-confidence
* recall-confidence

The artifact is generated only on global rank zero.

### Scope

This PR intentionally supports:

* bounding-box detection only
* global micro-averaged curves
* one matching IoU threshold
* one NMS pass at the minimum confidence threshold

The following are not included:

* per-class curves
* AUPRC
* instance-keypoint or segmentation curves

mAP remains the recommended primary detection metric.

## Dependencies & Potential Impact

No new external dependency is introduced.

Potential impact:

* evaluation packets from `EfficientBBoxHead` and `PrecisionBBoxHead` now include the additional `detections_pre_nms` key
* the existing post-NMS `boundingbox` output remains unchanged
* training output remains unchanged
* export output remains unchanged
* the curve metric is opt-in and does not affect configurations that do not attach it
* generating the curve artifact requires rendering one Matplotlib figure at evaluation epoch end on global rank zero

The metric uses the decoded candidates produced by the detection head, so the supported heads and the metric share the same pre-NMS tensor contract.

## Testing & Validation

Validation performed:

* Ruff checks passed
* formatting checks passed
* Python compilation passed
* `git diff --check` passed
* private metadata and temporary-code checks passed

Focused metric validation:

* 23 `PrecisionRecallCurve` tests passed
* invalid configuration and empty-input cases covered
* accumulation and reset behavior covered
* scalar and artifact separation covered
* behavior with `log_sub_metrics=True` and `False` covered
* MLflow metric and artifact keys covered

Detection-head validation:

* real forward-path tests for `EfficientBBoxHead`
* real forward-path tests for `PrecisionBBoxHead`
* exact replay of the canonical post-NMS output from `detections_pre_nms`
* training contract checked
* evaluation contract checked
* export contract checked

Regression validation:

* 95 metric unit tests passed
* 4 Lightning utility tests passed

Distributed validation:

* two-process CPU/Gloo validation passed
* distributed states matched a single-process reference
* computed vectors and primary scalar were identical across ranks
* curve artifact generation occurred only on rank zero

The final commit was also rebased onto the current `main` and revalidated before push.

## Deployment Plan

No deployment is required.

Rollout:

* review the implementation and metric contract
* verify hosted CI
* use `PrecisionRecallCurve` only in detection configurations that require confidence-based curves
* keep mAP as the default primary detection metric

Rollback:

* revert this PR if the additional evaluation packet output or metric artifact hooks cause regressions

Monitoring:

* hosted CI results
* reviewer feedback on the pre-NMS output contract
* reviewer feedback on the global micro matching and single-NMS design
* runtime and memory behavior in larger detection validation runs

## AI Usage

Assisted-by: ChatGPT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a bounding-box Precision/Recall curve metric with precision, recall, F1, and best-confidence reporting.
  - Added visual curve artifacts for validation and testing results.

- **Improvements**
  - Standardized metric logging and artifact handling.
  - Inference now exposes pre-NMS detections for more accurate evaluation.

- **Tests**
  - Added comprehensive metric, logging, artifact, and detection-head integration coverage.

- **Chores**
  - Added Matplotlib for curve rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->