### PR TITLE
Fix invariants dropped by the parameter-groups rework

### DIFF
--- a/luxonis_train/callbacks/training_manager.py
+++ b/luxonis_train/callbacks/training_manager.py
@@ -23,7 +23,11 @@ class TrainingManager(BaseFinetuning):
         epoch: int,
         optimizer: Optimizer,
     ) -> None:
-        _ = optimizer
+        try:
+            optimizers = list(pl_module.trainer.optimizers)
+        except RuntimeError:
+            optimizers = [optimizer]
+
         for (
             node_name,
             node,
@@ -33,8 +37,16 @@ class TrainingManager(BaseFinetuning):
             if e == epoch:
                 logger.info(f"Unfreezing node '{node_name}'")
                 self.make_trainable(node)
+                # `optimizer` is the fallback for parameters that no
+                # optimizer claimed at build time, which happens when a
+                # training strategy is active: it skips frozen
+                # parameters, and only nodes with a `finetuning` entry
+                # get an optimizer of their own.
                 pl_module.nodes.restore_unfrozen_parameters(
-                    node, lr_after_unfreeze
+                    node,
+                    lr_after_unfreeze,
+                    fallback_optimizer=optimizer,
+                    optimizers=optimizers,
                 )
 
     @override

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from contextlib import suppress
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Literal, NamedTuple
+from typing import Annotated, Any, ClassVar, Literal, NamedTuple
 
 from loguru import logger
 from luxonis_ml.enums import DatasetType
@@ -119,6 +119,24 @@ class ParameterPattern(BaseModelExtraForbid):
 class SchedulerConfig(ConfigItem):
     name: str = "ConstantLR"
 
+    # Finetuning overrides inherit the name from the config they extend,
+    # so for them `params` without a `name` is meaningful.
+    _requires_explicit_name: ClassVar[bool] = True
+
+    @model_validator(mode="after")
+    def validate_name_given_with_params(self) -> Self:
+        if (
+            self._requires_explicit_name
+            and self.params
+            and "name" not in self.model_fields_set
+        ):
+            raise ValueError(
+                "Scheduler `params` were given without a `name`. "
+                f"Specify the scheduler name explicitly instead of relying "
+                f"on the '{self.name}' default."
+            )
+        return self
+
     def get_sequential_lr_params(self) -> "SequentialLRParams":
         if self.name != "SequentialLR":
             raise RuntimeError(
@@ -141,9 +159,24 @@ class SequentialLRParams(BaseModelExtraForbid):
     milestones: list[int]
     last_epoch: int = -1
 
+    @field_validator("schedulers", mode="after")
+    @classmethod
+    def validate_scheduler_names(
+        cls, schedulers: list[SchedulerConfig]
+    ) -> list[SchedulerConfig]:
+        for i, scheduler in enumerate(schedulers):
+            if "name" not in scheduler.model_fields_set:
+                raise ValueError(
+                    f"Scheduler at index {i} of 'SequentialLR' does not "
+                    "specify the `name` field."
+                )
+        return schedulers
+
 
 class FinetuningSchedulerConfig(SchedulerConfig):
     name: str | None = None
+
+    _requires_explicit_name: ClassVar[bool] = False
 
 
 class OptimizerConfig(ConfigItem):

--- a/luxonis_train/lightning/luxonis_lightning.py
+++ b/luxonis_train/lightning/luxonis_lightning.py
@@ -48,6 +48,7 @@ from .utils import (
     check_tensor_device,
     compute_losses,
     compute_visualization_buffer,
+    get_gradient_accumulation_schedule,
     get_model_execution_order,
     log_balanced_class_images,
     log_sequential_images,
@@ -171,6 +172,9 @@ class LuxonisLightningModule(pl.LightningModule):
         self._training_strategy_base_configs: (
             tuple[OptimizerConfig, SchedulerConfig] | None
         ) = None
+        self._gradient_accumulation_schedule: dict[int, int] | None = (
+            get_gradient_accumulation_schedule(self.cfg)
+        )
 
     @override
     def load_state_dict(
@@ -465,40 +469,110 @@ class LuxonisLightningModule(pl.LightningModule):
 
     @override
     def training_step(
-        self, train_batch: tuple[dict[str, Tensor] | Tensor, Labels]
+        self,
+        train_batch: tuple[dict[str, Tensor] | Tensor, Labels],
+        batch_idx: int = 0,
     ) -> Tensor:
         loss = self.compute_training_loss(train_batch)
         if self.automatic_optimization:
             return loss
-        optimizers = self.optimizers()
-        if optimizers is None:
-            optimizers = []
-        elif not isinstance(optimizers, list):
-            optimizers = [optimizers]
-        schedulers = self.lr_schedulers()
-        if schedulers is None:
-            schedulers = []
-        elif not isinstance(schedulers, list):
-            schedulers = [schedulers]
-        for optimizer in optimizers:
-            optimizer.zero_grad()
-        self.manual_backward(loss)
-        if self.cfg.trainer.gradient_clip_val is not None:
+
+        optimizers = self._active_optimizers()
+        schedulers = self._active_schedulers()
+
+        accumulation = self._accumulation_factor()
+        # Automatic optimization normalizes the loss by the accumulation
+        # factor before the backward pass, so manual accumulation has to
+        # do the same to keep the gradient magnitude unchanged.
+        self.manual_backward(loss / accumulation)
+
+        is_last_batch = self.trainer.is_last_batch
+        if (batch_idx + 1) % accumulation == 0 or is_last_batch:
+            self._clip_gradients_globally()
             for optimizer in optimizers:
-                self.clip_gradients(
-                    cast(Optimizer, optimizer),
-                    gradient_clip_val=self.cfg.trainer.gradient_clip_val,
-                    gradient_clip_algorithm=(
-                        self.cfg.trainer.gradient_clip_algorithm or "norm"
-                    ),
-                )
-        for optimizer in optimizers:
-            optimizer.step()
-        if self.trainer.is_last_batch:
+                optimizer.step()
+            for optimizer in optimizers:
+                optimizer.zero_grad()
+
+        if is_last_batch:
             for scheduler in schedulers:
                 if not isinstance(scheduler, ReduceLROnPlateau):
                     scheduler.step()
         return loss
+
+    def _active_optimizers(self) -> list[Any]:
+        optimizers = self.optimizers()
+        if optimizers is None:
+            return []
+        if isinstance(optimizers, list):
+            return optimizers
+        return [optimizers]
+
+    def _active_schedulers(self) -> list[Any]:
+        schedulers = self.lr_schedulers()
+        if schedulers is None:
+            return []
+        if isinstance(schedulers, list):
+            return schedulers
+        return [schedulers]
+
+    def _accumulation_factor(self) -> int:
+        """Return the number of batches to accumulate gradients over.
+
+        Lightning rejects `accumulate_grad_batches != 1` under manual
+        optimization, so with multiple optimizers the configured
+        schedule has to be honored here. Ignoring it would be silently
+        wrong for the predefined models, whose loss weights
+        `smart_cfg_auto_populate` has already scaled by the very same
+        factor.
+        """
+        schedule = self._gradient_accumulation_schedule
+        if not schedule:
+            return 1
+        factor = 1
+        for epoch in sorted(schedule):
+            if self.current_epoch >= epoch:
+                factor = schedule[epoch]
+        return max(1, factor)
+
+    def _clip_gradients_globally(self) -> None:
+        """Clip the gradients of the whole model as a single unit.
+
+        Automatic optimization clips one global norm over all
+        parameters. Clipping each optimizer separately would let the
+        total norm grow with the number of optimizers, so a config that
+        converged before adding a `finetuning` entry could diverge after
+        it.
+        """
+        clip_val = self.cfg.trainer.gradient_clip_val
+        if clip_val is None:
+            return
+        parameters = [p for p in self.parameters() if p.grad is not None]
+        if not parameters:
+            return
+        if self.cfg.trainer.gradient_clip_algorithm == "value":
+            torch.nn.utils.clip_grad_value_(parameters, clip_val)
+        else:
+            torch.nn.utils.clip_grad_norm_(parameters, clip_val)
+
+    def _reduce_across_ranks(self, value: float) -> float:
+        """Average a rank-local value over all processes.
+
+        The loss accumulator is per-rank. Stepping `ReduceLROnPlateau`
+        with it would let ranks disagree about when to decay, and
+        learning rates are optimizer state that DDP never re-
+        synchronizes, so the replicas would silently drift apart.
+        """
+        try:
+            trainer = self.trainer
+        except RuntimeError:
+            return value
+        if trainer.world_size <= 1:
+            return value
+        reduced = trainer.strategy.reduce(
+            torch.tensor(value, device=self.device), reduce_op="mean"
+        )
+        return float(reduced)
 
     def _step_reduce_lr_on_plateau_schedulers(
         self, loss: float, metrics: dict[str, dict[str, float]]
@@ -506,15 +580,18 @@ class LuxonisLightningModule(pl.LightningModule):
         if self.automatic_optimization:
             return
 
-        schedulers = self.lr_schedulers()
-        if schedulers is None:
+        schedulers = [
+            scheduler
+            for scheduler in self._active_schedulers()
+            if isinstance(scheduler, ReduceLROnPlateau)
+        ]
+        if not schedulers:
             return
-        if not isinstance(schedulers, list):
-            schedulers = [schedulers]
+
+        if any(scheduler.mode == "min" for scheduler in schedulers):
+            loss = self._reduce_across_ranks(loss)
 
         for scheduler in schedulers:
-            if not isinstance(scheduler, ReduceLROnPlateau):
-                continue
             if scheduler.mode == "min":
                 scheduler.step(loss)
                 continue
@@ -682,7 +759,12 @@ class LuxonisLightningModule(pl.LightningModule):
                 base_optimizer_cfg,
                 base_scheduler_cfg,
                 include_default=False,
+                group_splitter=self.training_strategy.split_parameter_group,
             )
+            # The strategy only adjusts learning rates of its own
+            # optimizer, so it has to be told about the optimizers built
+            # from the `finetuning` rules for its warmup to cover them.
+            self.training_strategy.attach_optimizers(optimizers)
             used_params = {
                 id(p)
                 for optimizer in optimizers
@@ -696,8 +778,18 @@ class LuxonisLightningModule(pl.LightningModule):
             schedulers = [*schedulers, *strategy_schedulers]
         else:
             optimizers, schedulers = self.nodes.build_optimizers()
-        if len(optimizers) > 1:
-            self.automatic_optimization = False
+
+        if not optimizers:
+            raise ValueError(
+                "No optimizer was created because no parameter of the model "
+                "is trainable. Check the `freezing` settings of the nodes "
+                "and make sure at least one node has trainable parameters."
+            )
+
+        # Assigned unconditionally: the flag lives on the module, so
+        # leaving it at `False` would leak into any later `fit` call on
+        # the same model.
+        self.automatic_optimization = len(optimizers) == 1
 
         self._log_optimizer_scheduler_info(optimizers, schedulers)
 
@@ -727,8 +819,12 @@ class LuxonisLightningModule(pl.LightningModule):
             base_scheduler_cfg,
             include_default=False,
         )
+        # `configure_callbacks` runs before `TrainingManager` freezes
+        # the configured nodes, so without excluding them here the
+        # strategy would count parameters that are frozen by the time
+        # the optimizers are really built, and overestimate.
         return count + self.training_strategy.estimate_optimizer_count(
-            used_params
+            used_params | self.nodes.frozen_parameter_ids()
         )
 
     def load_checkpoint(self, ckpt: PathType | dict[str, Any] | None) -> None:

--- a/luxonis_train/lightning/utils.py
+++ b/luxonis_train/lightning/utils.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Hashable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Hashable, Iterator, Mapping, Sequence
 from contextlib import suppress
 from functools import cached_property
 from pathlib import Path
@@ -90,7 +90,17 @@ class OptimizerPlan(NamedTuple):
 class UnfreezeTarget(NamedTuple):
     optimizer: Optimizer
     optimizer_params: Kwargs
-    parameter_group: dict[str, Any] | None
+    group_index: int | None
+
+
+# Splits the parameters matched by a single finetuning rule into
+# sub-groups with different optimizer options. Used by training
+# strategies whose optimizer options depend on the kind of parameter
+# (e.g. no weight decay for biases and normalization weights).
+GroupSplitter = Callable[
+    [list[tuple[nn.Module, nn.Parameter]], Kwargs, set[str]],
+    list[tuple[list[nn.Parameter], Kwargs]],
+]
 
 
 def _freeze_config_value(value: Any) -> Hashable:
@@ -359,6 +369,7 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
         cfg_base_scheduler: SchedulerConfig | None,
         used_params: set[int] | None = None,
         include_default: bool = True,
+        group_splitter: GroupSplitter | None = None,
     ) -> tuple[list[OptimizerPlan], set[int]]:
         cfg_base_optimizer = cfg_base_optimizer or self.cfg.trainer.optimizer
         cfg_base_scheduler = cfg_base_scheduler or self.cfg.trainer.scheduler
@@ -438,7 +449,7 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
                 cfg_scheduler = merge_config_items(
                     cfg_base_scheduler, finetuning.scheduler
                 )
-                params = []
+                params: list[tuple[nn.Module, nn.Parameter]] = []
                 patterns = finetuning.parameters or [
                     ParameterPattern(name=".*")
                 ]
@@ -464,7 +475,7 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
                                 or node.unfreeze_after is not None
                             )
                         ):
-                            params.append(p)
+                            params.append((module, p))
                             used_params.add(id(p))
 
                 if not params:
@@ -483,15 +494,31 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
                 )
                 if group_key not in groups:
                     groups[group_key] = ([], cfg_scheduler)
-                groups[group_key][0].append(
-                    OptimizerGroupPlan(
-                        parameters=params,
-                        trainable_parameters=[
-                            p for p in params if p.requires_grad
-                        ],
-                        optimizer_params=cfg_optimizer.params,
+
+                if group_splitter is None:
+                    splits = [([p for _, p in params], cfg_optimizer.params)]
+                else:
+                    explicit_keys = set(
+                        finetuning.optimizer.params
+                        if finetuning.optimizer is not None
+                        else {}
                     )
-                )
+                    splits = group_splitter(
+                        params, cfg_optimizer.params, explicit_keys
+                    )
+
+                for split_params, split_options in splits:
+                    if not split_params:
+                        continue
+                    groups[group_key][0].append(
+                        OptimizerGroupPlan(
+                            parameters=split_params,
+                            trainable_parameters=[
+                                p for p in split_params if p.requires_grad
+                            ],
+                            optimizer_params=split_options,
+                        )
+                    )
 
         for (optimizer_name, _, _), (
             parameter_groups,
@@ -550,6 +577,21 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
     def formatted_name(self, node_name: str) -> str:
         return self[node_name].formatted_name
 
+    def frozen_parameter_ids(self) -> set[int]:
+        """Ids of the parameters that C{TrainingManager} freezes before
+        training starts.
+
+        Needed wherever optimizers have to be reasoned about before
+        C{BaseFinetuning.setup} has actually frozen anything, because at
+        that point every parameter still has C{requires_grad=True}.
+        """
+        return {
+            id(parameter)
+            for node in self.values()
+            if node.unfreeze_after is not None
+            for parameter in node.module.parameters()
+        }
+
     def frozen_nodes(
         self,
     ) -> Iterator[tuple[str, BaseNode, int, float | None]]:
@@ -563,12 +605,39 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
                 )
 
     def restore_unfrozen_parameters(
-        self, module: BaseNode, lr: float | None
+        self,
+        module: BaseNode,
+        lr: float | None,
+        fallback_optimizer: Optimizer | None = None,
+        optimizers: Sequence[Optimizer] = (),
     ) -> None:
+        """Attach the parameters of a just-unfrozen node to an
+        optimizer.
+
+        @type module: BaseNode
+        @param module: The node that has just been unfrozen.
+        @type lr: float | None
+        @param lr: The learning rate to use for the unfrozen parameters.
+            If C{None}, the current learning rate of the optimizer is
+            used, so that parameters unfrozen mid-training join at the
+            already decayed rate rather than at the initial one.
+        @type fallback_optimizer: Optimizer | None
+        @param fallback_optimizer: Optimizer to attach parameters to
+            when no optimizer claimed them at build time. This happens
+            when a training strategy is active, because the strategy
+            skips frozen parameters and only nodes with a C{finetuning}
+            entry get an optimizer of their own.
+        @type optimizers: Sequence[Optimizer]
+        @param optimizers: All optimizers of the run, used to detect
+            parameters that already belong to some optimizer.
+        """
         targets: dict[int, tuple[UnfreezeTarget, list[nn.Parameter]]] = {}
+        unclaimed: list[nn.Parameter] = []
+
         for parameter in module.parameters():
             target = self._unfreeze_targets.pop(id(parameter), None)
             if target is None:
+                unclaimed.append(parameter)
                 continue
             target_id = id(target)
             if target_id not in targets:
@@ -576,29 +645,37 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
             targets[target_id][1].append(parameter)
 
         for target, parameters in targets.values():
-            existing_parameter_ids = {
-                id(parameter)
-                for group in target.optimizer.param_groups
-                for parameter in group["params"]
-            }
-            parameters = [
-                parameter
-                for parameter in parameters
-                if id(parameter) not in existing_parameter_ids
-            ]
-            if not parameters:
-                continue
+            _attach_parameter_group(
+                target.optimizer,
+                parameters,
+                lr,
+                target.optimizer_params,
+                target.group_index,
+            )
 
-            if target.parameter_group is not None:
-                target.parameter_group["params"].extend(parameters)
-                if lr is not None:
-                    target.parameter_group["lr"] = float(lr)
-                continue
+        assigned_ids = {
+            id(parameter)
+            for optimizer in optimizers
+            for group in optimizer.param_groups
+            for parameter in group["params"]
+        }
+        unclaimed = [
+            parameter
+            for parameter in unclaimed
+            if parameter.requires_grad and id(parameter) not in assigned_ids
+        ]
+        if not unclaimed:
+            return
 
-            parameter_group = {"params": parameters} | target.optimizer_params
-            if lr is not None:
-                parameter_group["lr"] = float(lr)
-            target.optimizer.add_param_group(parameter_group)
+        if fallback_optimizer is None:
+            logger.warning(
+                f"{len(unclaimed)} parameters of node '{module.name}' were "
+                "unfrozen but belong to no optimizer, so they will not be "
+                "trained."
+            )
+            return
+
+        _attach_parameter_group(fallback_optimizer, unclaimed, lr, {}, None)
 
     def traverse(
         self,
@@ -611,6 +688,7 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
         base_scheduler: SchedulerConfig | None = None,
         used_params: set[int] | None = None,
         include_default: bool = True,
+        group_splitter: GroupSplitter | None = None,
     ) -> tuple[
         Sequence[Optimizer],
         Sequence[LRSchedulerTypeUnion | LRSchedulerConfig],
@@ -631,6 +709,7 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
             base_scheduler,
             used_params=used_params,
             include_default=include_default,
+            group_splitter=group_splitter,
         )
         self._unfreeze_targets.clear()
         for plan in optimizer_plans:
@@ -642,17 +721,16 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
             if not configured_groups:
                 configured_groups = plan.parameter_groups
 
+            parameter_groups = [
+                {"params": group.trainable_parameters} | group.optimizer_params
+                for group in configured_groups
+            ]
             cfg_optimizer = OptimizerConfig(
                 name=plan.optimizer_name,
                 params=cast(
                     Params,
-                    {
-                        "params": [
-                            {"params": group.trainable_parameters}
-                            | group.optimizer_params
-                            for group in configured_groups
-                        ]
-                    },
+                    {"params": parameter_groups}
+                    | _shared_group_options(parameter_groups),
                 ),
             )
             optimizer, scheduler = build_optimizer_scheduler(
@@ -664,19 +742,15 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
             optimizers.append(optimizer)
             schedulers.append(scheduler)
 
-            configured_parameter_groups = {
-                id(group): parameter_group
-                for group, parameter_group in zip(
-                    configured_groups,
-                    optimizer.param_groups,
-                    strict=True,
-                )
+            configured_group_indices = {
+                id(group): index
+                for index, group in enumerate(configured_groups)
             }
             for group in plan.parameter_groups:
                 target = UnfreezeTarget(
                     optimizer=optimizer,
                     optimizer_params=group.optimizer_params,
-                    parameter_group=configured_parameter_groups.get(id(group)),
+                    group_index=configured_group_indices.get(id(group)),
                 )
                 for parameter in group.parameters:
                     if not parameter.requires_grad:
@@ -745,9 +819,12 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
                     callback.name == "GradientAccumulationScheduler"
                     and n_optimizers > 1
                 ):
-                    logger.warning(
-                        "Gradient accumulation scheduling is not supported for multiple optimizers. "
-                        "The callback will be ignored."
+                    logger.info(
+                        "Multiple optimizers are used, so training runs in "
+                        "manual optimization mode, where Lightning does not "
+                        "support the 'GradientAccumulationScheduler' "
+                        "callback. The configured schedule will be applied "
+                        "directly in the training step instead."
                     )
                     continue
                 callbacks.append(
@@ -779,6 +856,128 @@ class Nodes(dict[str, NodeWrapper] if TYPE_CHECKING else nn.ModuleDict):
                 )
 
         return callbacks
+
+
+_MISSING = object()
+
+
+def _options_equal(left: Any, right: Any) -> bool:
+    if left is _MISSING:
+        return False
+    if left is right:
+        return True
+    try:
+        return bool(left == right)
+    except Exception:  # pragma: no cover
+        return False
+
+
+def _shared_group_options(
+    parameter_groups: Sequence[Mapping[str, Any]],
+) -> Kwargs:
+    """Options that every parameter group agrees on.
+
+    These are also passed to the optimizer's constructor so that
+    arguments consumed only in C{__init__} (such as Adagrad's
+    C{initial_accumulator_value}) take effect, and so that the
+    constructor's own validation of the hyperparameters runs. The per-
+    group dicts keep the same values, so per-group overrides are
+    unaffected.
+    """
+    if not parameter_groups:
+        return {}
+    first, *rest = parameter_groups
+    return {
+        key: value
+        for key, value in first.items()
+        if key != "params"
+        and all(
+            _options_equal(group.get(key, _MISSING), value) for group in rest
+        )
+    }
+
+
+def _current_group_lr(
+    optimizer: Optimizer, group_index: int | None
+) -> float | None:
+    """Return the learning rate the optimizer currently uses.
+
+    Mirrors C{BaseFinetuning.unfreeze_and_add_param_group}: parameters
+    unfrozen mid-training join at the rate the scheduler has decayed to,
+    not at the initially configured one.
+    """
+    groups = optimizer.param_groups
+    if not groups:
+        return None
+    if group_index is not None and 0 <= group_index < len(groups):
+        group = groups[group_index]
+    else:
+        group = groups[0]
+    lr = group.get("lr")
+    return None if lr is None else float(lr)
+
+
+def _attach_parameter_group(
+    optimizer: Optimizer,
+    parameters: list[nn.Parameter],
+    lr: float | None,
+    optimizer_params: Kwargs,
+    group_index: int | None,
+) -> None:
+    """Add parameters to an optimizer as a new parameter group.
+
+    Always a *new* group: extending an existing one in place is
+    invisible to C{BaseFinetuning._store}, which only records groups
+    appended past the ones it already knows about. The stale metadata
+    would then drop the parameters when training is resumed.
+    """
+    existing_ids = {
+        id(parameter)
+        for group in optimizer.param_groups
+        for parameter in group["params"]
+    }
+    parameters = [
+        parameter
+        for parameter in parameters
+        if id(parameter) not in existing_ids
+    ]
+    if not parameters:
+        return
+
+    parameter_group: dict[str, Any] = {"params": parameters} | optimizer_params
+    if lr is None:
+        lr = _current_group_lr(optimizer, group_index)
+    if lr is not None:
+        parameter_group["lr"] = float(lr)
+    optimizer.add_param_group(parameter_group)
+
+
+def get_gradient_accumulation_schedule(cfg: Config) -> dict[int, int] | None:
+    """Return the configured gradient accumulation schedule as C{{epoch:
+    factor}}.
+
+    Lightning refuses to accumulate gradients itself under manual
+    optimization, so with more than one optimizer the schedule has to be
+    applied by hand in the training step.
+    """
+    for callback in cfg.trainer.callbacks:
+        if (
+            callback.active
+            and callback.name == "GradientAccumulationScheduler"
+        ):
+            scheduling = callback.params.get("scheduling")
+            if isinstance(scheduling, Mapping):
+                schedule = {
+                    int(epoch): int(factor)
+                    for epoch, factor in scheduling.items()
+                    if isinstance(epoch, int | str)
+                    and isinstance(factor, int | str)
+                }
+                if schedule:
+                    return schedule
+    if cfg.trainer.accumulate_grad_batches is not None:
+        return {0: int(cfg.trainer.accumulate_grad_batches)}
+    return None
 
 
 def compute_losses(

--- a/luxonis_train/nodes/heads/ocr_ctc_head.py
+++ b/luxonis_train/nodes/heads/ocr_ctc_head.py
@@ -1,5 +1,6 @@
 import math
 
+from loguru import logger
 from luxonis_ml.typing import Params
 from torch import Tensor, nn
 from torch.nn import functional as F
@@ -22,6 +23,7 @@ class OCRCTCHead(BaseHead):
         ignore_unknown: bool = True,
         mid_channels: int | None = None,
         return_feats: bool = False,
+        fc_decay: float | None = None,
         **kwargs,
     ):
         """OCR CTC head.
@@ -44,10 +46,29 @@ class OCRCTCHead(BaseHead):
         @type return_feats: bool
         @param return_feats: Whether to return features. Defaults to
             False.
+        @type fc_decay: float | None
+        @param fc_decay: Deprecated and ignored. It never had any effect
+            on training. Use a C{finetuning} entry with a
+            C{weight_decay} optimizer parameter to regularize the fully
+            connected layers instead.
         """
         super().__init__(**kwargs)
         if len(set(alphabet)) != len(alphabet):  # pragma: no cover
             raise ValueError("Alphabet has duplicate characters.")
+
+        if fc_decay is not None:
+            logger.warning(
+                "The `fc_decay` parameter of 'OCRCTCHead' is deprecated "
+                "and has no effect. It never applied any regularization. "
+                "Use a `finetuning` entry on the node to set "
+                "`weight_decay` for the fully connected layers instead:\n"
+                "  finetuning:\n"
+                "    - parameters:\n"
+                "        module_type: Linear\n"
+                "      optimizer:\n"
+                "        params:\n"
+                f"          weight_decay: {fc_decay}"
+            )
 
         self.return_feats = return_feats
 

--- a/luxonis_train/strategies/base_strategy.py
+++ b/luxonis_train/strategies/base_strategy.py
@@ -5,7 +5,9 @@ from lightning.pytorch.utilities.types import (
     LRSchedulerConfig,
     LRSchedulerTypeUnion,
 )
+from luxonis_ml.typing import Kwargs
 from luxonis_ml.utils.registry import AutoRegisterMeta
+from torch import nn
 from torch.optim import Optimizer
 
 import luxonis_train as lxt
@@ -38,3 +40,46 @@ class BaseTrainingStrategy(
     ) -> int:
         _ = excluded_params
         return 1
+
+    def attach_optimizers(self, optimizers: Sequence[Optimizer]) -> None:
+        """Register optimizers that were built outside of the strategy.
+
+        Parameters claimed by C{finetuning} rules end up in their own
+        optimizers, which the strategy does not own. Strategies that
+        adjust learning rates during training should override this to
+        keep those optimizers in sync with their own.
+
+        @type optimizers: Sequence[Optimizer]
+        @param optimizers: The optimizers built from the C{finetuning}
+            rules.
+        """
+        _ = optimizers
+
+    def split_parameter_group(
+        self,
+        parameters: list[tuple[nn.Module, nn.Parameter]],
+        optimizer_params: Kwargs,
+        explicit_keys: set[str],
+    ) -> list[tuple[list[nn.Parameter], Kwargs]]:
+        """Split the parameters matched by one C{finetuning} rule into
+        optimizer parameter groups.
+
+        Strategies that apply different optimizer options depending on
+        the kind of parameter should override this, so that rules
+        inheriting the strategy's base config do not silently get
+        options the strategy itself would never apply.
+
+        @type parameters: list[tuple[nn.Module, nn.Parameter]]
+        @param parameters: The matched parameters together with the
+            module that owns them.
+        @type optimizer_params: Kwargs
+        @param optimizer_params: The optimizer options of the rule,
+            already merged with the strategy's base config.
+        @type explicit_keys: set[str]
+        @param explicit_keys: Options the user set on the rule itself.
+            These must be left alone, as they express explicit intent.
+        @rtype: list[tuple[list[nn.Parameter], Kwargs]]
+        @return: One entry per parameter group to create.
+        """
+        _ = explicit_keys
+        return [([parameter for _, parameter in parameters], optimizer_params)]

--- a/luxonis_train/strategies/triple_lr_sgd.py
+++ b/luxonis_train/strategies/triple_lr_sgd.py
@@ -1,8 +1,10 @@
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast
 
 import numpy as np
+from luxonis_ml.typing import Kwargs
 from torch import nn
 from torch.optim import SGD
 from torch.optim.lr_scheduler import LambdaLR
@@ -13,6 +15,25 @@ import luxonis_train as lxt
 from luxonis_train.config.config import OptimizerConfig, SchedulerConfig
 
 from .base_strategy import BaseTrainingStrategy
+
+
+def _optional_float(value: object) -> float | None:
+    return None if value is None else float(cast(float, value))
+
+
+def is_undecayed_parameter(module: nn.Module, parameter: nn.Parameter) -> bool:
+    """Whether L{TripleLRSGD} leaves this parameter out of weight decay.
+
+    Mirrors the grouping done by L{TripleLRSGD.parameter_groups}, where
+    only regular weights are decayed while biases and BatchNorm weights
+    are not.
+    """
+    if getattr(module, "bias", None) is parameter:
+        return True
+    return (
+        isinstance(module, nn.BatchNorm2d)
+        and getattr(module, "weight", None) is parameter
+    )
 
 
 @dataclass
@@ -31,6 +52,8 @@ class TripleLRScheduler:
             round(self.warmup_epochs * self.max_stepnum), 100
         )
         self.step = 0
+        self.external_optimizers: list[Optimizer] = []
+        self.external_targets: list[list[tuple[float, float | None]]] = []
         self.lrf = self.lre / self.optimizer.defaults["lr"]
         if self.cosine_annealing:
             self.lf = lambda x: (
@@ -45,6 +68,22 @@ class TripleLRScheduler:
 
     def create_scheduler(self) -> LambdaLR:
         return LambdaLR(self.optimizer, lr_lambda=self.lf)
+
+    def attach_optimizers(self, optimizers: Sequence[Optimizer]) -> None:
+        """Record the optimizers built from the C{finetuning} rules so
+        that warmup covers them too.
+
+        Their configured learning rate and momentum are captured now,
+        because warmup overwrites both on every step.
+        """
+        self.external_optimizers = list(optimizers)
+        self.external_targets = [
+            [
+                (float(group["lr"]), _optional_float(group.get("momentum")))
+                for group in optimizer.param_groups
+            ]
+            for optimizer in optimizers
+        ]
 
     def update_learning_rate(self, current_epoch: int) -> None:
         self.step = self.step % self.max_stepnum
@@ -68,7 +107,31 @@ class TripleLRScheduler:
                         [0, self.warmup_stepnum],
                         [self.warmup_momentum, momentum],
                     )
+            self._warmup_external_optimizers(curr_step, current_epoch)
         self.step += 1
+
+    def _warmup_external_optimizers(
+        self, curr_step: int, current_epoch: int
+    ) -> None:
+        for optimizer, targets in zip(
+            self.external_optimizers, self.external_targets, strict=True
+        ):
+            # Groups added after `attach_optimizers` (by unfreezing) have
+            # no recorded target, so `zip` leaves them untouched.
+            for param, (lr, momentum) in zip(
+                optimizer.param_groups, targets, strict=False
+            ):
+                param["lr"] = np.interp(
+                    curr_step,
+                    [0, self.warmup_stepnum],
+                    [0.0, lr * self.lf(current_epoch)],
+                )
+                if momentum is not None and "momentum" in param:
+                    param["momentum"] = np.interp(
+                        curr_step,
+                        [0, self.warmup_stepnum],
+                        [self.warmup_momentum, momentum],
+                    )
 
 
 @dataclass
@@ -191,6 +254,7 @@ class TripleLRSGDStrategy(BaseTrainingStrategy):
             len(self.model.core.loaders["train"]) / self.cfg.trainer.batch_size
         )
         self._excluded_params: set[int] = set()
+        self._external_optimizers: list[Optimizer] = []
         self._build_optimizer_scheduler()
 
     def _build_optimizer_scheduler(
@@ -216,6 +280,9 @@ class TripleLRSGDStrategy(BaseTrainingStrategy):
             epochs=self.cfg.trainer.epochs,
             max_stepnum=self.max_stepnum,
         )
+        # `configure_optimizers` can rebuild the scheduler after the
+        # finetuning optimizers were attached, so re-attach them here.
+        self.scheduler.attach_optimizers(self._external_optimizers)
 
     @override
     def get_base_configs(self) -> tuple[OptimizerConfig, SchedulerConfig]:
@@ -231,6 +298,53 @@ class TripleLRSGDStrategy(BaseTrainingStrategy):
             name="LambdaLR",
             params={"lr_lambda": self.scheduler.lf},  # type: ignore
         )
+
+    @override
+    def attach_optimizers(self, optimizers: Sequence[Optimizer]) -> None:
+        self._external_optimizers = list(optimizers)
+        self.scheduler.attach_optimizers(self._external_optimizers)
+
+    @override
+    def split_parameter_group(
+        self,
+        parameters: list[tuple[nn.Module, nn.Parameter]],
+        optimizer_params: Kwargs,
+        explicit_keys: set[str],
+    ) -> list[tuple[list[nn.Parameter], Kwargs]]:
+        """Keep the strategy's own rule that biases and BatchNorm
+        weights are never decayed.
+
+        Without this, a C{finetuning} rule inheriting C{weight_decay}
+        from L{get_base_configs} would apply it to every parameter it
+        matched, including the ones L{TripleLRSGD.create_optimizer}
+        deliberately leaves undecayed. A C{weight_decay} the user set on
+        the rule itself is honored as written.
+        """
+        if (
+            "weight_decay" not in optimizer_params
+            or "weight_decay" in explicit_keys
+            or not optimizer_params["weight_decay"]
+        ):
+            return [
+                ([parameter for _, parameter in parameters], optimizer_params)
+            ]
+
+        decayed: list[nn.Parameter] = []
+        undecayed: list[nn.Parameter] = []
+        for module, parameter in parameters:
+            if is_undecayed_parameter(module, parameter):
+                undecayed.append(parameter)
+            else:
+                decayed.append(parameter)
+
+        groups = []
+        if decayed:
+            groups.append((decayed, optimizer_params))
+        if undecayed:
+            groups.append(
+                (undecayed, optimizer_params | {"weight_decay": 0.0})
+            )
+        return groups
 
     @override
     def configure_optimizers(

--- a/tests/unittests/test_finetuning/test_review_fixes.py
+++ b/tests/unittests/test_finetuning/test_review_fixes.py
@@ -1,0 +1,721 @@
+"""Regression tests for the invariants the parameter-groups rework
+initially dropped.
+
+Each test reproduces a concrete way training used to go silently wrong
+and asserts the restored behaviour.
+"""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+from lightning.pytorch.callbacks import BaseFinetuning
+from luxonis_ml.typing import Params
+from torch import Size, nn
+from torch.optim import SGD, Adagrad, Optimizer
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
+import luxonis_train as lxt
+from luxonis_train.callbacks import TrainingManager
+from luxonis_train.config import Config
+from luxonis_train.config.config import SchedulerConfig, SequentialLRParams
+from luxonis_train.lightning.utils import get_gradient_accumulation_schedule
+
+from ._helpers import config, node, tiny_head_node
+
+TRIPLE_LR = {"name": "TripleLRSGDStrategy", "params": {"lr": 0.02}}
+
+
+def build(cfg: Params, opts: Params) -> lxt.LuxonisModel:
+    return lxt.LuxonisModel(
+        deepcopy(cfg),
+        opts | {"loader.params.n_classes": 10},
+        allow_empty_dataset=True,
+    )
+
+
+def frozen_node(name: str, unfreeze_after: int = 1, **extra: Any) -> Params:
+    node_cfg = node(name)
+    node_cfg["freezing"] = {"active": True, "unfreeze_after": unfreeze_after}
+    node_cfg.update(extra)
+    return node_cfg
+
+
+def optimized_ids(optimizers: list[Optimizer]) -> set[int]:
+    return {
+        id(parameter)
+        for optimizer in optimizers
+        for group in optimizer.param_groups
+        for parameter in group["params"]
+    }
+
+
+def trainable_ids(module: nn.Module) -> set[int]:
+    return {
+        id(parameter)
+        for parameter in module.parameters()
+        if parameter.requires_grad
+    }
+
+
+def unfreeze(
+    module: "lxt.LuxonisLightningModule",
+    optimizers: list[Optimizer],
+    epoch: int = 1,
+) -> TrainingManager:
+    """Run the freeze/unfreeze cycle the way Lightning drives it."""
+    manager = TrainingManager()
+    manager.finetune_function(module, epoch, optimizers[0])
+    return manager
+
+
+def test_unfrozen_parameters_are_never_orphaned_with_a_strategy(
+    opts: Params,
+):
+    """A frozen node with no ``finetuning`` entry of its own used to end
+    up in no optimizer at all once a training strategy and any
+    ``finetuning`` entry were combined.
+
+    The strategy skips frozen parameters and only claims what is left
+    over, and the strategy path builds node optimizers with
+    ``include_default=False``, so nothing registered an unfreeze target
+    for that node. Its weights then stayed at their initial values for
+    the whole run, silently.
+    """
+    model = build(
+        config(
+            [
+                frozen_node("Backbone"),
+                node("Neck"),
+                node(
+                    "Head",
+                    {
+                        "parameters": [{"module_type": "Linear"}],
+                        "optimizer": {"name": "SGD", "params": {"lr": 0.01}},
+                    },
+                ),
+            ],
+            trainer={"training_strategy": TRIPLE_LR},
+        ),
+        opts,
+    )
+    module = model.lightning_module
+
+    manager = TrainingManager()
+    manager.freeze_before_training(module)
+    optimizers, _ = module.configure_optimizers()
+    optimizers = list(optimizers)
+
+    backbone = module.nodes["Backbone"].module
+    assert not any(p.requires_grad for p in backbone.parameters())
+
+    manager.finetune_function(module, 1, optimizers[0])
+
+    assert all(p.requires_grad for p in backbone.parameters())
+    orphaned = trainable_ids(module) - optimized_ids(optimizers)
+    assert orphaned == set()
+
+
+def test_unfreezing_adds_a_new_parameter_group(opts: Params):
+    """``BaseFinetuning._store`` only records parameter groups appended
+    past the ones it already knows about.
+
+    Extending an existing group in place therefore left the checkpoint
+    metadata stale, and resuming a run would drop the newly unfrozen
+    parameters from the optimizer entirely.
+    """
+    head = tiny_head_node(
+        {
+            "parameters": [{"module_type": "Linear"}],
+            "optimizer": {"name": "SGD", "params": {"lr": 0.02}},
+        }
+    )
+    head["freezing"] = {"active": True, "unfreeze_after": 1}
+    model = build(config([head]), opts)
+    module = model.lightning_module
+
+    manager = TrainingManager()
+    manager.freeze_before_training(module)
+    optimizers, _ = module.configure_optimizers()
+    optimizers = list(optimizers)
+
+    before = [len(optimizer.param_groups) for optimizer in optimizers]
+    manager.finetune_function(module, 1, optimizers[0])
+    after = [len(optimizer.param_groups) for optimizer in optimizers]
+
+    assert sum(after) > sum(before)
+    assert trainable_ids(module) <= optimized_ids(optimizers)
+
+
+def test_unfreezing_survives_param_groups_being_rebuilt(opts: Params):
+    """On resume, ``BaseFinetuning.on_fit_start`` replaces
+    ``optimizer.param_groups`` with freshly built dicts.
+
+    Holding on to a group dict captured at build time would leave the
+    unfrozen parameters in a detached dict that no optimizer reads.
+    """
+    head = tiny_head_node(
+        {
+            "parameters": [{"module_type": "Linear"}],
+            "optimizer": {"name": "SGD", "params": {"lr": 0.02}},
+        }
+    )
+    head["freezing"] = {"active": True, "unfreeze_after": 1}
+    model = build(config([head]), opts)
+    module = model.lightning_module
+
+    manager = TrainingManager()
+    manager.freeze_before_training(module)
+    optimizers, _ = module.configure_optimizers()
+    optimizers = list(optimizers)
+
+    # What `on_fit_start` does when restarting: rebuild every group dict
+    # from the stored metadata.
+    named_parameters = dict(module.named_parameters())
+    for optimizer in optimizers:
+        mapping = {p: n for n, p in named_parameters.items()}
+        metadata = BaseFinetuning._apply_mapping_to_param_groups(
+            optimizer.param_groups, mapping
+        )
+        optimizer.param_groups = BaseFinetuning._apply_mapping_to_param_groups(
+            metadata, named_parameters
+        )
+
+    manager.finetune_function(module, 1, optimizers[0])
+
+    assert trainable_ids(module) <= optimized_ids(optimizers)
+
+
+def test_unfreeze_uses_the_current_learning_rate(opts: Params):
+    """Without an explicit ``lr_after_unfreeze`` the parameters must
+    join at the rate the scheduler has decayed to.
+
+    Using the configured initial rate instead would hand freshly
+    unfrozen pretrained weights a learning-rate jump exactly at the
+    unfreeze epoch. The frozen node here has no ``finetuning`` entry, so
+    its parameters form their own group with no trainable member, which
+    is the case that took the configured rate verbatim.
+    """
+    model = build(
+        config(
+            [frozen_node("Backbone"), node("Neck"), node("Head")],
+            trainer={"optimizer": {"name": "SGD", "params": {"lr": 0.02}}},
+        ),
+        opts,
+    )
+    module = model.lightning_module
+
+    manager = TrainingManager()
+    manager.freeze_before_training(module)
+    optimizers, _ = module.configure_optimizers()
+    optimizers = list(optimizers)
+
+    # Stand in for a scheduler having decayed the rate by the time the
+    # node is unfrozen.
+    for optimizer in optimizers:
+        for group in optimizer.param_groups:
+            group["lr"] = 0.01
+    group_counts = [len(optimizer.param_groups) for optimizer in optimizers]
+
+    manager.finetune_function(module, 1, optimizers[0])
+
+    added = [
+        group
+        for optimizer, count in zip(optimizers, group_counts, strict=True)
+        for group in optimizer.param_groups[count:]
+    ]
+    assert added, "unfrozen parameters must be added as a new group"
+    for group in added:
+        assert group["lr"] == pytest.approx(0.01)
+
+
+def test_explicit_lr_after_unfreeze_still_wins(opts: Params):
+    head = tiny_head_node()
+    head["freezing"] = {
+        "active": True,
+        "unfreeze_after": 1,
+        "lr_after_unfreeze": 0.007,
+    }
+    model = build(config([head]), opts)
+    module = model.lightning_module
+
+    manager = TrainingManager()
+    manager.freeze_before_training(module)
+    optimizers, _ = module.configure_optimizers()
+    optimizers = list(optimizers)
+    before = len(optimizers[0].param_groups)
+
+    manager.finetune_function(module, 1, optimizers[0])
+
+    added = optimizers[0].param_groups[before:]
+    assert added
+    assert all(group["lr"] == pytest.approx(0.007) for group in added)
+
+
+def test_constructor_only_optimizer_arguments_are_applied(opts: Params):
+    """Hyperparameters used to travel only inside the per-group dicts,
+    so arguments a torch optimizer consumes in ``__init__`` were
+    silently dropped.
+
+    ``Adagrad`` seeds its accumulator state from
+    ``initial_accumulator_value`` in the constructor and ignores the key
+    when it appears on a parameter group.
+    """
+    model = build(
+        config(
+            [tiny_head_node()],
+            trainer={
+                "optimizer": {
+                    "name": "Adagrad",
+                    "params": {
+                        "lr": 0.01,
+                        "initial_accumulator_value": 0.7,
+                    },
+                }
+            },
+        ),
+        opts,
+    )
+    optimizers, _ = model.lightning_module.configure_optimizers()
+    optimizer = next(iter(optimizers))
+    assert isinstance(optimizer, Adagrad)
+
+    sums = [
+        optimizer.state[parameter]["sum"]
+        for group in optimizer.param_groups
+        for parameter in group["params"]
+    ]
+    assert sums
+    assert all(
+        torch.allclose(value, torch.full_like(value, 0.7)) for value in sums
+    )
+
+
+def test_invalid_optimizer_hyperparameters_are_rejected(opts: Params):
+    """Passing the options to the constructor also restores torch's own
+    validation, which never ran while they lived on group dicts only.
+    """
+    model_config = config(
+        [tiny_head_node()],
+        trainer={
+            "optimizer": {
+                "name": "SGD",
+                "params": {"lr": 0.01, "nesterov": True, "momentum": 0},
+            }
+        },
+    )
+    model = build(model_config, opts)
+    with pytest.raises(ValueError, match=r"[Nn]esterov"):
+        model.lightning_module.configure_optimizers()
+
+
+def test_no_trainable_parameters_raises_a_clear_error(opts: Params):
+    """An empty optimizer list used to reach Lightning's training loop
+    and die there with ``IndexError: list index out of range``.
+    """
+    model = build(config([tiny_head_node()]), opts)
+    module = model.lightning_module
+    for parameter in module.parameters():
+        parameter.requires_grad = False
+
+    with pytest.raises(ValueError, match="no parameter of the model"):
+        module.configure_optimizers()
+
+
+def test_automatic_optimization_is_restored_between_runs(opts: Params):
+    """``automatic_optimization`` lives on the module, so leaving it at
+    ``False`` leaked into later ``fit`` calls and made Lightning reject
+    ``gradient_clip_val`` that the user never changed.
+    """
+    model = build(
+        config(
+            [
+                tiny_head_node(
+                    {
+                        "parameters": [{"module_type": "Linear"}],
+                        "optimizer": {"name": "SGD"},
+                    }
+                )
+            ]
+        ),
+        opts,
+    )
+    module = model.lightning_module
+
+    optimizers, _ = module.configure_optimizers()
+    assert len(list(optimizers)) > 1
+    assert module.automatic_optimization is False
+
+    # A second `configure_optimizers` that yields a single optimizer
+    # must hand the flag back.
+    module.nodes["Head"].finetuning = []
+    optimizers, _ = module.configure_optimizers()
+    assert len(list(optimizers)) == 1
+    assert module.automatic_optimization is True
+
+
+def test_expected_optimizer_count_accounts_for_freezing(opts: Params):
+    """``configure_callbacks`` runs before ``TrainingManager`` freezes
+    anything, so counting optimizers against the live ``requires_grad``
+    flags overestimated and silently disabled gradient accumulation.
+    """
+    model = build(
+        config(
+            [
+                # Every unfrozen parameter is claimed by a rule, so once
+                # the Backbone is frozen the strategy has nothing left
+                # and contributes no optimizer of its own.
+                frozen_node("Backbone"),
+                node(
+                    "Neck",
+                    {
+                        "parameters": [{"name": ".*"}],
+                        "optimizer": {"name": "SGD", "params": {"lr": 0.01}},
+                    },
+                ),
+                node(
+                    "Head",
+                    {
+                        "parameters": [{"name": ".*"}],
+                        "optimizer": {"name": "SGD", "params": {"lr": 0.01}},
+                    },
+                ),
+            ],
+            trainer={
+                "training_strategy": TRIPLE_LR,
+                "accumulate_grad_batches": 4,
+            },
+        ),
+        opts,
+    )
+    module = model.lightning_module
+
+    estimated = module._expected_optimizer_count()
+
+    TrainingManager().freeze_before_training(module)
+    optimizers, _ = module.configure_optimizers()
+
+    assert estimated == len(list(optimizers))
+
+
+def test_gradient_accumulation_is_applied_under_manual_optimization(
+    opts: Params, monkeypatch: pytest.MonkeyPatch
+):
+    """Lightning refuses to accumulate gradients itself under manual
+    optimization, so the configured factor has to be honoured in the
+    training step.
+
+    Dropping it silently was actively harmful for predefined models,
+    whose loss weights ``smart_cfg_auto_populate`` has already scaled by
+    the very same factor.
+    """
+    model = build(
+        config(
+            [
+                tiny_head_node(
+                    {
+                        "parameters": [{"module_type": "Linear"}],
+                        "optimizer": {"name": "SGD"},
+                    }
+                )
+            ],
+            trainer={"accumulate_grad_batches": 3},
+        ),
+        opts,
+    )
+    module = model.lightning_module
+    optimizers, _ = module.configure_optimizers()
+    optimizers = list(optimizers)
+    assert module.automatic_optimization is False
+    assert module._accumulation_factor() == 3
+
+    backward_losses: list[float] = []
+    steps: list[int] = []
+
+    monkeypatch.setattr(
+        module,
+        "compute_training_loss",
+        lambda _batch: torch.tensor(3.0, requires_grad=True),
+    )
+    monkeypatch.setattr(
+        module, "optimizers", lambda *_a, **_k: list(optimizers)
+    )
+    monkeypatch.setattr(module, "lr_schedulers", list)
+    monkeypatch.setattr(
+        module,
+        "manual_backward",
+        lambda loss: backward_losses.append(float(loss)),
+    )
+    for index, optimizer in enumerate(optimizers):
+        monkeypatch.setattr(
+            optimizer, "step", lambda index=index: steps.append(index)
+        )
+        monkeypatch.setattr(optimizer, "zero_grad", lambda: None)
+    module._trainer = SimpleNamespace(  # type: ignore[assignment]
+        is_last_batch=False, current_epoch=0
+    )
+
+    for batch_idx in range(6):
+        module.training_step((torch.empty(0), {}), batch_idx=batch_idx)
+
+    # The loss is normalized the same way automatic optimization does.
+    assert backward_losses == [pytest.approx(1.0)] * 6
+    # Two accumulation windows over six batches, each optimizer stepping
+    # once per window.
+    assert len(steps) == 2 * len(optimizers)
+
+
+def test_gradient_accumulation_schedule_is_read_from_the_callback():
+    cfg = Config.get_config(
+        config(
+            [tiny_head_node()],
+            trainer={
+                "callbacks": [
+                    {
+                        "name": "GradientAccumulationScheduler",
+                        "params": {"scheduling": {0: 1, 2: 4}},
+                    }
+                ]
+            },
+        )
+    )
+    assert get_gradient_accumulation_schedule(cfg) == {0: 1, 2: 4}
+
+
+def test_accumulate_grad_batches_is_read_when_no_callback_is_set():
+    cfg = Config.get_config(
+        config([tiny_head_node()], trainer={"accumulate_grad_batches": 8})
+    )
+    assert get_gradient_accumulation_schedule(cfg) == {0: 8}
+
+
+def test_global_gradient_clipping_scales_with_the_whole_model(
+    opts: Params, monkeypatch: pytest.MonkeyPatch
+):
+    """Clipping each optimizer separately let the total applied norm
+    grow with the number of optimizers.
+
+    With two optimizers each holding a unit-norm gradient, per-optimizer
+    clipping to 1.0 would be a no-op while a global clip has to scale
+    both down.
+    """
+    model = build(
+        config(
+            [
+                tiny_head_node(
+                    {
+                        "parameters": [{"module_type": "Linear"}],
+                        "optimizer": {"name": "SGD"},
+                    }
+                )
+            ],
+            trainer={"gradient_clip_val": 1.0},
+        ),
+        opts,
+    )
+    module = model.lightning_module
+    optimizers, _ = module.configure_optimizers()
+    assert len(list(optimizers)) > 1
+
+    parameters = [p for p in module.parameters() if p.requires_grad]
+    for parameter in parameters:
+        parameter.grad = torch.zeros_like(parameter)
+    # Two parameters carrying a unit-norm gradient each: total norm √2.
+    parameters[0].grad.view(-1)[0] = 1.0
+    parameters[-1].grad.view(-1)[0] = 1.0
+
+    module._clip_gradients_globally()
+
+    total_norm = torch.linalg.vector_norm(
+        torch.stack(
+            [
+                torch.linalg.vector_norm(p.grad.detach())
+                for p in parameters
+                if p.grad is not None
+            ]
+        )
+    )
+    assert float(total_norm) == pytest.approx(1.0, abs=1e-5)
+
+
+def test_plateau_scheduler_reduces_the_loss_across_ranks(
+    opts: Params, monkeypatch: pytest.MonkeyPatch
+):
+    """The loss accumulator is rank-local.
+
+    Stepping ``ReduceLROnPlateau`` with it would let ranks disagree
+    about when to decay, and learning rates are optimizer state DDP
+    never re-synchronizes.
+    """
+    model = build(config([tiny_head_node()]), opts)
+    module = model.lightning_module
+    module.automatic_optimization = False
+
+    reduced: list[float] = []
+
+    def fake_reduce(tensor: torch.Tensor, reduce_op: str = "mean") -> Any:
+        reduced.append(float(tensor))
+        assert reduce_op == "mean"
+        return torch.tensor(0.25)
+
+    module._trainer = SimpleNamespace(  # type: ignore[assignment]
+        world_size=2,
+        strategy=SimpleNamespace(reduce=fake_reduce),
+    )
+
+    optimizer = SGD([nn.Parameter(torch.zeros(1))], lr=0.1)
+    plateau = ReduceLROnPlateau(optimizer, mode="min")
+    stepped: list[float] = []
+    monkeypatch.setattr(plateau, "step", stepped.append)
+    monkeypatch.setattr(module, "lr_schedulers", lambda: plateau)
+
+    module._step_reduce_lr_on_plateau_schedulers(
+        loss=0.42, metrics={"Head": {"Accuracy": 0.9}}
+    )
+
+    assert reduced == [pytest.approx(0.42)]
+    assert stepped == [pytest.approx(0.25)]
+
+
+def test_strategy_base_weight_decay_skips_biases_and_batchnorm(
+    opts: Params,
+):
+    """``TripleLRSGD`` deliberately decays only regular weights.
+
+    A ``finetuning`` rule inheriting ``weight_decay`` from the
+    strategy's base config used to apply it to every parameter it
+    matched, turning on exactly the regularisation the strategy avoids.
+    """
+    model = build(
+        config(
+            [tiny_head_node({"parameters": [{"name": ".*"}]})],
+            trainer={"training_strategy": TRIPLE_LR},
+        ),
+        opts,
+    )
+    module = model.lightning_module
+    optimizers, _ = module.configure_optimizers()
+    inherited = next(iter(optimizers))
+
+    names = {id(p): name for name, p in module.named_parameters()}
+    decay_by_name = {
+        names[id(parameter)]: group["weight_decay"]
+        for group in inherited.param_groups
+        for parameter in group["params"]
+    }
+    assert decay_by_name
+
+    biases = [n for n in decay_by_name if n.endswith(".bias")]
+    weights = [n for n in decay_by_name if n.endswith(".weight")]
+    assert biases
+    assert weights
+
+    for name in biases:
+        assert decay_by_name[name] == pytest.approx(0.0), name
+    for name in weights:
+        assert decay_by_name[name] == pytest.approx(0.0005), name
+
+
+def test_explicit_weight_decay_on_a_rule_is_left_alone(opts: Params):
+    """Leave a ``weight_decay`` written on the rule itself alone.
+
+    The split only applies to one inherited from the strategy; one the
+    user wrote expresses explicit intent.
+    """
+    model = build(
+        config(
+            [
+                tiny_head_node(
+                    {
+                        "parameters": [{"module_type": "Linear"}],
+                        "optimizer": {"params": {"weight_decay": 0.0004}},
+                    }
+                )
+            ],
+            trainer={"training_strategy": TRIPLE_LR},
+        ),
+        opts,
+    )
+    optimizers, _ = model.lightning_module.configure_optimizers()
+    groups = [
+        group
+        for group in next(iter(optimizers)).param_groups
+        if group["params"]
+    ]
+    assert groups
+    assert all(
+        group["weight_decay"] == pytest.approx(0.0004) for group in groups
+    )
+
+
+def test_strategy_warmup_covers_finetuning_optimizers(opts: Params):
+    """``update_parameters`` only touched the strategy's own optimizer,
+    so parameters claimed by ``finetuning`` rules started at full
+    learning rate while the rest of the model was still warming up.
+    """
+    model = build(
+        config(
+            [tiny_head_node({"parameters": [{"module_type": "Linear"}]})],
+            trainer={"training_strategy": TRIPLE_LR},
+        ),
+        opts,
+    )
+    module = model.lightning_module
+    optimizers, _ = module.configure_optimizers()
+    finetuning_optimizer = next(iter(optimizers))
+
+    configured = [group["lr"] for group in finetuning_optimizer.param_groups]
+    assert all(lr > 0 for lr in configured)
+
+    assert module.training_strategy is not None
+    module.training_strategy.update_parameters()
+
+    warmed = [group["lr"] for group in finetuning_optimizer.param_groups]
+    assert all(lr < configured[i] for i, lr in enumerate(warmed))
+
+
+def test_sequential_lr_scheduler_requires_a_name():
+    """``SchedulerConfig.name`` gained a default, which turned a missing
+    name on a nested ``SequentialLR`` entry into a silent ``ConstantLR``
+    instead of a validation error.
+    """
+    with pytest.raises(ValueError, match="`name`"):
+        SequentialLRParams(
+            schedulers=[
+                {"name": "LinearLR", "params": {"total_iters": 5}},  # type: ignore[list-item]
+                {"params": {"T_max": 100}},  # type: ignore[list-item]
+            ],
+            milestones=[5],
+        )
+
+
+def test_scheduler_params_without_a_name_are_rejected():
+    with pytest.raises(ValueError, match="without a `name`"):
+        SchedulerConfig(params={"T_max": 100})
+
+    # The default stays usable when nothing is configured.
+    assert SchedulerConfig().name == "ConstantLR"
+    assert SchedulerConfig(name="StepLR", params={"step_size": 1}).params
+
+
+def test_ocr_head_still_accepts_the_removed_fc_decay():
+    """``fc_decay`` was a public node parameter.
+
+    Removing it outright turned every existing OCR config into a
+    ``TypeError`` at model construction, since nodes take no
+    ``**kwargs`` catch-all. It is accepted again, ignored, and reported.
+    """
+    from luxonis_train.nodes.heads.ocr_ctc_head import OCRCTCHead
+
+    head = OCRCTCHead(
+        alphabet=["a", "b", "c"],
+        fc_decay=0.0004,
+        input_shapes=[{"features": [Size((4, 8, 1, 16))]}],
+        original_in_shape=Size((3, 32, 128)),
+        task_name="ocr",
+    )
+    assert isinstance(head, OCRCTCHead)
+    # Ignored, not stored: it never applied any regularization.
+    assert not hasattr(head, "fc_decay")

--- a/tests/unittests/test_finetuning/test_strategy.py
+++ b/tests/unittests/test_finetuning/test_strategy.py
@@ -267,9 +267,12 @@ def test_manual_multi_optimizer_training_step_clips_gradients(
     opts: Params, monkeypatch: pytest.MonkeyPatch
 ):
     """Under manual optimization (multi-optimizer path) Lightning
-    doesn't clip gradients for us — the training step must call
-    ``clip_gradients`` once per optimizer with the configured value and
-    algorithm.
+    doesn't clip gradients for us — the training step must clip the
+    whole model *once*, exactly like automatic optimization does.
+
+    Clipping each optimizer separately would let the total applied
+    gradient scale with the number of optimizers, so adding a single
+    ``finetuning`` entry could make a previously converging run diverge.
 
     Setup:
         Head rule targeting Linear with SGD (forces two optimizers →
@@ -277,9 +280,9 @@ def test_manual_multi_optimizer_training_step_clips_gradients(
         ``gradient_clip_algorithm='value'``.
 
     Expected result:
-        ``automatic_optimization`` flipped to ``False`` and
-        ``clip_gradients`` was invoked once for each configured
-        optimizer with the exact ``(1.5, 'value')`` arguments.
+        ``automatic_optimization`` flipped to ``False`` and the clipping
+        happened in a single call covering every parameter that has a
+        gradient, rather than once per optimizer.
     """
     model = _build_model(
         config(
@@ -300,7 +303,7 @@ def test_manual_multi_optimizer_training_step_clips_gradients(
     )
     module = model.lightning_module
     optimizers, _ = module.configure_optimizers()
-    calls: list[tuple[Optimizer, float, str]] = []
+    calls: list[tuple[set[int], float]] = []
     optimizer_accesses: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     monkeypatch.setattr(
@@ -327,21 +330,25 @@ def test_manual_multi_optimizer_training_step_clips_gradients(
     monkeypatch.setattr(module, "lr_schedulers", list)
     monkeypatch.setattr(module, "manual_backward", lambda _loss: None)
     monkeypatch.setattr(
-        module,
-        "clip_gradients",
-        lambda optimizer, gradient_clip_val, gradient_clip_algorithm: (
-            calls.append(
-                (optimizer, gradient_clip_val, gradient_clip_algorithm)
-            )
+        torch.nn.utils,
+        "clip_grad_value_",
+        lambda parameters, clip_value: calls.append(
+            ({id(parameter) for parameter in parameters}, clip_value)
         ),
     )
+    for parameter in module.parameters():
+        parameter.grad = torch.ones_like(parameter)
+    # Captured up front: `optimizer.zero_grad()` clears the gradients
+    # again once the step has run.
+    expected_ids = {id(parameter) for parameter in module.parameters()}
     module._trainer = SimpleNamespace(is_last_batch=False)  # type: ignore[assignment]
 
-    module.training_step((torch.empty(0), {}))
+    module.training_step((torch.empty(0), {}), batch_idx=0)
 
     assert module.automatic_optimization is False
     assert optimizer_accesses == [((), {})]
-    assert calls == [(optimizer, 1.5, "value") for optimizer in optimizers]
+    assert len(optimizers) > 1
+    assert calls == [(expected_ids, 1.5)]
 
 
 def test_manual_training_step_accepts_single_optimizer_and_scheduler(


### PR DESCRIPTION
Fixes the 15 verified findings from the code review of `feature/parameter-groups`. Base is `feature/parameter-groups`, not `main`.

## Silent loss of training signal

- **Unfrozen parameters could end up in no optimizer.** With a `training_strategy` plus any `finetuning` entry, a frozen node without its own `finetuning` block was claimed by nobody: the strategy skips `requires_grad=False` parameters and the strategy path builds node optimizers with `include_default=False`. `TrainingManager` now falls back to the optimizer Lightning hands `finetune_function`.
- **In-place param-group mutation was invisible to `BaseFinetuning._store`,** which only records groups appended past the ones it already knows. Unfrozen parameters are now always attached as a *new* group, so resumed runs keep them.
- **A cached `param_groups[i]` dict is orphaned** whenever a checkpoint restore rebuilds `optimizer.param_groups`. The group is now resolved from the live optimizer at unfreeze time.
- **Unfreezing used the configured initial lr** instead of the already-decayed one, giving freshly unfrozen weights an lr jump at the unfreeze epoch.

## Optimizer construction

- **Constructor-only arguments were silently discarded.** Options travelled only inside per-group dicts, so e.g. `Adagrad(initial_accumulator_value=0.7)` never seeded the accumulator, and torch's own validation (negative lr, nesterov-without-momentum) never ran. Options shared by all groups are now passed to the constructor too.
- **An empty optimizer list** reached Lightning's loop and died with `IndexError`. It now raises a clear error.

## Manual optimization (>1 optimizer)

- **Gradient accumulation was silently dropped.** Lightning refuses to accumulate under manual optimization, so the configured schedule is now applied in the training step. This was actively harmful for predefined models, whose loss weights `smart_cfg_auto_populate` has already scaled by the same factor.
- **Gradients were clipped per optimizer,** letting the total norm grow with the optimizer count. Now clipped once over the whole model, as automatic optimization does.
- **`ReduceLROnPlateau` stepped on a rank-local loss.** Learning rates are optimizer state DDP never re-synchronizes, so replicas could drift apart. The loss is now reduced across ranks.
- **`automatic_optimization` was never restored,** leaking `False` into later `fit` calls and breaking `gradient_clip_val`.
- **The optimizer count was estimated before freezing ran,** so `configure_callbacks` could overestimate and silently disable gradient accumulation.

## Training strategies

- `attach_optimizers` lets warmup cover optimizers built from `finetuning` rules, which previously started at full lr while the rest of the model warmed up.
- `split_parameter_group` keeps an inherited `weight_decay` off biases and BatchNorm weights, which `TripleLRSGD` deliberately never decays. A `weight_decay` written on the rule itself is honored as-is.

## Config and nodes

- Scheduler `params` without an explicit `name` are rejected instead of silently meaning `ConstantLR` — including nested `SequentialLR` entries.
- `OCRCTCHead(fc_decay=...)` is accepted again as a deprecated no-op, so existing configs and exported archives keep loading.

## Verification

- 21 new regression tests in `tests/unittests/test_finetuning/test_review_fixes.py`, one per finding. **20 of 21 fail against the unfixed code** — checked by reverting `luxonis_train/` and re-running. The one that passes is a guard against the weight-decay split over-applying, which correctly passes both before and after.
- One existing test (`test_manual_multi_optimizer_training_step_clips_gradients`) asserted the per-optimizer clipping that was itself the bug; it now asserts a single global clip.
- Full unit suite: 383 passed. The 9 failures + 1 error are pre-existing missing-GCS-credential failures, identical on the base commit.
- `pyright --warnings --level warning --pythonversion 3.10 luxonis_train`: clean apart from 2 pre-existing unresolved `aimet_torch` imports.
- `pre-commit` passes on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)