### PR TITLE
Fix review findings in detection confidence curves

### DIFF
--- a/luxonis_train/attached_modules/metrics/README.md
+++ b/luxonis_train/attached_modules/metrics/README.md
@@ -20,6 +20,7 @@ List of all the available metrics.
 - [MedianDistances](#mediandistances)
 - [OCRAccuracy](#ocraccuracy)
 - [ConfusionMatrix](#confusionmatrix)
+- [PrecisionRecallCurve](#precisionrecallcurve)
 
 ## Accuracy
 
@@ -161,3 +162,25 @@ Works with **classification, segmentation, object detection, instance keypoint d
 | Key             | Type    | Default value | Description                                                                |
 | --------------- | ------- | ------------- | -------------------------------------------------------------------------- |
 | `iou_threshold` | `float` | `0.45`        | `IoU` threshold for bounding boxes. Only relevant for `BOUNDIBGBOX` tasks. |
+
+## PrecisionRecallCurve
+
+Computes precision, recall, and F1 over a fixed grid of confidence thresholds and logs them as a three-panel figure (precision-recall, precision-confidence, recall-confidence). The scalar metric is the maximum F1 over the grid, with the confidence that achieves it logged as a sub-metric.
+
+Works with **object detection, instance keypoint detection and instance segmentation tasks**. Must be attached to a detection head, from which it re-runs NMS on the head's pre-NMS candidates - so its own NMS parameters are independent of the head's `conf_thres`.
+
+> [!NOTE]
+> **Important:** the metric's runtime grows with the number of NMS candidates above `nms_conf_threshold`. Raise `nms_conf_threshold` (or `min_confidence`) if validation is slow.
+
+**Params**
+
+| Key                      | Type                  | Default value | Description                                                                                                                              |
+| ------------------------ | --------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `confidence_thresholds`  | `list[float] \| None` | `None`        | Explicit, strictly increasing confidence grid. Mutually exclusive with the three parameters below                                        |
+| `num_thresholds`         | `int \| None`         | `101`         | Number of points in the generated grid                                                                                                   |
+| `min_confidence`         | `float \| None`       | `0.0`         | Lowest generated confidence threshold                                                                                                    |
+| `max_confidence`         | `float \| None`       | `1.0`         | Highest generated confidence threshold                                                                                                   |
+| `matching_iou_threshold` | `float`               | `0.5`         | `IoU` required for a prediction to match a ground-truth box                                                                              |
+| `nms_conf_threshold`     | `float`               | `1e-3`        | Confidence floor applied before NMS. Candidates below it are never counted. Effective floor is the larger of it and the lowest threshold |
+| `nms_iou_threshold`      | `float \| None`       | `None`        | `IoU` used by NMS. Defaults to the attached head's `iou_thres`                                                                           |
+| `max_detections`         | `int \| None`         | `None`        | Maximum detections retained by NMS. Defaults to the attached head's `max_det`                                                            |

--- a/luxonis_train/attached_modules/metrics/precision_recall_curve.py
+++ b/luxonis_train/attached_modules/metrics/precision_recall_curve.py
@@ -74,10 +74,10 @@ class PrecisionRecallCurve(BaseMetric):
             counted, not even at the lowest confidence threshold. The
             metric spends most of its time in NMS, whose cost grows with
             the number of candidates above the floor, so a floor of C{0}
-            keeps every decoded anchor (including the ones scoring zero)
-            and makes validation needlessly slow. The default of C{1e-3}
-            matches common detection validation practice. The effective
-            floor is the larger of this value and the lowest confidence
+            keeps every decoded anchor scoring above zero and makes
+            validation needlessly slow. The default of C{1e-3} matches
+            common detection validation practice. The effective floor is
+            the larger of this value and the lowest confidence
             threshold.
         @type nms_iou_threshold: float | None
         @param nms_iou_threshold: IoU used by NMS. Defaults to the
@@ -521,7 +521,9 @@ def _exclusive_threshold(value: float) -> float:
     C{non_max_suppression} keeps candidates scoring strictly above
     C{conf_thres}, while the curve counts use C{>=}. Returning the
     largest C{float32} below C{value} keeps candidates scoring exactly
-    C{value} in both.
+    C{value} in both. A floor of C{0} is the exception: C{conf_thres}
+    may not be negative, so candidates scoring exactly zero are always
+    dropped.
     """
     if value <= 0.0:
         return 0.0

--- a/luxonis_train/attached_modules/metrics/precision_recall_curve.py
+++ b/luxonis_train/attached_modules/metrics/precision_recall_curve.py
@@ -74,11 +74,11 @@ class PrecisionRecallCurve(BaseMetric):
             counted, not even at the lowest confidence threshold. The
             metric spends most of its time in NMS, whose cost grows with
             the number of candidates above the floor, so a floor of C{0}
-            - which keeps every decoded anchor, including the ones
-            scoring zero - makes validation needlessly slow. The default
-            of C{1e-3} matches common detection validation practice; the
-            effective floor is the larger of this value and the lowest
-            confidence threshold.
+            keeps every decoded anchor (including the ones scoring zero)
+            and makes validation needlessly slow. The default of C{1e-3}
+            matches common detection validation practice. The effective
+            floor is the larger of this value and the lowest confidence
+            threshold.
         @type nms_iou_threshold: float | None
         @param nms_iou_threshold: IoU used by NMS. Defaults to the
             attached detection head value.

--- a/luxonis_train/attached_modules/metrics/precision_recall_curve.py
+++ b/luxonis_train/attached_modules/metrics/precision_recall_curve.py
@@ -238,7 +238,10 @@ class PrecisionRecallCurve(BaseMetric):
         predictions = non_max_suppression(
             detections_pre_nms,
             n_classes=self.node.n_classes,
-            conf_thres=_exclusive_threshold(self.nms_conf_threshold),
+            conf_thres=_exclusive_threshold(
+                self.nms_conf_threshold,
+                detections_pre_nms.dtype,
+            ),
             iou_thres=self.nms_iou_threshold,
             bbox_format="xyxy",
             max_det=self.max_detections,
@@ -515,21 +518,20 @@ class PrecisionRecallCurve(BaseMetric):
         return figure
 
 
-def _exclusive_threshold(value: float) -> float:
+def _exclusive_threshold(value: float, dtype: torch.dtype) -> float:
     """Convert an inclusive confidence floor to an exclusive one.
 
     C{non_max_suppression} keeps candidates scoring strictly above
-    C{conf_thres}, while the curve counts use C{>=}. Returning the
-    largest C{float32} below C{value} keeps candidates scoring exactly
-    C{value} in both. A floor of C{0} is the exception: C{conf_thres}
-    may not be negative, so candidates scoring exactly zero are always
-    dropped.
+    C{conf_thres}, while the curve counts use C{>=}. Compute the
+    predecessor in the prediction dtype before returning it as a float,
+    so it does not round back to C{value}. A floor of C{0} cannot
+    include zero-scoring predictions.
     """
     if value <= 0.0:
         return 0.0
     return float(
         torch.nextafter(
-            torch.tensor(value, dtype=torch.float32),
-            torch.tensor(float("-inf"), dtype=torch.float32),
+            torch.tensor(value, dtype=dtype),
+            torch.tensor(float("-inf"), dtype=dtype),
         )
     )

--- a/luxonis_train/attached_modules/metrics/precision_recall_curve.py
+++ b/luxonis_train/attached_modules/metrics/precision_recall_curve.py
@@ -1,19 +1,36 @@
-from typing import cast
+from typing import TYPE_CHECKING
 
 import torch
 from torch import Tensor
 from torchvision.ops import box_convert, box_iou
 
+from luxonis_train.nodes.heads.base_detection_head import BaseDetectionHead
 from luxonis_train.tasks import Tasks
 from luxonis_train.utils import non_max_suppression
 
 from .base_metric import BaseMetric
 
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+
+DEFAULT_NUM_THRESHOLDS = 101
+DEFAULT_MIN_CONFIDENCE = 0.0
+DEFAULT_MAX_CONFIDENCE = 1.0
+
+ARTIFACT_WIDTH = 1200
+ARTIFACT_HEIGHT = 400
+
 
 class PrecisionRecallCurve(BaseMetric):
     """Compute global detection curves over a fixed confidence grid."""
 
-    supported_tasks = [Tasks.BOUNDINGBOX]
+    supported_tasks = [
+        Tasks.BOUNDINGBOX,
+        Tasks.INSTANCE_KEYPOINTS,
+        Tasks.INSTANCE_SEGMENTATION,
+    ]
+
+    node: BaseDetectionHead
     thresholds: Tensor
     true_positives: Tensor
     false_positives: Tensor
@@ -23,10 +40,11 @@ class PrecisionRecallCurve(BaseMetric):
         self,
         *,
         confidence_thresholds: list[float] | None = None,
-        num_thresholds: int = 101,
-        min_confidence: float = 0.0,
-        max_confidence: float = 1.0,
+        num_thresholds: int | None = None,
+        min_confidence: float | None = None,
+        max_confidence: float | None = None,
         matching_iou_threshold: float = 0.5,
+        nms_conf_threshold: float = 1e-3,
         nms_iou_threshold: float | None = None,
         max_detections: int | None = None,
         **kwargs,
@@ -34,17 +52,33 @@ class PrecisionRecallCurve(BaseMetric):
         """Initialize the detection curve metric.
 
         @type confidence_thresholds: list[float] | None
-        @param confidence_thresholds: Explicit confidence grid. When
-            omitted, a linearly spaced grid is created.
-        @type num_thresholds: int
+        @param confidence_thresholds: Explicit confidence grid. Mutually
+            exclusive with C{num_thresholds}, C{min_confidence} and
+            C{max_confidence}. When omitted, a linearly spaced grid is
+            created from those three parameters.
+        @type num_thresholds: int | None
         @param num_thresholds: Number of points in the generated grid.
-        @type min_confidence: float
+            Defaults to C{101}.
+        @type min_confidence: float | None
         @param min_confidence: Minimum generated confidence threshold.
-        @type max_confidence: float
+            Defaults to C{0.0}.
+        @type max_confidence: float | None
         @param max_confidence: Maximum generated confidence threshold.
+            Defaults to C{1.0}.
         @type matching_iou_threshold: float
         @param matching_iou_threshold: IoU required for a prediction to
             match a ground-truth box.
+        @type nms_conf_threshold: float
+        @param nms_conf_threshold: Confidence floor applied before NMS.
+            Candidates scoring below it are discarded and therefore never
+            counted, not even at the lowest confidence threshold. The
+            metric spends most of its time in NMS, whose cost grows with
+            the number of candidates above the floor, so a floor of C{0}
+            - which keeps every decoded anchor, including the ones
+            scoring zero - makes validation needlessly slow. The default
+            of C{1e-3} matches common detection validation practice; the
+            effective floor is the larger of this value and the lowest
+            confidence threshold.
         @type nms_iou_threshold: float | None
         @param nms_iou_threshold: IoU used by NMS. Defaults to the
             attached detection head value.
@@ -70,7 +104,13 @@ class PrecisionRecallCurve(BaseMetric):
             nms_iou_threshold
         )
         self.max_detections = self._resolve_max_detections(max_detections)
-        self.min_confidence = float(thresholds[0])
+        self.lowest_threshold = float(thresholds[0])
+        self.nms_conf_threshold = max(
+            self._validate_unit_interval(
+                nms_conf_threshold, "nms_conf_threshold"
+            ),
+            self.lowest_threshold,
+        )
 
         self.add_state(
             "true_positives",
@@ -88,6 +128,10 @@ class PrecisionRecallCurve(BaseMetric):
             dist_reduce_fx="sum",
         )
 
+        # The pre-NMS candidates are large; heads only keep them in
+        # their output packet when a module such as this one asks for it.
+        self.node.request_detections_pre_nms()
+
     @staticmethod
     def _validate_unit_interval(value: float, name: str) -> float:
         value = float(value)
@@ -100,11 +144,28 @@ class PrecisionRecallCurve(BaseMetric):
         cls,
         *,
         confidence_thresholds: list[float] | None,
-        num_thresholds: int,
-        min_confidence: float,
-        max_confidence: float,
+        num_thresholds: int | None,
+        min_confidence: float | None,
+        max_confidence: float | None,
     ) -> Tensor:
+        grid_parameters = {
+            "num_thresholds": num_thresholds,
+            "min_confidence": min_confidence,
+            "max_confidence": max_confidence,
+        }
         if confidence_thresholds is not None:
+            provided = sorted(
+                name
+                for name, value in grid_parameters.items()
+                if value is not None
+            )
+            if provided:
+                raise ValueError(
+                    "confidence_thresholds must not be combined with "
+                    f"{', '.join(provided)}; the explicit grid would "
+                    "silently take precedence."
+                )
+
             thresholds = torch.tensor(
                 confidence_thresholds,
                 dtype=torch.float32,
@@ -122,6 +183,13 @@ class PrecisionRecallCurve(BaseMetric):
                     "confidence_thresholds must be strictly increasing."
                 )
             return thresholds
+
+        if num_thresholds is None:
+            num_thresholds = DEFAULT_NUM_THRESHOLDS
+        if min_confidence is None:
+            min_confidence = DEFAULT_MIN_CONFIDENCE
+        if max_confidence is None:
+            max_confidence = DEFAULT_MAX_CONFIDENCE
 
         if num_thresholds < 2:
             raise ValueError("num_thresholds must be at least 2.")
@@ -148,12 +216,12 @@ class PrecisionRecallCurve(BaseMetric):
 
     def _resolve_nms_iou_threshold(self, value: float | None) -> float:
         if value is None:
-            value = cast(float, self.node.iou_thres)
+            value = self.node.iou_thres
         return self._validate_unit_interval(value, "nms_iou_threshold")
 
     def _resolve_max_detections(self, value: int | None) -> int:
         if value is None:
-            value = cast(int, self.node.max_det)
+            value = self.node.max_det
         if value <= 0:
             raise ValueError("max_detections must be positive.")
         return int(value)
@@ -164,11 +232,13 @@ class PrecisionRecallCurve(BaseMetric):
         target_boundingbox: Tensor,
     ) -> None:
         """Update curve counts from one batch of decoded candidates."""
+        self._detach_inference_states()
+
         target_boundingbox = target_boundingbox.to(detections_pre_nms.device)
         predictions = non_max_suppression(
             detections_pre_nms,
             n_classes=self.node.n_classes,
-            conf_thres=self.min_confidence,
+            conf_thres=_exclusive_threshold(self.nms_conf_threshold),
             iou_thres=self.nms_iou_threshold,
             bbox_format="xyxy",
             max_det=self.max_detections,
@@ -186,6 +256,22 @@ class PrecisionRecallCurve(BaseMetric):
             dim=1
         )
         self.target_count += target_boundingbox.shape[0]
+
+    def _detach_inference_states(self) -> None:
+        """Replace inference-mode states with regular tensors.
+
+        C{reset} runs inside the evaluation loop, which Lightning
+        executes under C{torch.inference_mode}, so the fresh states
+        become inference tensors. In-place updates to those raise a
+        C{RuntimeError} once the metric is updated outside inference
+        mode again, as the quantization evaluation trainer does.
+        """
+        if self.true_positives.is_inference():
+            self.true_positives = self.true_positives.clone()
+        if self.false_positives.is_inference():
+            self.false_positives = self.false_positives.clone()
+        if self.target_count.is_inference():
+            self.target_count = self.target_count.clone()
 
     def _match_predictions(
         self,
@@ -217,41 +303,15 @@ class PrecisionRecallCurve(BaseMetric):
             )
             image_predictions = image_predictions[order]
 
-            scores = image_predictions[:, 4]
-            prediction_boxes = image_predictions[:, :4]
-            prediction_classes = image_predictions[:, 5].long()
-            true_positive = torch.zeros(
-                len(image_predictions),
-                dtype=torch.bool,
-                device=image_predictions.device,
+            all_scores.append(image_predictions[:, 4])
+            all_true_positive.append(
+                self._match_image_predictions(
+                    prediction_boxes=image_predictions[:, :4],
+                    prediction_classes=image_predictions[:, 5].long(),
+                    target_boxes=target_boxes,
+                    target_classes=target_classes,
+                )
             )
-            matched_targets = torch.zeros(
-                len(target_boxes),
-                dtype=torch.bool,
-                device=image_predictions.device,
-            )
-
-            for prediction_index in range(len(image_predictions)):
-                candidate_indices = torch.where(
-                    (target_classes == prediction_classes[prediction_index])
-                    & ~matched_targets
-                )[0]
-                if candidate_indices.numel() == 0:
-                    continue
-
-                ious = box_iou(
-                    prediction_boxes[prediction_index].unsqueeze(0),
-                    target_boxes[candidate_indices],
-                ).squeeze(0)
-                best_iou, best_local_index = torch.max(ious, dim=0)
-
-                if best_iou >= self.matching_iou_threshold:
-                    target_index = candidate_indices[best_local_index]
-                    matched_targets[target_index] = True
-                    true_positive[prediction_index] = True
-
-            all_scores.append(scores)
-            all_true_positive.append(true_positive)
 
         if not all_scores:
             return (
@@ -267,6 +327,55 @@ class PrecisionRecallCurve(BaseMetric):
         true_positive = torch.cat(all_true_positive)
         order = torch.argsort(scores, descending=True, stable=True)
         return scores[order], true_positive[order]
+
+    def _match_image_predictions(
+        self,
+        *,
+        prediction_boxes: Tensor,
+        prediction_classes: Tensor,
+        target_boxes: Tensor,
+        target_classes: Tensor,
+    ) -> Tensor:
+        """Greedily assign score-sorted predictions to unique targets.
+
+        The IoU matrix is computed once per image and the remaining loop
+        only visits predictions that have at least one same-class target
+        above the IoU threshold, which is a small fraction of the
+        C{max_detections} predictions in practice.
+        """
+        true_positive = torch.zeros(
+            len(prediction_boxes),
+            dtype=torch.bool,
+            device=prediction_boxes.device,
+        )
+        if len(target_boxes) == 0 or len(prediction_boxes) == 0:
+            return true_positive
+
+        ious = box_iou(prediction_boxes, target_boxes)
+        eligible = (
+            prediction_classes.unsqueeze(1) == target_classes.unsqueeze(0)
+        ) & (ious >= self.matching_iou_threshold)
+        matched_targets = torch.zeros(
+            len(target_boxes),
+            dtype=torch.bool,
+            device=prediction_boxes.device,
+        )
+
+        candidates = eligible.any(dim=1).nonzero(as_tuple=True)[0]
+        for prediction_index in candidates.tolist():
+            available = eligible[prediction_index] & ~matched_targets
+            if not bool(available.any()):
+                continue
+
+            target_index = int(
+                torch.argmax(
+                    ious[prediction_index].masked_fill(~available, -1)
+                )
+            )
+            matched_targets[target_index] = True
+            true_positive[prediction_index] = True
+
+        return true_positive
 
     @staticmethod
     def _prepare_targets(
@@ -305,7 +414,10 @@ class PrecisionRecallCurve(BaseMetric):
         precision = torch.where(
             true_positives + false_positives > 0,
             true_positives / (true_positives + false_positives),
-            torch.zeros_like(true_positives),
+            # No prediction reaches the threshold, so nothing is
+            # predicted incorrectly. Reporting 0 instead would drag the
+            # curve to the floor over the whole high-confidence range.
+            torch.ones_like(true_positives),
         )
         recall = torch.where(
             self.target_count > 0,
@@ -349,20 +461,28 @@ class PrecisionRecallCurve(BaseMetric):
         """Render PR, precision-confidence, and recall-confidence
         curves.
         """
-        from matplotlib.figure import Figure
-
         from luxonis_train.attached_modules.visualizers.utils import (
             figure_to_torch,
         )
+
+        return {
+            "curves": figure_to_torch(
+                self.build_curve_figure(values),
+                width=ARTIFACT_WIDTH,
+                height=ARTIFACT_HEIGHT,
+            )
+        }
+
+    def build_curve_figure(self, values: dict[str, Tensor]) -> "Figure":
+        """Build the three-panel curve figure."""
+        from matplotlib.figure import Figure
 
         confidence = values["confidence"].detach().cpu().numpy()
         precision = values["precision"].detach().cpu().numpy()
         recall = values["recall"].detach().cpu().numpy()
 
-        artifact_width = 1200
-        artifact_height = 400
         figure = Figure(
-            figsize=(artifact_width / 100, artifact_height / 100),
+            figsize=(ARTIFACT_WIDTH / 100, ARTIFACT_HEIGHT / 100),
             layout="constrained",
         )
         axes = figure.subplots(1, 3)
@@ -371,6 +491,7 @@ class PrecisionRecallCurve(BaseMetric):
         axes[0].set_title("Precision-Recall")
         axes[0].set_xlabel("Recall")
         axes[0].set_ylabel("Precision")
+        axes[0].set_xlim(0, 1)
 
         axes[1].plot(confidence, precision)
         axes[1].set_title("Precision-Confidence")
@@ -382,15 +503,31 @@ class PrecisionRecallCurve(BaseMetric):
         axes[2].set_xlabel("Confidence")
         axes[2].set_ylabel("Recall")
 
+        # The confidence axes span the configured grid, which is not
+        # necessarily the whole unit interval.
+        for axis in axes[1:]:
+            axis.set_xlim(float(confidence[0]), float(confidence[-1]))
+
         for axis in axes:
-            axis.set_xlim(0, 1)
             axis.set_ylim(0, 1)
             axis.grid()
 
-        return {
-            "curves": figure_to_torch(
-                figure,
-                width=artifact_width,
-                height=artifact_height,
-            )
-        }
+        return figure
+
+
+def _exclusive_threshold(value: float) -> float:
+    """Convert an inclusive confidence floor to an exclusive one.
+
+    C{non_max_suppression} keeps candidates scoring strictly above
+    C{conf_thres}, while the curve counts use C{>=}. Returning the
+    largest C{float32} below C{value} keeps candidates scoring exactly
+    C{value} in both.
+    """
+    if value <= 0.0:
+        return 0.0
+    return float(
+        torch.nextafter(
+            torch.tensor(value, dtype=torch.float32),
+            torch.tensor(float("-inf"), dtype=torch.float32),
+        )
+    )

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -45,7 +45,10 @@ from .utils import (
     compute_visualization_buffer,
     get_model_execution_order,
     log_balanced_class_images,
+    log_metric_artifacts,
     log_sequential_images,
+    metric_artifact_image_name,
+    mlflow_image_key,
     postprocess_metrics,
 )
 
@@ -842,6 +845,19 @@ class LuxonisLightningModule(pl.LightningModule):
                     metric.get_loggable_values(computed),
                     log_sub_metrics=self.cfg.trainer.log_sub_metrics,
                 )
+                if (
+                    self.trainer.is_global_zero
+                    and not self.trainer.sanity_checking
+                ):
+                    log_metric_artifacts(
+                        self.tracker,
+                        metric,
+                        computed,
+                        mode=mode,
+                        formatted_node_name=formatted_node_name,
+                        metric_name=metric_name,
+                        current_epoch=self.current_epoch,
+                    )
                 metric.reset()
                 if isinstance(
                     self.trainer.strategy,
@@ -878,46 +894,6 @@ class LuxonisLightningModule(pl.LightningModule):
                             sync_dist=True,
                         )
 
-                if self.trainer.is_global_zero:
-                    try:
-                        artifacts = metric.get_artifacts(computed)
-                    except Exception:
-                        logger.exception(
-                            "Failed to generate artifacts for metric "
-                            f"'{metric_name}'. Skipping artifact logging."
-                        )
-                        artifacts = {}
-
-                    for artifact_name, artifact in artifacts.items():
-                        if artifact.dim() != 3:
-                            logger.warning(
-                                "Skipping metric artifact "
-                                f"'{artifact_name}' from metric "
-                                f"'{metric_name}': expected shape "
-                                f"[C, H, W], got {tuple(artifact.shape)}."
-                            )
-                            continue
-
-                        try:
-                            image = (
-                                artifact.detach()
-                                .cpu()
-                                .numpy()
-                                .transpose(1, 2, 0)
-                            )
-                            self.tracker.log_image(
-                                name=f"{mode}/metrics/{self.current_epoch}/"
-                                f"{formatted_node_name}/{metric_name}/"
-                                f"{artifact_name}",
-                                img=image,
-                                step=self.current_epoch,
-                            )
-                        except Exception:
-                            logger.exception(
-                                "Failed to log metric artifact "
-                                f"'{artifact_name}' from metric "
-                                f"'{metric_name}'. Skipping artifact logging."
-                            )
         self._print_results(
             stage="Validation" if mode == "val" else "Test",
             loss=self._loss_accumulators[mode]["loss"],
@@ -1035,14 +1011,26 @@ class LuxonisLightningModule(pl.LightningModule):
                 for artifact_name in metric.get_artifact_names():
                     for epoch_idx in sorted({0, *val_eval_epochs}):
                         artifact_keys.add(
-                            f"val/metrics/{epoch_idx}/"
-                            f"{formatted_node_name}/{metric_name}/"
-                            f"{artifact_name}.png"
+                            mlflow_image_key(
+                                metric_artifact_image_name(
+                                    "val",
+                                    formatted_node_name,
+                                    metric_name,
+                                    artifact_name,
+                                ),
+                                epoch_idx,
+                            )
                         )
                     artifact_keys.add(
-                        f"test/metrics/{test_eval_epoch}/"
-                        f"{formatted_node_name}/{metric_name}/"
-                        f"{artifact_name}.png"
+                        mlflow_image_key(
+                            metric_artifact_image_name(
+                                "test",
+                                formatted_node_name,
+                                metric_name,
+                                artifact_name,
+                            ),
+                            test_eval_epoch,
+                        )
                     )
 
             for viz_name in node.visualizers:

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -563,6 +563,99 @@ def postprocess_metrics(
             )
 
 
+def metric_artifact_image_name(
+    mode: Literal["test", "val"],
+    formatted_node_name: str,
+    metric_name: str,
+    artifact_name: str,
+) -> str:
+    """Build the tracker image name for a metric artifact.
+
+    The epoch is deliberately not part of the name - C{log_image}
+    inserts the step as its own path segment, the same way visualization
+    images are named.
+    """
+    return (
+        f"{mode}/metrics/{formatted_node_name}/{metric_name}/{artifact_name}"
+    )
+
+
+def mlflow_image_key(name: str, step: int) -> str:
+    """Return the MLflow artifact path an image is logged under.
+
+    Mirrors the path construction of C{LuxonisTracker.log_image}, which
+    splits the caption off the name and puts the step in between.
+    """
+    base_path, caption = name.rsplit("/", 1)
+    return f"{base_path}/{step}/{caption}.png"
+
+
+def log_metric_artifacts(
+    tracker: LuxonisTrackerPL,
+    metric: BaseMetric,
+    computed: Any,
+    *,
+    mode: Literal["test", "val"],
+    formatted_node_name: str,
+    metric_name: str,
+    current_epoch: int,
+) -> None:
+    """Render and log the image artifacts of a single metric.
+
+    Must be called before the metric is reset, as artifacts may be
+    derived from the metric's state. Every failure is reported and
+    swallowed - a metric that cannot produce or upload a figure must not
+    bring down the run.
+    """
+    try:
+        artifacts = metric.get_artifacts(computed)
+    except Exception:
+        logger.exception(
+            "Failed to generate artifacts for metric "
+            f"'{metric_name}'. Skipping artifact logging."
+        )
+        return
+
+    if not isinstance(artifacts, dict):
+        logger.warning(
+            f"Metric '{metric_name}' returned artifacts of type "
+            f"'{type(artifacts).__name__}', expected a dict of "
+            "images. Skipping artifact logging."
+        )
+        return
+
+    for artifact_name, artifact in artifacts.items():
+        try:
+            if not isinstance(artifact, Tensor):
+                logger.warning(
+                    f"Skipping metric artifact '{artifact_name}' from "
+                    f"metric '{metric_name}': expected a tensor of shape "
+                    f"[C, H, W], got a '{type(artifact).__name__}'."
+                )
+                continue
+            if artifact.dim() != 3:
+                logger.warning(
+                    f"Skipping metric artifact '{artifact_name}' from "
+                    f"metric '{metric_name}': expected shape [C, H, W], "
+                    f"got {tuple(artifact.shape)}."
+                )
+                continue
+
+            tracker.log_image(
+                name=metric_artifact_image_name(
+                    mode, formatted_node_name, metric_name, artifact_name
+                ),
+                img=artifact.detach().cpu().numpy().transpose(1, 2, 0),
+                step=current_epoch,
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to log metric artifact '{artifact_name}' from "
+                f"metric '{metric_name}'. The artifact is dropped for "
+                f"epoch {current_epoch}."
+            )
+
+
 T = TypeVar("T", bound=BaseAttachedModule)
 
 

--- a/luxonis_train/nodes/heads/base_detection_head.py
+++ b/luxonis_train/nodes/heads/base_detection_head.py
@@ -40,6 +40,7 @@ class BaseDetectionHead(BaseHead):
         self.conf_thres = conf_thres
         self.iou_thres = iou_thres
         self.max_det = max_det
+        self._keep_detections_pre_nms = False
 
         if len(self.in_channels) < self.n_heads:
             logger.warning(
@@ -53,6 +54,24 @@ class BaseDetectionHead(BaseHead):
             self.attach_index = (-self.n_heads - 1, -1)
 
         self.stride = self.fit_stride_to_heads()
+
+    @property
+    def keep_detections_pre_nms(self) -> bool:
+        """Whether the pre-NMS candidates are part of the output packet.
+
+        @type: bool
+        """
+        return self._keep_detections_pre_nms
+
+    def request_detections_pre_nms(self) -> None:
+        """Ask the head to add the decoded pre-NMS candidates to its
+        output packet under the C{"detections_pre_nms"} key.
+
+        The candidate tensor is of shape C{[B, n_anchors, 5 +
+        n_classes]}, which is large enough to matter for peak memory, so
+        attached modules that need it have to opt in.
+        """
+        self._keep_detections_pre_nms = True
 
     def _forward(
         self, inputs: list[Tensor]

--- a/luxonis_train/nodes/heads/efficient_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_bbox_head.py
@@ -163,29 +163,6 @@ class EfficientBBoxHead(BaseDetectionHead):
             [f"output{i + 1}_yolov6r2" for i in range(self.n_heads)]
         )
 
-    def _postprocess_detections(
-        self,
-        features: list[Tensor],
-        class_scores: Tensor,
-        distributions: Tensor,
-        anchor_points: Tensor,
-        stride_tensor: Tensor,
-        *,
-        tail: list[Tensor] | None = None,
-    ) -> list[Tensor]:
-        """Perform post-processing of the output and returns bboxs after
-        NMS.
-        """
-        detections_pre_nms = self._prepare_bbox_inference_output(
-            features,
-            class_scores,
-            distributions,
-            anchor_points,
-            stride_tensor,
-            tail=tail,
-        )
-        return self._run_nms(detections_pre_nms)
-
     def _prepare_bbox_inference_output(
         self,
         features: list[Tensor],

--- a/luxonis_train/nodes/heads/efficient_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_bbox_head.py
@@ -123,13 +123,15 @@ class EfficientBBoxHead(BaseDetectionHead):
             stride_tensor,
         )
         bboxes = self._run_nms(detections_pre_nms)
-        return {
+        packet: Packet[Tensor] = {
             self.task.main_output: bboxes,
             "features": features_list,
             "class_scores": class_scores,
             "distributions": distributions,
-            "detections_pre_nms": detections_pre_nms,
         }
+        if self.keep_detections_pre_nms:
+            packet["detections_pre_nms"] = detections_pre_nms
+        return packet
 
     @staticmethod
     def _wrap_export(

--- a/luxonis_train/nodes/heads/efficient_keypoint_bbox_head.py
+++ b/luxonis_train/nodes/heads/efficient_keypoint_bbox_head.py
@@ -141,15 +141,18 @@ class EfficientKeypointBBoxHead(EfficientBBoxHead):
             self.grid_cell_offset,
             multiply_with_stride=False,
         )
-        boxes, kpts = self._postprocess_keypoint_detections(
+        detections_pre_nms = self._prepare_bbox_inference_output(
             features_list,
             class_scores,
             distributions,
-            pred_keypoints,
             anchor_points,
             stride_tensor,
+            tail=[pred_keypoints],
         )
-        return {
+        boxes, kpts = self._split_keypoint_detections(
+            self._run_nms(detections_pre_nms)
+        )
+        packet: Packet[Tensor] = {
             "boundingbox": boxes,
             "keypoints": kpts,
             "features": features_list,
@@ -157,6 +160,9 @@ class EfficientKeypointBBoxHead(EfficientBBoxHead):
             "distributions": distributions,
             "keypoints_raw": keypoints_raw,
         }
+        if self.keep_detections_pre_nms:
+            packet["detections_pre_nms"] = detections_pre_nms
+        return packet
 
     @property
     @override
@@ -202,27 +208,10 @@ class EfficientKeypointBBoxHead(EfficientBBoxHead):
             batch_size, self.n_keypoints_flat, -1
         )
 
-    def _postprocess_keypoint_detections(
-        self,
-        features: list[Tensor],
-        class_scores: Tensor,
-        distributions: Tensor,
-        pred_keypoints: Tensor,
-        anchor_points: Tensor,
-        stride_tensor: Tensor,
+    def _split_keypoint_detections(
+        self, detections: list[Tensor]
     ) -> tuple[list[Tensor], list[Tensor]]:
-        """Perform post-processing of the output and returns bboxs after
-        NMS.
-        """
-        detections = super()._postprocess_detections(
-            features,
-            class_scores,
-            distributions,
-            anchor_points,
-            stride_tensor,
-            tail=[pred_keypoints],
-        )
-
+        """Split post-NMS detections into bboxes and keypoints."""
         bboxes = [detection[:, :6] for detection in detections]
         keypoints = [
             detection[:, 6:].reshape(-1, self.n_keypoints, 3)

--- a/luxonis_train/nodes/heads/precision_bbox_head.py
+++ b/luxonis_train/nodes/heads/precision_bbox_head.py
@@ -120,11 +120,13 @@ class PrecisionBBoxHead(BaseDetectionHead):
             predicts_objectness=False,
         )
 
-        return {
+        packet: Packet[Tensor] = {
             "features": features_list,
             "boundingbox": boxes,
-            "detections_pre_nms": detections_pre_nms,
         }
+        if self.keep_detections_pre_nms:
+            packet["detections_pre_nms"] = detections_pre_nms
+        return packet
 
     @override
     def initialize_weights(self, method: str | None = None) -> None:

--- a/luxonis_train/nodes/heads/precision_seg_bbox_head.py
+++ b/luxonis_train/nodes/heads/precision_seg_bbox_head.py
@@ -145,6 +145,8 @@ class PrecisionSegmentBBoxHead(PrecisionBBoxHead):
             "boundingbox": [],
             self.task.main_output: [],
         }
+        if self.keep_detections_pre_nms:
+            results["detections_pre_nms"] = preds_combined
 
         for i, pred in enumerate(preds):
             height, width = self.original_in_shape[-2:]

--- a/tests/unittests/test_metrics/test_precision_recall_curve.py
+++ b/tests/unittests/test_metrics/test_precision_recall_curve.py
@@ -9,6 +9,9 @@ import torch
 from torch import Size, Tensor
 
 from luxonis_train.attached_modules.metrics import PrecisionRecallCurve
+from luxonis_train.attached_modules.metrics.precision_recall_curve import (
+    _exclusive_threshold,
+)
 from luxonis_train.lightning.luxonis_lightning import LuxonisLightningModule
 from luxonis_train.lightning.utils import (
     log_metric_artifacts,
@@ -405,6 +408,19 @@ def test_prediction_at_lowest_threshold_is_counted() -> None:
 
     torch.testing.assert_close(metric.true_positives, torch.tensor([1, 0, 0]))
     assert float(metric.compute()["recall"][0]) == 1.0
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_exclusive_threshold_preserves_floor_in_low_precision(
+    dtype: torch.dtype,
+) -> None:
+    """The NMS threshold predecessor must use the prediction dtype.
+
+    A float32 predecessor can round back to 0.5 in low precision.
+    """
+    score = torch.tensor(0.5, dtype=dtype)
+
+    assert score > _exclusive_threshold(0.5, dtype)
 
 
 def test_greedy_matching_is_class_aware_and_uses_each_target_once() -> None:

--- a/tests/unittests/test_metrics/test_precision_recall_curve.py
+++ b/tests/unittests/test_metrics/test_precision_recall_curve.py
@@ -3,34 +3,69 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, cast
 
+import numpy as np
 import pytest
 import torch
 from torch import Size, Tensor
 
 from luxonis_train.attached_modules.metrics import PrecisionRecallCurve
 from luxonis_train.lightning.luxonis_lightning import LuxonisLightningModule
+from luxonis_train.lightning.utils import (
+    log_metric_artifacts,
+    metric_artifact_image_name,
+    mlflow_image_key,
+)
 from luxonis_train.nodes import BaseNode
+from luxonis_train.nodes.heads.base_detection_head import BaseDetectionHead
 from luxonis_train.nodes.heads.efficient_bbox_head import EfficientBBoxHead
+from luxonis_train.nodes.heads.efficient_keypoint_bbox_head import (
+    EfficientKeypointBBoxHead,
+)
 from luxonis_train.nodes.heads.precision_bbox_head import PrecisionBBoxHead
+from luxonis_train.nodes.heads.precision_seg_bbox_head import (
+    PrecisionSegmentBBoxHead,
+)
 from luxonis_train.tasks import Tasks
 from luxonis_train.typing import Packet
-from luxonis_train.utils import non_max_suppression
+from luxonis_train.utils import IncompatibleError, non_max_suppression
 from luxonis_train.utils.dataset_metadata import DatasetMetadata
 
+_FEATURE_SHAPES = (
+    Size([1, 16, 8, 8]),
+    Size([1, 32, 4, 4]),
+    Size([1, 64, 2, 2]),
+)
 
-class DummyBBoxNode(BaseNode, register=False):
+
+class DummyBBoxHead(BaseDetectionHead, register=False):
+    """Detection head that only provides the NMS parameters the metric
+    reads off its node.
+    """
+
     task = Tasks.BOUNDINGBOX
-    iou_thres = 0.45
-    max_det = 300
 
-    def forward(self, _: Tensor) -> Tensor:
+    def forward(self, inputs: list[Tensor]) -> Packet[Tensor]:
         raise NotImplementedError
 
 
-def make_node() -> DummyBBoxNode:
-    return DummyBBoxNode(
+class DummyBBoxNode(BaseNode, register=False):
+    """Bounding box node that is not a detection head."""
+
+    task = Tasks.BOUNDINGBOX
+
+    def forward(self, inputs: list[Tensor]) -> Packet[Tensor]:
+        raise NotImplementedError
+
+
+def make_node() -> DummyBBoxHead:
+    return DummyBBoxHead(
+        n_heads=3,
+        conf_thres=0.25,
+        iou_thres=0.45,
+        max_det=300,
         n_classes=2,
         original_in_shape=Size([3, 100, 100]),
+        in_sizes=list(_FEATURE_SHAPES),
         dataset_metadata=DatasetMetadata(
             classes={"": {"class0": 0, "class1": 1}}
         ),
@@ -40,6 +75,7 @@ def make_node() -> DummyBBoxNode:
 def make_metric(
     *,
     thresholds: list[float] | None = None,
+    **kwargs: Any,
 ) -> PrecisionRecallCurve:
     return PrecisionRecallCurve(
         node=make_node(),
@@ -47,6 +83,7 @@ def make_metric(
         matching_iou_threshold=0.5,
         nms_iou_threshold=0.45,
         max_detections=300,
+        **kwargs,
     )
 
 
@@ -76,6 +113,26 @@ def test_precision_recall_curve_uses_node_nms_defaults() -> None:
     assert metric.max_detections == 300
 
 
+def test_precision_recall_curve_rejects_non_detection_head() -> None:
+    """The metric reads C{iou_thres}/C{max_det} off its node, which only
+    detection heads define.
+
+    Without the C{node} annotation this failed with a bare
+    C{AttributeError} from C{nn.Module.__getattr__} instead of the
+    framework's actionable error.
+    """
+    node = DummyBBoxNode(
+        n_classes=2,
+        original_in_shape=Size([3, 100, 100]),
+        dataset_metadata=DatasetMetadata(
+            classes={"": {"class0": 0, "class1": 1}}
+        ),
+    )
+
+    with pytest.raises(IncompatibleError, match="BaseDetectionHead"):
+        PrecisionRecallCurve(node=node, confidence_thresholds=[0.0, 0.5, 1.0])
+
+
 def test_precision_recall_curve_values() -> None:
     metric = make_metric()
     predictions = make_pre_nms(
@@ -99,7 +156,7 @@ def test_precision_recall_curve_values() -> None:
     )
     torch.testing.assert_close(
         result["precision"],
-        torch.tensor([1 / 3, 1 / 2, 1.0, 0.0]),
+        torch.tensor([1 / 3, 1 / 2, 1.0, 1.0]),
     )
     torch.testing.assert_close(
         result["recall"],
@@ -109,6 +166,31 @@ def test_precision_recall_curve_values() -> None:
         result["f1"],
         torch.tensor([0.5, 2 / 3, 1.0, 0.0]),
     )
+
+
+def test_precision_is_one_where_nothing_is_predicted() -> None:
+    """Precision is undefined without predictions and is reported as
+    C{1}, the value the Precision-Confidence curve converges to.
+
+    Reporting C{0} instead dragged the curve to the floor over the whole
+    confidence range above the highest prediction score, and added a
+    spurious C{(0, 0)} endpoint to the PR curve.
+    """
+    metric = make_metric(thresholds=[0.0, 0.5, 0.95])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor([[0, 0, 0.1, 0.1, 0.2, 0.2]], dtype=torch.float32),
+    )
+
+    result = metric.compute()
+
+    assert int(metric.true_positives[-1]) == 0
+    assert int(metric.false_positives[-1]) == 0
+    assert float(result["precision"][-1]) == 1.0
+    assert float(result["recall"][-1]) == 0.0
+    # A precision of 1 at zero recall must not win the F1 argmax.
+    assert float(result["f1"][-1]) == 0.0
+    assert float(result["confidence_at_max_f1"]) == 0.0
 
 
 def test_precision_recall_curve_accumulates_and_resets() -> None:
@@ -143,6 +225,35 @@ def test_precision_recall_curve_accumulates_and_resets() -> None:
         torch.zeros(3, dtype=torch.long),
     )
     assert int(metric.target_count) == 0
+
+
+def test_update_after_reset_inside_inference_mode() -> None:
+    """States reset inside C{torch.inference_mode} must still be
+    updatable outside of it.
+
+    The evaluation loop resets the metric under C{torch.inference_mode},
+    which turns the default states into inference tensors. The
+    quantization evaluation trainer then runs with
+    C{inference_mode=False}, and the in-place accumulation used to fail
+    with C{RuntimeError: Inplace update to inference tensor outside
+    InferenceMode is not allowed}.
+    """
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    predictions = make_pre_nms([(10, 10, 30, 30, 0.9, 0)])
+    targets = torch.tensor(
+        [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+        dtype=torch.float32,
+    )
+
+    with torch.inference_mode():
+        metric.reset()
+
+    assert metric.true_positives.is_inference()
+
+    metric.update(predictions, targets)
+
+    torch.testing.assert_close(metric.true_positives, torch.tensor([1, 1, 0]))
+    assert int(metric.target_count) == 1
 
 
 @pytest.mark.parametrize(
@@ -207,20 +318,26 @@ def test_precision_recall_curve_run_update_routing() -> None:
     assert int(metric.target_count) == 1
 
 
+def _record_nms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    import luxonis_train.attached_modules.metrics.precision_recall_curve as module
+
+    calls: list[dict[str, Any]] = []
+    original = module.non_max_suppression
+
+    def recorded_nms(*args, **kwargs) -> list[Tensor]:
+        calls.append(kwargs)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module, "non_max_suppression", recorded_nms)
+    return calls
+
+
 def test_precision_recall_curve_runs_nms_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import luxonis_train.attached_modules.metrics.precision_recall_curve as module
-
-    calls = 0
-    original = module.non_max_suppression
-
-    def counted_nms(*args, **kwargs) -> list[Tensor]:
-        nonlocal calls
-        calls += 1
-        return original(*args, **kwargs)
-
-    monkeypatch.setattr(module, "non_max_suppression", counted_nms)
+    calls = _record_nms(monkeypatch)
 
     metric = make_metric()
     metric.update(
@@ -231,7 +348,93 @@ def test_precision_recall_curve_runs_nms_once(
         ),
     )
 
-    assert calls == 1
+    assert len(calls) == 1
+
+
+def test_nms_confidence_floor_is_positive_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NMS must not be re-run with a zero confidence threshold.
+
+    The default grid starts at C{0.0}, and passing that straight to
+    C{non_max_suppression} keeps every decoded anchor as an NMS
+    candidate, which is orders of magnitude slower than the head's own
+    post-processing. The floor is a separate parameter that defaults to
+    C{1e-3}.
+    """
+    calls = _record_nms(monkeypatch)
+
+    metric = PrecisionRecallCurve(node=make_node(), num_thresholds=11)
+    assert metric.lowest_threshold == 0.0
+    assert metric.nms_conf_threshold == pytest.approx(1e-3)
+
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
+        torch.tensor(
+            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
+            dtype=torch.float32,
+        ),
+    )
+
+    assert calls[0]["conf_thres"] == pytest.approx(1e-3)
+    assert calls[0]["conf_thres"] < 1e-3
+
+
+def test_nms_confidence_floor_follows_lowest_threshold() -> None:
+    metric = make_metric(thresholds=[0.4, 0.6, 0.8])
+
+    assert metric.nms_conf_threshold == pytest.approx(0.4)
+
+
+def test_prediction_at_lowest_threshold_is_counted() -> None:
+    """A prediction scoring exactly the lowest threshold belongs to the
+    first curve point.
+
+    The curve counts are computed with C{>=} while
+    C{non_max_suppression} filters with a strict C{>}, so a prediction
+    scoring exactly the confidence floor used to be dropped before it
+    could be counted.
+    """
+    metric = make_metric(thresholds=[0.5, 0.75, 0.9], nms_conf_threshold=0.5)
+    assert metric.nms_conf_threshold == 0.5
+
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.5, 0)]),
+        torch.tensor([[0, 0, 0.1, 0.1, 0.2, 0.2]], dtype=torch.float32),
+    )
+
+    torch.testing.assert_close(metric.true_positives, torch.tensor([1, 0, 0]))
+    assert float(metric.compute()["recall"][0]) == 1.0
+
+
+def test_greedy_matching_is_class_aware_and_uses_each_target_once() -> None:
+    """Matching is greedy by score, per class, and every target may only
+    be claimed once.
+    """
+    metric = make_metric(thresholds=[0.0, 0.65, 1.0])
+    predictions = make_pre_nms(
+        [
+            (0, 0, 20, 10, 0.9, 0),
+            (0, 10, 20, 20, 0.7, 0),
+            (50, 50, 70, 70, 0.6, 1),
+            (0, 0, 20, 20, 0.5, 1),
+        ]
+    )
+    targets = torch.tensor(
+        [
+            [0, 0, 0.0, 0.0, 0.2, 0.2],
+            [0, 1, 0.5, 0.5, 0.2, 0.2],
+        ],
+        dtype=torch.float32,
+    )
+
+    metric.update(predictions, targets)
+
+    # The 0.7 prediction overlaps the same target as the 0.9 one, and the
+    # 0.5 prediction has the right class but no overlapping target.
+    torch.testing.assert_close(metric.true_positives, torch.tensor([2, 1, 0]))
+    torch.testing.assert_close(metric.false_positives, torch.tensor([2, 1, 0]))
+    assert int(metric.target_count) == 2
 
 
 @pytest.mark.parametrize(
@@ -244,6 +447,7 @@ def test_precision_recall_curve_runs_nms_once(
         {"min_confidence": 0.8, "max_confidence": 0.2},
         {"matching_iou_threshold": 1.1},
         {"nms_iou_threshold": -0.1},
+        {"nms_conf_threshold": 1.5},
         {"max_detections": 0},
     ],
 )
@@ -259,6 +463,56 @@ def test_precision_recall_curve_rejects_invalid_configuration(
 
     with pytest.raises(ValueError, match="must"):
         PrecisionRecallCurve(**params)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"num_thresholds": 11},
+        {"min_confidence": 0.5},
+        {"max_confidence": 0.9},
+        {"num_thresholds": 11, "min_confidence": 0.5},
+    ],
+)
+def test_explicit_grid_rejects_generated_grid_parameters(
+    kwargs: dict[str, Any],
+) -> None:
+    """An explicit grid combined with the generated-grid parameters is a
+    configuration error.
+
+    The explicit grid used to silently win, so a config carrying both
+    produced a curve that ignored C{num_thresholds},
+    C{min_confidence} and C{max_confidence} without any warning - and
+    skipped their validation altogether.
+    """
+    with pytest.raises(ValueError, match="must not be combined"):
+        PrecisionRecallCurve(
+            node=make_node(),
+            confidence_thresholds=[0.0, 0.5, 1.0],
+            **kwargs,
+        )
+
+
+def test_confidence_axes_span_the_configured_grid() -> None:
+    """The confidence axes must follow the threshold grid.
+
+    Hardcoding C{xlim=(0, 1)} squeezed the whole curve into a sliver of
+    the panel for a grid that only covers the high-confidence region.
+    """
+    metric = make_metric(thresholds=[0.9, 0.95, 1.0])
+    metric.update(
+        make_pre_nms([(10, 10, 30, 30, 0.95, 0)]),
+        torch.tensor([[0, 0, 0.1, 0.1, 0.2, 0.2]], dtype=torch.float32),
+    )
+
+    figure = metric.build_curve_figure(metric.compute())
+    precision_recall, precision_conf, recall_conf = figure.axes
+
+    assert precision_recall.get_xlim() == (0, 1)
+    assert precision_conf.get_xlim() == pytest.approx((0.9, 1.0))
+    assert recall_conf.get_xlim() == pytest.approx((0.9, 1.0))
+    for axis in figure.axes:
+        assert axis.get_ylim() == (0, 1)
 
 
 class DummyNodes(dict[str, object]):
@@ -288,6 +542,7 @@ def make_epoch_end_harness(
     *,
     is_global_zero: bool,
     log_sub_metrics: bool = True,
+    sanity_checking: bool = False,
 ) -> SimpleNamespace:
     tracker = DummyTracker()
     logged: list[tuple[str, Tensor, bool]] = []
@@ -323,6 +578,7 @@ def make_epoch_end_harness(
         trainer=SimpleNamespace(
             strategy=object(),
             is_global_zero=is_global_zero,
+            sanity_checking=sanity_checking,
         ),
         device=torch.device("cpu"),
         progress_bar=SimpleNamespace(),
@@ -338,7 +594,7 @@ def make_epoch_end_harness(
     )
 
 
-def test_precision_recall_curve_separates_scalars_and_artifact() -> None:
+def make_updated_metric() -> PrecisionRecallCurve:
     metric = make_metric(thresholds=[0.0, 0.5, 1.0])
     metric.update(
         make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
@@ -347,6 +603,11 @@ def test_precision_recall_curve_separates_scalars_and_artifact() -> None:
             dtype=torch.float32,
         ),
     )
+    return metric
+
+
+def test_precision_recall_curve_separates_scalars_and_artifact() -> None:
+    metric = make_updated_metric()
 
     computed = metric.compute()
     primary, submetrics = metric.get_loggable_values(computed)
@@ -371,14 +632,7 @@ def test_precision_recall_curve_separates_scalars_and_artifact() -> None:
 
 
 def test_evaluation_epoch_end_logs_curve_once_and_resets() -> None:
-    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
-    metric.update(
-        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
-        torch.tensor(
-            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
-            dtype=torch.float32,
-        ),
-    )
+    metric = make_updated_metric()
     harness = make_epoch_end_harness(metric, is_global_zero=True)
 
     LuxonisLightningModule._evaluation_epoch_end(
@@ -396,8 +650,9 @@ def test_evaluation_epoch_end_logs_curve_once_and_resets() -> None:
     ]
     assert len(harness.tracker.images) == 1
     assert harness.tracker.images[0]["name"] == (
-        "val/metrics/3/head/PrecisionRecallCurve/curves"
+        "val/metrics/head/PrecisionRecallCurve/curves"
     )
+    assert harness.tracker.images[0]["step"] == 3
     assert int(metric.target_count) == 0
     torch.testing.assert_close(
         metric.true_positives,
@@ -405,15 +660,82 @@ def test_evaluation_epoch_end_logs_curve_once_and_resets() -> None:
     )
 
 
-def test_evaluation_epoch_end_logs_primary_without_submetrics() -> None:
-    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
-    metric.update(
-        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
-        torch.tensor(
-            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
-            dtype=torch.float32,
-        ),
+def test_logged_artifact_path_matches_registered_mlflow_key() -> None:
+    """The image name must resolve to the artifact key that
+    C{get_mlflow_logging_keys} advertises.
+
+    C{LuxonisTracker.log_image} inserts the step as its own path segment
+    for MLflow, so a name that carries the epoch itself resolved to
+    C{.../{epoch}/<node>/<metric>/{epoch}/curves.png} while the
+    registered key had no step segment at all - every consumer resolving
+    the advertised key found nothing.
+    """
+    metric = make_updated_metric()
+    harness = make_epoch_end_harness(metric, is_global_zero=True)
+
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness), "val"
     )
+    keys = LuxonisLightningModule.get_mlflow_logging_keys(
+        cast(LuxonisLightningModule, harness)
+    )
+
+    logged = harness.tracker.images[0]
+    assert (
+        mlflow_image_key(cast(str, logged["name"]), cast(int, logged["step"]))
+        == "val/metrics/head/PrecisionRecallCurve/3/curves.png"
+    )
+
+    # The harness validates every epoch, so epoch 3 is registered too.
+    harness.cfg.trainer.epochs = 4
+    keys = LuxonisLightningModule.get_mlflow_logging_keys(
+        cast(LuxonisLightningModule, harness)
+    )
+    assert (
+        mlflow_image_key(cast(str, logged["name"]), cast(int, logged["step"]))
+        in keys["artifacts"]
+    )
+
+
+def test_mlflow_image_key_matches_tracker_path_construction() -> None:
+    """C{mlflow_image_key} mirrors the MLflow branch of
+    C{LuxonisTracker.log_image}.
+    """
+    name = metric_artifact_image_name(
+        "val", "head", "PrecisionRecallCurve", "curves"
+    )
+    assert name == "val/metrics/head/PrecisionRecallCurve/curves"
+
+    base_path, caption = name.rsplit("/", 1)
+    assert mlflow_image_key(name, 7) == f"{base_path}/7/{caption}.png"
+
+
+def test_mlflow_keys_classify_curve_as_image_artifact() -> None:
+    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
+    harness = make_epoch_end_harness(metric, is_global_zero=True)
+
+    keys = LuxonisLightningModule.get_mlflow_logging_keys(
+        cast(LuxonisLightningModule, harness)
+    )
+
+    assert "val/metric/head/PrecisionRecallCurve" in keys["metrics"]
+    assert "val/metric/head/confidence_at_max_f1" in keys["metrics"]
+    assert (
+        "val/metrics/head/PrecisionRecallCurve/0/curves.png"
+        in keys["artifacts"]
+    )
+    assert (
+        "test/metrics/head/PrecisionRecallCurve/2/curves.png"
+        in keys["artifacts"]
+    )
+    assert not any(
+        name.endswith(("/precision", "/recall", "/confidence", "/f1"))
+        for name in keys["metrics"]
+    )
+
+
+def test_evaluation_epoch_end_logs_primary_without_submetrics() -> None:
+    metric = make_updated_metric()
     harness = make_epoch_end_harness(
         metric,
         is_global_zero=True,
@@ -435,14 +757,7 @@ def test_evaluation_epoch_end_logs_primary_without_submetrics() -> None:
 
 
 def test_evaluation_epoch_end_skips_artifact_on_nonzero_rank() -> None:
-    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
-    metric.update(
-        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
-        torch.tensor(
-            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
-            dtype=torch.float32,
-        ),
-    )
+    metric = make_updated_metric()
     harness = make_epoch_end_harness(metric, is_global_zero=False)
 
     LuxonisLightningModule._evaluation_epoch_end(
@@ -453,63 +768,141 @@ def test_evaluation_epoch_end_skips_artifact_on_nonzero_rank() -> None:
     assert int(metric.target_count) == 0
 
 
-def test_evaluation_epoch_end_skips_invalid_artifact_shape(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
-    metric.update(
-        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
-        torch.tensor(
-            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
-            dtype=torch.float32,
-        ),
+def test_evaluation_epoch_end_skips_artifact_during_sanity_check() -> None:
+    """Sanity checking must not publish a curve.
+
+    The sanity-check validation pass runs before any epoch has finished,
+    so logging its figure would publish a plot built from a couple of
+    batches - and pay the full rendering cost on every run. Every other
+    conditional logging path in the module already guards
+    C{trainer.sanity_checking}.
+    """
+    metric = make_updated_metric()
+    harness = make_epoch_end_harness(
+        metric, is_global_zero=True, sanity_checking=True
     )
 
-    def invalid_artifacts(
-        values: dict[str, Tensor],
-    ) -> dict[str, Tensor]:
-        del values
-        return {"curves": torch.zeros((10, 10))}
+    LuxonisLightningModule._evaluation_epoch_end(
+        cast(LuxonisLightningModule, harness), "val"
+    )
 
-    monkeypatch.setattr(metric, "get_artifacts", invalid_artifacts)
+    assert harness.tracker.images == []
+    assert int(metric.target_count) == 0
+
+
+def test_artifacts_are_built_before_the_metric_is_reset() -> None:
+    """C{get_artifacts} must see the state the values were computed
+    from.
+
+    The artifact hook is public and may render from the metric's own
+    accumulators, but it used to be called after C{metric.reset()} - so
+    it silently rendered an all-zero figure next to correct scalars.
+    """
+    metric = make_updated_metric()
+    observed: list[int] = []
+
+    def get_artifacts(values: dict[str, Tensor]) -> dict[str, Tensor]:
+        del values
+        observed.append(int(metric.target_count))
+        return {}
+
+    metric.get_artifacts = get_artifacts  # type: ignore[method-assign]
     harness = make_epoch_end_harness(metric, is_global_zero=True)
 
     LuxonisLightningModule._evaluation_epoch_end(
         cast(LuxonisLightningModule, harness), "val"
     )
 
-    metric_logs = [
-        name
-        for name, _, _ in harness._logged
-        if name.startswith("val/metric/")
-    ]
-    assert metric_logs == [
-        "val/metric/head/PrecisionRecallCurve",
-        "val/metric/head/confidence_at_max_f1",
-    ]
-    assert harness.tracker.images == []
+    assert observed == [1]
     assert int(metric.target_count) == 0
 
 
-def test_evaluation_epoch_end_skips_artifact_generation_failure(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    "artifacts",
+    [
+        pytest.param({"curves": np.zeros((3, 4, 4))}, id="numpy-array"),
+        pytest.param({"curves": object()}, id="not-a-tensor"),
+        pytest.param({"curves": torch.zeros((10, 10))}, id="wrong-dim"),
+        pytest.param([torch.zeros((3, 4, 4))], id="not-a-dict"),
+        pytest.param(None, id="none"),
+    ],
+)
+def test_log_metric_artifacts_tolerates_unusable_artifacts(
+    artifacts: Any,
 ) -> None:
-    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
-    metric.update(
-        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
-        torch.tensor(
-            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
-            dtype=torch.float32,
-        ),
+    """A metric returning something other than C{[C, H, W]} tensors must
+    not take down the validation epoch.
+
+    The dict iteration and the shape check used to sit outside both
+    C{try} blocks, so a C{get_artifacts} returning e.g. a numpy image
+    raised C{AttributeError} out of C{_evaluation_epoch_end} - defeating
+    the whole point of handling artifact failures.
+    """
+    metric = make_updated_metric()
+    metric.get_artifacts = lambda values: artifacts  # type: ignore[method-assign]
+    tracker = DummyTracker()
+
+    log_metric_artifacts(
+        cast(Any, tracker),
+        metric,
+        metric.compute(),
+        mode="val",
+        formatted_node_name="head",
+        metric_name="PrecisionRecallCurve",
+        current_epoch=3,
     )
 
-    def failing_artifacts(
-        values: dict[str, Tensor],
-    ) -> dict[str, Tensor]:
+    assert tracker.images == []
+
+
+def test_log_metric_artifacts_survives_generation_failure() -> None:
+    metric = make_updated_metric()
+
+    def failing_artifacts(values: dict[str, Tensor]) -> dict[str, Tensor]:
         del values
         raise RuntimeError("artifact rendering failed")
 
-    monkeypatch.setattr(metric, "get_artifacts", failing_artifacts)
+    metric.get_artifacts = failing_artifacts  # type: ignore[method-assign]
+    tracker = DummyTracker()
+
+    log_metric_artifacts(
+        cast(Any, tracker),
+        metric,
+        metric.compute(),
+        mode="val",
+        formatted_node_name="head",
+        metric_name="PrecisionRecallCurve",
+        current_epoch=3,
+    )
+
+    assert tracker.images == []
+
+
+def test_log_metric_artifacts_survives_tracker_failure() -> None:
+    metric = make_updated_metric()
+
+    class FailingTracker(DummyTracker):
+        def log_image(self, name: str, img: object, step: int) -> None:
+            raise RuntimeError("tracker image logging failed")
+
+    tracker = FailingTracker()
+
+    log_metric_artifacts(
+        cast(Any, tracker),
+        metric,
+        metric.compute(),
+        mode="val",
+        formatted_node_name="head",
+        metric_name="PrecisionRecallCurve",
+        current_epoch=3,
+    )
+
+    assert tracker.images == []
+
+
+def test_evaluation_epoch_end_survives_broken_artifacts() -> None:
+    metric = make_updated_metric()
+    metric.get_artifacts = lambda values: {"curves": np.zeros((3, 4, 4))}  # type: ignore[method-assign]
     harness = make_epoch_end_harness(metric, is_global_zero=True)
 
     LuxonisLightningModule._evaluation_epoch_end(
@@ -527,94 +920,22 @@ def test_evaluation_epoch_end_skips_artifact_generation_failure(
     ]
     assert harness.tracker.images == []
     assert int(metric.target_count) == 0
-
-
-def test_evaluation_epoch_end_skips_tracker_image_logging_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
-    metric.update(
-        make_pre_nms([(10, 10, 30, 30, 0.9, 0)]),
-        torch.tensor(
-            [[0, 0, 0.1, 0.1, 0.2, 0.2]],
-            dtype=torch.float32,
-        ),
-    )
-    harness = make_epoch_end_harness(metric, is_global_zero=True)
-
-    def failing_log_image(
-        *args: object,
-        **kwargs: object,
-    ) -> None:
-        del args, kwargs
-        raise RuntimeError("tracker image logging failed")
-
-    monkeypatch.setattr(
-        harness.tracker,
-        "log_image",
-        failing_log_image,
-    )
-
-    LuxonisLightningModule._evaluation_epoch_end(
-        cast(LuxonisLightningModule, harness),
-        "val",
-    )
-
-    metric_logs = [
-        name
-        for name, _, _ in harness._logged
-        if name.startswith("val/metric/")
-    ]
-    assert metric_logs == [
-        "val/metric/head/PrecisionRecallCurve",
-        "val/metric/head/confidence_at_max_f1",
-    ]
-    assert harness.tracker.images == []
-    assert int(metric.target_count) == 0
-
-
-def test_mlflow_keys_classify_curve_as_image_artifact() -> None:
-    metric = make_metric(thresholds=[0.0, 0.5, 1.0])
-    harness = make_epoch_end_harness(metric, is_global_zero=True)
-
-    keys = LuxonisLightningModule.get_mlflow_logging_keys(
-        cast(LuxonisLightningModule, harness)
-    )
-
-    assert "val/metric/head/PrecisionRecallCurve" in keys["metrics"]
-    assert "val/metric/head/confidence_at_max_f1" in keys["metrics"]
-    assert (
-        "val/metrics/0/head/PrecisionRecallCurve/curves.png"
-        in keys["artifacts"]
-    )
-    assert (
-        "test/metrics/2/head/PrecisionRecallCurve/curves.png"
-        in keys["artifacts"]
-    )
-    assert not any(
-        name.endswith(("/precision", "/recall", "/confidence", "/f1"))
-        for name in keys["metrics"]
-    )
 
 
 _REAL_BATCH_SIZE = 2
 _REAL_IMAGE_HEIGHT = 64
 _REAL_IMAGE_WIDTH = 64
 _REAL_N_CLASSES = 2
+_REAL_N_KEYPOINTS = 3
 _REAL_FEATURE_SHAPES = (
     Size([_REAL_BATCH_SIZE, 16, 8, 8]),
     Size([_REAL_BATCH_SIZE, 32, 4, 4]),
     Size([_REAL_BATCH_SIZE, 64, 2, 2]),
 )
+_REAL_N_ANCHORS = sum(shape[-2] * shape[-1] for shape in _REAL_FEATURE_SHAPES)
 
 
-class _RealEfficientBBoxHead(EfficientBBoxHead, register=False):
-    task = Tasks.BOUNDINGBOX
-    original_in_shape = cast(
-        Any, Size([3, _REAL_IMAGE_HEIGHT, _REAL_IMAGE_WIDTH])
-    )
-    n_classes = cast(Any, _REAL_N_CLASSES)
-
+class _FakeShapesMixin:
     @property
     def input_shapes(self) -> list[Packet[Size]]:
         return [{"features": list(_REAL_FEATURE_SHAPES)}]
@@ -624,20 +945,53 @@ class _RealEfficientBBoxHead(EfficientBBoxHead, register=False):
         return list(_REAL_FEATURE_SHAPES)
 
 
-class _RealPrecisionBBoxHead(PrecisionBBoxHead, register=False):
+class _RealEfficientBBoxHead(
+    _FakeShapesMixin, EfficientBBoxHead, register=False
+):
     task = Tasks.BOUNDINGBOX
     original_in_shape = cast(
         Any, Size([3, _REAL_IMAGE_HEIGHT, _REAL_IMAGE_WIDTH])
     )
     n_classes = cast(Any, _REAL_N_CLASSES)
 
-    @property
-    def input_shapes(self) -> list[Packet[Size]]:
-        return [{"features": list(_REAL_FEATURE_SHAPES)}]
 
-    @property
-    def in_sizes(self) -> list[Size]:
-        return list(_REAL_FEATURE_SHAPES)
+class _RealPrecisionBBoxHead(
+    _FakeShapesMixin, PrecisionBBoxHead, register=False
+):
+    task = Tasks.BOUNDINGBOX
+    original_in_shape = cast(
+        Any, Size([3, _REAL_IMAGE_HEIGHT, _REAL_IMAGE_WIDTH])
+    )
+    n_classes = cast(Any, _REAL_N_CLASSES)
+
+
+class _RealKeypointBBoxHead(
+    _FakeShapesMixin, EfficientKeypointBBoxHead, register=False
+):
+    task = Tasks.INSTANCE_KEYPOINTS
+    original_in_shape = cast(
+        Any, Size([3, _REAL_IMAGE_HEIGHT, _REAL_IMAGE_WIDTH])
+    )
+    n_classes = cast(Any, _REAL_N_CLASSES)
+    n_keypoints = cast(Any, _REAL_N_KEYPOINTS)
+
+
+class _RealSegmentBBoxHead(
+    _FakeShapesMixin, PrecisionSegmentBBoxHead, register=False
+):
+    task = Tasks.INSTANCE_SEGMENTATION
+    original_in_shape = cast(
+        Any, Size([3, _REAL_IMAGE_HEIGHT, _REAL_IMAGE_WIDTH])
+    )
+    n_classes = cast(Any, _REAL_N_CLASSES)
+
+
+_REAL_HEADS = (
+    _RealEfficientBBoxHead,
+    _RealPrecisionBBoxHead,
+    _RealKeypointBBoxHead,
+    _RealSegmentBBoxHead,
+)
 
 
 def _make_real_features(seed: int) -> list[Tensor]:
@@ -648,30 +1002,80 @@ def _make_real_features(seed: int) -> list[Tensor]:
     ]
 
 
-@pytest.mark.parametrize(
-    ("head_cls", "seed"),
-    [
-        (_RealEfficientBBoxHead, 1301),
-        (_RealPrecisionBBoxHead, 1302),
-    ],
-)
-def test_real_bbox_head_to_precision_recall_curve_e2e(
-    head_cls: type[EfficientBBoxHead | PrecisionBBoxHead],
-    seed: int,
-) -> None:
-    torch.manual_seed(seed)
-
+def _make_real_head(head_cls: type[BaseDetectionHead]) -> BaseDetectionHead:
     head = head_cls(
         n_heads=3,
         conf_thres=0.0,
         iou_thres=0.45,
         max_det=50,
         dataset_metadata=DatasetMetadata(
-            classes={"": {"class0": 0, "class1": 1}}
+            classes={"": {"class0": 0, "class1": 1}},
+            n_keypoints={"": _REAL_N_KEYPOINTS},
         ),
         task_name="",
     )
     head.eval()
+    return head
+
+
+@pytest.mark.parametrize("head_cls", _REAL_HEADS)
+def test_pre_nms_candidates_are_opt_in(
+    head_cls: type[BaseDetectionHead],
+) -> None:
+    """Heads only keep the pre-NMS candidates when asked to.
+
+    The C{[B, n_anchors, 5 + n_classes]} tensor is large enough to shift
+    peak validation memory, so it used to be paid for by every detection
+    model whether or not a module consumed it.
+    """
+    torch.manual_seed(1300)
+    head = _make_real_head(head_cls)
+
+    assert head.keep_detections_pre_nms is False
+    with torch.inference_mode():
+        assert "detections_pre_nms" not in head(_make_real_features(1300))
+
+    PrecisionRecallCurve(node=head, confidence_thresholds=[0.0, 0.5, 1.0])
+
+    assert head.keep_detections_pre_nms is True
+    with torch.inference_mode():
+        packet = head(_make_real_features(1300))
+    assert "detections_pre_nms" in packet
+    detections_pre_nms = packet["detections_pre_nms"]
+    assert isinstance(detections_pre_nms, Tensor)
+    assert detections_pre_nms.shape[:2] == (_REAL_BATCH_SIZE, _REAL_N_ANCHORS)
+    assert detections_pre_nms.shape[-1] >= 5 + _REAL_N_CLASSES
+
+
+@pytest.mark.parametrize(
+    ("head_cls", "seed"),
+    [
+        (_RealEfficientBBoxHead, 1301),
+        (_RealPrecisionBBoxHead, 1302),
+        (_RealKeypointBBoxHead, 1303),
+        (_RealSegmentBBoxHead, 1304),
+    ],
+)
+def test_real_bbox_head_to_precision_recall_curve_e2e(
+    head_cls: type[BaseDetectionHead],
+    seed: int,
+) -> None:
+    """Every detection head can feed the metric.
+
+    The metric only supported C{BOUNDINGBOX} and only two of the four
+    detection heads emitted the pre-NMS candidates, so attaching it to a
+    keypoint or instance-segmentation head failed at model build time or
+    at the first batch.
+    """
+    torch.manual_seed(seed)
+
+    head = _make_real_head(head_cls)
+    metric = PrecisionRecallCurve(
+        node=head,
+        confidence_thresholds=[0.0, 0.5, 1.0],
+        matching_iou_threshold=0.5,
+        nms_conf_threshold=0.0,
+    )
 
     with torch.inference_mode():
         packet = head(_make_real_features(seed))
@@ -683,11 +1087,7 @@ def test_real_bbox_head_to_precision_recall_curve_e2e(
 
     assert isinstance(detections_pre_nms, Tensor)
     assert isinstance(boundingbox, list)
-    assert detections_pre_nms.shape == (
-        _REAL_BATCH_SIZE,
-        sum(shape[-2] * shape[-1] for shape in _REAL_FEATURE_SHAPES),
-        5 + _REAL_N_CLASSES,
-    )
+    assert detections_pre_nms.shape[:2] == (_REAL_BATCH_SIZE, _REAL_N_ANCHORS)
     assert len(boundingbox) == _REAL_BATCH_SIZE
 
     replay = non_max_suppression(
@@ -700,7 +1100,7 @@ def test_real_bbox_head_to_precision_recall_curve_e2e(
         predicts_objectness=False,
     )
     for actual, expected in zip(boundingbox, replay, strict=True):
-        torch.testing.assert_close(actual, expected)
+        torch.testing.assert_close(actual, expected[:, :6])
 
     image_index, detection = next(
         (index, detections[0])
@@ -723,13 +1123,6 @@ def test_real_bbox_head_to_precision_recall_curve_e2e(
             ]
         ]
     )
-    interior_score = min(max(score, 1e-6), 1.0 - 1e-6)
-
-    metric = PrecisionRecallCurve(
-        node=head,
-        confidence_thresholds=[0.0, interior_score, 1.0],
-        matching_iou_threshold=0.5,
-    )
     labels = {f"{head.task_name}/boundingbox": target}
 
     parameters = metric.get_parameters(packet, labels)
@@ -744,6 +1137,7 @@ def test_real_bbox_head_to_precision_recall_curve_e2e(
     artifacts = metric.get_artifacts(computed)
 
     assert float(computed["max_f1"]) > 0
+    assert score > 0
     torch.testing.assert_close(primary, computed["max_f1"])
     assert set(submetrics) == {"confidence_at_max_f1"}
     assert all(value.numel() == 1 for value in submetrics.values())


### PR DESCRIPTION
Fixes the defects found by a code review of `feat/detection-confidence-curves`, with a regression test per bug. Every test that guards a bug carries a docstring describing it. 54 tests in `tests/unittests/test_metrics/test_precision_recall_curve.py`, `precision_recall_curve.py` at 100% statement coverage, `pyright` and `pre-commit` clean.

## Crash-class bugs

### 1. Metric states reset under `inference_mode` could not be updated again

`update()` accumulates in place (`self.true_positives += ...`) with no `is_inference()` guard. Lightning's validation loop runs `_evaluation_epoch_end` — and therefore `metric.reset()` — inside `torch.inference_mode()`, so the fresh states become inference tensors. The AIMET/quantization eval trainer is built with `inference_mode=False` (`core.py`), so its first `update()` died with:

```
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.
```

`DetectionConfusionMatrix._update` guards against exactly this; this metric was the only tensor-state metric without it. Fixed by cloning inference states at the top of `update()`.

**Test:** `test_update_after_reset_inside_inference_mode` — resets inside `inference_mode`, asserts the states *are* inference tensors, then updates outside it.

### 2. A bad artifact took down the validation epoch

`artifacts.items()` and `artifact.dim()` sat outside both `try/except` blocks, so a metric whose `get_artifacts` returned a numpy image, a PIL image, or a list raised `AttributeError` out of `_evaluation_epoch_end` — defeating the point of `16c1be1` ("Handle metric artifact logging failures"). The annotation is `dict[str, Tensor]` but `reportIncompatibleMethodOverride` is off, so nothing catches it statically.

Fixed by extracting the whole block into `lightning/utils.log_metric_artifacts`, which validates the container and each artifact inside the failure handling.

**Tests:** `test_log_metric_artifacts_tolerates_unusable_artifacts` (numpy array / non-tensor / wrong rank / list / `None`), plus `test_evaluation_epoch_end_survives_broken_artifacts` through the real epoch-end path.

## Logging contract

### 3. The registered MLflow artifact key never matched the written path

`LuxonisTracker.log_image` inserts the step as its own path segment for MLflow (`{base_path}/{step}/{caption}.png`). The call site put the epoch *in the name* and `get_mlflow_logging_keys` registered a key with no step segment at all, so the real artifact landed at `val/metrics/3/head/PrecisionRecallCurve/3/curves.png` while the advertised key was `val/metrics/3/head/PrecisionRecallCurve/curves.png`. Anything resolving artifacts by the advertised key (the `tests/integration/test_mlflow_logging.py` contract, the Optuna monitor lookup) found nothing. The naming convention was copied from `log_matrix`, which does *not* insert the step.

Fixed by dropping the epoch from the name — matching how visualizations are named — and deriving both sides from shared helpers: `metric_artifact_image_name()` and `mlflow_image_key()`. The layout is now `{mode}/metrics/{node}/{metric}/{epoch}/{artifact}.png`. As a side effect, TensorBoard now gets one stepped image tag instead of one single-frame tag per epoch.

**Tests:** `test_logged_artifact_path_matches_registered_mlflow_key` takes the name actually handed to the tracker, applies the tracker's own path rule, and asserts the result is in `get_mlflow_logging_keys()["artifacts"]`; `test_mlflow_image_key_matches_tracker_path_construction` pins the helper to the tracker's construction.

### 4. `get_artifacts` ran after `metric.reset()`

`get_artifacts` is a public hook, and a metric rendering from its own accumulators saw them zeroed — silently wrong figures next to correct scalars, with no exception to notice. Artifacts are now built before the reset.

**Test:** `test_artifacts_are_built_before_the_metric_is_reset`.

### 5. Artifacts were logged during sanity checking

The block was guarded only by `is_global_zero`. Lightning suppresses `self.log(...)` during sanity checking but not direct tracker calls, so a curve built from `n_sanity_val_steps` batches was published at step 0 before any epoch finished — and the figure was rendered on every run. Every other conditional logging path in the module already guards `trainer.sanity_checking`.

**Test:** `test_evaluation_epoch_end_skips_artifact_during_sanity_check`.

## Metric correctness and cost

### 6. NMS re-run at `conf_thres=0.0`, plus a per-prediction matching loop

`conf_thres=self.min_confidence` is `0.0` under the default grid, so every decoded anchor — including anchors scoring zero — became an NMS candidate, and `_match_predictions` then issued a `torch.where` + `box_iou` + `torch.max` per prediction (up to `batch_size × max_det` iterations per batch).

Two fixes:
- New `nms_conf_threshold` parameter (default `1e-3`, the usual detection-validation floor; effective floor is `max(nms_conf_threshold, lowest_threshold)`).
- `_match_image_predictions` computes one IoU matrix per image and only loops over predictions that have an eligible target, keeping the greedy-by-score semantics exactly.

Measured on batch 8 × 8400 anchors × 80 classes: `update()` 0.166 s → 0.090 s per batch, with byte-identical TP/FP counts against the old matcher. The NMS floor's benefit scales with how sharp the detector's score distribution is (NMS alone: 0.092 s at conf 0, 0.003 s at conf 0.25), so the docstring and README now state that the metric's cost grows with the number of candidates above the floor.

**Tests:** `test_nms_confidence_floor_is_positive_by_default`, `test_nms_confidence_floor_follows_lowest_threshold`, `test_greedy_matching_is_class_aware_and_uses_each_target_once`.

### 7. Precision reported as 0 where nothing is predicted

With `tp + fp == 0` precision was defined as 0, so for a detector topping out at 0.87 the Precision-Confidence panel fell off a cliff to zero over the whole 0.88–1.0 range — the opposite of the truth — and the PR curve got a spurious `(0, 0)` endpoint. Now reported as 1 (the convention; Ultralytics interpolates the P-conf curve with `left=1`). F1 stays 0 there, so `max_f1` and `confidence_at_max_f1` are unaffected.

**Tests:** `test_precision_is_one_where_nothing_is_predicted`, and `test_precision_recall_curve_values` (which previously asserted the wrong value).

### 8. Predictions scoring exactly the lowest threshold were dropped

`non_max_suppression` filters with a strict `>` while the curve counts use `>=`, so a prediction scoring exactly the floor (e.g. `sigmoid(0) == 0.5` exactly) was excluded from the very bucket it defines. The floor is now converted to the largest `float32` strictly below it before being passed to NMS.

**Test:** `test_prediction_at_lowest_threshold_is_counted`.

### 9. Confidence axes were hardcoded to `(0, 1)`

`min_confidence: 0.9` — the configuration you'd pick to zoom into the high-confidence region — squeezed the entire curve into the rightmost 10% of both confidence panels. The confidence axes now span the configured grid; the PR panel keeps `(0, 1)`. Figure construction moved into `build_curve_figure` so the axes are testable.

**Test:** `test_confidence_axes_span_the_configured_grid`.

### 10. An explicit grid silently ignored (and unvalidated) the generated-grid parameters

`confidence_thresholds` returned early, so `num_thresholds` / `min_confidence` / `max_confidence` were dropped without a word — and their validation was skipped, so `min_confidence: 5.0` passed construction. Those three now default to `None` and combining them with an explicit grid raises.

**Test:** `test_explicit_grid_rejects_generated_grid_parameters` (parametrized over each combination).

### 11. Only 2 of the 4 detection heads emitted `detections_pre_nms`

`supported_tasks` was `BOUNDINGBOX`-only while `MeanAveragePrecisionBBox` and `DetectionConfusionMatrix` also accept `INSTANCE_KEYPOINTS` and `INSTANCE_SEGMENTATION`, so attaching this metric to `EfficientKeypointBBoxHead` or `PrecisionSegmentBBoxHead` raised `IncompatibleError` at build time — and widening the tasks alone would have failed at the first batch, because neither head put `detections_pre_nms` in its packet.

`supported_tasks` widened to the three detection tasks and all four heads now emit the key (with the keypoint/mask tail appended, which NMS already handles via `has_additional`).

**Tests:** `test_real_bbox_head_to_precision_recall_curve_e2e` and `test_pre_nms_candidates_are_opt_in`, both parametrized over all four heads.

### 12. The pre-NMS tensor was retained for every detection model

`detections_pre_nms` was `[B, n_anchors, 5 + n_classes]` live in the packet for the whole step — ~91 MB at 640×640/80 classes/batch 32, ~360 MB at batch 128, plus a `.clone()` per consuming module — paid by every `EfficientBBoxHead`/`PrecisionBBoxHead` user even without the metric attached. Now opt-in: `BaseDetectionHead.request_detections_pre_nms()`, which `PrecisionRecallCurve.__init__` calls.

**Test:** `test_pre_nms_candidates_are_opt_in` — the key is absent from a bare head's packet and present after a metric is attached.

### 13. A non-detection head failed with a bare `AttributeError`

`iou_thres` / `max_det` are read off the node but only exist on `BaseDetectionHead`, and with no `node:` annotation the framework's compatibility check never ran — a custom `Tasks.BOUNDINGBOX` head got `AttributeError: 'MyHead' object has no attribute 'iou_thres'` from `nn.Module.__getattr__`. Added `node: BaseDetectionHead`, which both produces the framework's actionable `IncompatibleError` and makes the attribute accesses type-check (the two `cast(...)` calls were no-ops, since every attribute on a node types as `Any`).

**Test:** `test_precision_recall_curve_rejects_non_detection_head`.

### 14. Epoch-end tests were coupled to module internals

The artifact tests hand-built a 15-attribute `SimpleNamespace` and called `LuxonisLightningModule._evaluation_epoch_end` unbound, so any new field in that method broke them with an `AttributeError` on the fake. Extracting `log_metric_artifacts` (see #2) lets the artifact cases call a real function with real arguments; a few tests still exercise the epoch-end path deliberately, for the wiring.

## Not applied

**Swallowed `log_image` failures for TensorBoard/W&B.** The review flagged that the broad `except` around `tracker.log_image` drops the image for good on backends with no internal retry (MLflow spools failures locally, TensorBoard and W&B do not). That is the deliberate trade-off of `16c1be1` — a failed plot upload must not kill a training run — so the handler stays; its message now says the artifact is dropped for that epoch instead of the vaguer "Skipping artifact logging".

## Other behavior changes worth a look

- Artifact path layout is now `{mode}/metrics/{node}/{metric}/{epoch}/{artifact}.png` (#3).
- Counts at threshold `0.0` now exclude predictions scoring below `1e-3` by default (#6); set `nms_conf_threshold: 0.0` for the old behavior.
- `num_thresholds` / `min_confidence` / `max_confidence` default to `None`; their effective values are unchanged (#10).
- `PrecisionRecallCurve.min_confidence` → `lowest_threshold`, to stop the attribute shadowing the same-named constructor parameter.
- `EfficientKeypointBBoxHead._postprocess_keypoint_detections` → `_split_keypoint_detections`, now that the forward decodes and runs NMS itself.
- `PrecisionRecallCurve` documented in `attached_modules/metrics/README.md`, which the original commit did not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Precision-recall metrics now support bounding boxes, instance keypoints, and instance segmentation.
  * Added configurable confidence grids, matching thresholds, NMS settings, and detection limits.
  * Added standardized metric image artifact logging for validation and test results.

* **Bug Fixes**
  * Improved prediction-to-target matching and confidence-threshold handling.
  * Corrected precision behavior when no predictions are available.
  * Improved curve rendering and artifact logging reliability.

* **Documentation**
  * Added comprehensive PrecisionRecallCurve documentation and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->