### PR TITLE
Integrate latest LuxonisML changes and port its Codecov fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,25 +247,76 @@ jobs:
           LUXONISML_BUCKET: luxonis-test-bucket
           SUITE: ${{ matrix.suite }}
           HUBAI_API_KEY: ${{ secrets.HUBAI_API_KEY }}
-        run: pytest -x --cov --junitxml=junit.xml -o junit_family=legacy -m "${SUITE}"
+        run: >-
+          pytest -x -m "${SUITE}"
+          --cov --cov-report=xml:coverage-${SUITE}.xml
+          --junitxml=junit-${SUITE}.xml -o junit_family=legacy
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3
+        if: ${{ always() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
           fail_ci_if_error: false
+          files: junit-${{ matrix.suite }}.xml
           flags: ${{ matrix.suite }}
+          disable_search: true
+          handle_no_reports_found: true
+
+      - name: Upload coverage as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: coverage-${{ matrix.suite }}
+          path: coverage-${{ matrix.suite }}.xml
+          if-no-files-found: ignore
+          overwrite: true
+
+  # Coverage is uploaded once, after every suite finished. Uploading each
+  # suite on its own makes Codecov report the partial runs as the total.
+  coverage:
+    needs: tests
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      # Required by codecov-action, it builds the path-fixing file network
+      # from the checked out repository.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: ${{ inputs.train_ref && 'Luxonis/luxonis-train' || github.repository }}
+          ref: ${{ inputs.train_ref || github.head_ref || github.ref }}
+          persist-credentials: false
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: coverage-*
+          path: coverage
+          merge-multiple: true
+
+      - name: Collect coverage files
+        id: coverage-files
+        shell: bash
+        run: |
+          files=$(find coverage -type f -name 'coverage-*.xml' | sort | paste -sd, -)
+          if [[ -z "$files" ]]; then
+            echo "No coverage files found" >&2
+            exit 1
+          fi
+          echo "files=$files" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-          flags: ${{ matrix.suite }}
-
-      - name: Upload coverage as artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: coverage-${{ matrix.suite }}
-          path: coverage.xml
-          overwrite: true
+          files: ${{ steps.coverage-files.outputs.files }}
+          flags: pytest
+          name: pytest
+          disable_search: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,9 +248,8 @@ jobs:
           SUITE: ${{ matrix.suite }}
           HUBAI_API_KEY: ${{ secrets.HUBAI_API_KEY }}
         run: >-
-          pytest -x -m "${SUITE}"
-          --cov --cov-report=xml:coverage-${SUITE}.xml
-          --junitxml=junit-${SUITE}.xml -o junit_family=legacy
+          pytest -x --cov --cov-report=xml:coverage-${SUITE}.xml
+          --junitxml=junit-${SUITE}.xml -o junit_family=legacy -m "${SUITE}"
 
       - name: Upload test results to Codecov
         if: ${{ always() }}
@@ -273,8 +272,8 @@ jobs:
           if-no-files-found: ignore
           overwrite: true
 
-  # Coverage is uploaded once, after every suite finished. Uploading each
-  # suite on its own makes Codecov report the partial runs as the total.
+  # Coverage is uploaded once, after all the suites have finished. Uploading
+  # each suite on its own makes Codecov report the partial runs as the total.
   coverage:
     needs: tests
     runs-on: ubuntu-latest

--- a/.github/workflows/update-cov-report.yaml
+++ b/.github/workflows/update-cov-report.yaml
@@ -3,29 +3,108 @@ name: Update Coverage Report
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
 
 jobs:
   update-base-report:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        suite: [unit, predefined_light, predefined_heavy, combinations, misc]
 
     steps:
+      # Required by codecov-action, it builds the path-fixing file network
+      # from the checked out repository.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.head_ref }}
+          persist-credentials: false
+
+      - name: Find the CI run of the merged pull request
+        id: ci-run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # A commit can be associated with more than one pull request and the
+          # order is not guaranteed, so match the one that actually produced
+          # $GITHUB_SHA instead of taking the first.
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
+            --jq 'map(select(.merge_commit_sha == env.GITHUB_SHA)) | .[0].number // empty')
+          if [[ -z "$pr" ]]; then
+            echo "::error::No merged pull request produced $GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          # Never query the runs without a head_sha, that silently matches the
+          # most recent successful CI run of any branch.
+          head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr" --jq '.head.sha // empty')
+          if [[ -z "$head_sha" ]]; then
+            echo "::error::Could not resolve the head commit of PR #$pr" >&2
+            exit 1
+          fi
+
+          run_id=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yaml/runs?head_sha=$head_sha&status=success" --jq '.workflow_runs[0].id // empty')
+          if [[ -z "$run_id" ]]; then
+            echo "::error::No successful CI run found for PR #$pr ($head_sha)" >&2
+            exit 1
+          fi
+
+          # The coverage was measured on the pull request's tree. If main moved
+          # on in the meantime, that tree is not what landed and uploading it
+          # would report coverage of source that is not in $GITHUB_SHA.
+          pr_tree=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha" --jq '.commit.tree.sha // empty')
+          main_tree=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA" --jq '.commit.tree.sha // empty')
+          if [[ -z "$pr_tree" || -z "$main_tree" ]]; then
+            echo "::error::Could not compare the trees of $head_sha and $GITHUB_SHA" >&2
+            exit 1
+          fi
+
+          if [[ "$pr_tree" != "$main_tree" ]]; then
+            echo "::warning::PR #$pr was not merged as-is, skipping the coverage upload for $GITHUB_SHA"
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Using coverage from PR #$pr (run $run_id)"
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "upload=true" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts
+        if: ${{ steps.ci-run.outputs.upload == 'true' }}
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
-          name: coverage-${{ matrix.suite }}
-          path: coverage.xml
+          run_id: ${{ steps.ci-run.outputs.run-id }}
+          name: coverage-.*
+          name_is_regexp: true
+          path: coverage
           workflow: ci.yaml
+          merge_multiple: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Collect coverage files
+        if: ${{ steps.ci-run.outputs.upload == 'true' }}
+        id: coverage-files
+        shell: bash
+        run: |
+          files=$(find coverage -type f -name 'coverage-*.xml' | sort | paste -sd, -)
+          if [[ -z "$files" ]]; then
+            echo "No coverage files found" >&2
+            exit 1
+          fi
+          echo "files=$files" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage results to Codecov
+        if: ${{ steps.ci-run.outputs.upload == 'true' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          files: ${{ steps.coverage-files.outputs.files }}
+          flags: pytest
+          name: pytest
+          disable_search: true

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -178,9 +178,7 @@ def _yield_visualizations(
     metadata_types = loader.get_metadata_types()
     categorical_encodings = loader.get_categorical_encodings()
     for idx in range(len(loader)):
-        np_images, np_labels, applied_augmentations = get_visualization_item(
-            idx
-        )
+        np_images, np_labels, augmentations = get_visualization_item(idx)
         main_image = np_images[loader.image_source]
         main_image = cv2.cvtColor(main_image, cv2.COLOR_RGB2BGR).astype(
             np.uint8
@@ -198,7 +196,7 @@ def _yield_visualizations(
             categorical_encodings=categorical_encodings,
         )
         if list_augmentations:
-            viz = add_augmentation_footer(viz, applied_augmentations)
+            viz = add_augmentation_footer(viz, augmentations)
         yield viz
 
 

--- a/luxonis_train/__main__.py
+++ b/luxonis_train/__main__.py
@@ -125,9 +125,7 @@ def _yield_visualizations(
 ) -> Iterator["np.ndarray"]:
     import cv2
     import numpy as np
-    from luxonis_ml.data.utils.augmentations_collector import (
-        AugmentationsCollector,
-    )
+    from luxonis_ml.data.utils.cli_utils import get_tracked_augmentations
     from luxonis_ml.data.utils.visualizations import (
         add_augmentation_footer,
         visualize,
@@ -137,10 +135,11 @@ def _yield_visualizations(
 
     def get_visualization_item(
         idx: int,
-    ) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+    ) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray], list[str]]:
         raw_loader = getattr(loader, "loader", None)
         if raw_loader is not None:
-            np_images, np_labels = raw_loader[idx]
+            sample = raw_loader[idx]
+            np_images, np_labels = sample
             if isinstance(np_images, np.ndarray):
                 np_images = {loader.image_source: np_images}
 
@@ -151,7 +150,11 @@ def _yield_visualizations(
             ):
                 np_labels = remap_keypoints(np_labels)
 
-            return np_images, np_labels
+            return (
+                np_images,
+                np_labels,
+                list(get_tracked_augmentations(sample.metadata) or {}),
+            )
 
         images, labels = loader[idx]
         if not isinstance(images, dict):
@@ -162,6 +165,7 @@ def _yield_visualizations(
                 for name, image in images.items()
             },
             {task: label.numpy() for task, label in labels.items()},
+            [],
         )
 
     opts = opts or []
@@ -170,23 +174,13 @@ def _yield_visualizations(
     model = create_model(config, opts)
 
     loader = model.loaders[view]
-    raw_loader = getattr(loader, "loader", None)
-    if list_augmentations and raw_loader is not None:
-        collector = AugmentationsCollector(
-            raw_loader.augmentations,  # type: ignore[attr-defined]
-            [
-                aug.model_dump()
-                for aug in model.cfg_preprocessing.get_active_augmentations()
-            ],
-        )
-        get_applied_augmentations = collector.get_applied_augmentations
-    else:
-        get_applied_augmentations = list
 
     metadata_types = loader.get_metadata_types()
     categorical_encodings = loader.get_categorical_encodings()
     for idx in range(len(loader)):
-        np_images, np_labels = get_visualization_item(idx)
+        np_images, np_labels, applied_augmentations = get_visualization_item(
+            idx
+        )
         main_image = np_images[loader.image_source]
         main_image = cv2.cvtColor(main_image, cv2.COLOR_RGB2BGR).astype(
             np.uint8
@@ -204,7 +198,7 @@ def _yield_visualizations(
             categorical_encodings=categorical_encodings,
         )
         if list_augmentations:
-            viz = add_augmentation_footer(viz, get_applied_augmentations())
+            viz = add_augmentation_footer(viz, applied_augmentations)
         yield viz
 
 

--- a/luxonis_train/config/config.py
+++ b/luxonis_train/config/config.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from contextlib import suppress
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Literal, NamedTuple
+from typing import Annotated, Any, Literal, NamedTuple, cast
 
 from loguru import logger
 from luxonis_ml.enums import DatasetType
@@ -573,10 +573,13 @@ class TrainerConfig(BaseModelExtraForbid):
                 # fail due to GradientAccumulationScheduler param verification
                 continue
 
-            callback.params["scheduling"] = {
-                int(k) if isinstance(k, str) and k.isdigit() else k: v
-                for k, v in scheduling.items()
-            }
+            callback.params["scheduling"] = cast(
+                ParamValue,
+                {
+                    int(k) if isinstance(k, str) and k.isdigit() else k: v
+                    for k, v in scheduling.items()
+                },
+            )
         return self
 
     @model_validator(mode="after")

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 import yaml
 from luxonis_ml.data import LuxonisDataset
-from luxonis_ml.data.utils import visualizations
 from luxonis_ml.typing import Kwargs, Params
 from luxonis_ml.utils import environ
 from pytest_subtests import SubTests
@@ -95,14 +94,18 @@ def test_cli_command_success(
 def test_list_augmentations(
     coco_dataset: LuxonisDataset, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    captured: list[list[str]] = []
-    add_footer = visualizations.add_augmentation_footer
+    captured_augmentations: list[list[str]] = []
 
-    def capture(image: np.ndarray, augmentations: list[str]) -> np.ndarray:
-        captured.append(augmentations)
-        return add_footer(image, augmentations)
+    def mock_add_augmentation_footer(
+        image: np.ndarray, augmentations: list[str]
+    ) -> np.ndarray:
+        captured_augmentations.append(augmentations)
+        return image
 
-    monkeypatch.setattr(visualizations, "add_augmentation_footer", capture)
+    monkeypatch.setattr(
+        "luxonis_ml.data.utils.visualizations.add_augmentation_footer",
+        mock_add_augmentation_footer,
+    )
 
     next(
         _yield_visualizations(
@@ -116,7 +119,7 @@ def test_list_augmentations(
             list_augmentations=True,
         )
     )
-    assert captured == [["HorizontalFlip"]]
+    assert captured_augmentations == [["HorizontalFlip"]]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_cli_commands.py
+++ b/tests/integration/test_cli_commands.py
@@ -5,9 +5,11 @@ from collections.abc import Callable
 from pathlib import Path
 from types import GeneratorType
 
+import numpy as np
 import pytest
 import yaml
 from luxonis_ml.data import LuxonisDataset
+from luxonis_ml.data.utils import visualizations
 from luxonis_ml.typing import Kwargs, Params
 from luxonis_ml.utils import environ
 from pytest_subtests import SubTests
@@ -88,6 +90,33 @@ def test_cli_command_success(
             ],
             weights=str(ckpt),
         )
+
+
+def test_list_augmentations(
+    coco_dataset: LuxonisDataset, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[list[str]] = []
+    add_footer = visualizations.add_augmentation_footer
+
+    def capture(image: np.ndarray, augmentations: list[str]) -> np.ndarray:
+        captured.append(augmentations)
+        return add_footer(image, augmentations)
+
+    monkeypatch.setattr(visualizations, "add_augmentation_footer", capture)
+
+    next(
+        _yield_visualizations(
+            [
+                "loader.params.dataset_name",
+                coco_dataset.identifier,
+                "trainer.preprocessing.augmentations",
+                str([{"name": "HorizontalFlip", "params": {"p": 1.0}}]),
+            ],
+            config="configs/detection_light_model.yaml",
+            list_augmentations=True,
+        )
+    )
+    assert captured == [["HorizontalFlip"]]
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/test_visualizers/test_classification_visualizer.py
+++ b/tests/unittests/test_visualizers/test_classification_visualizer.py
@@ -25,7 +25,7 @@ class DummyClassificationNode(BaseNode, register=False):
         ),
         (
             None,
-            "27e4034252004f457e7d3c7cc1c5a2eb2e0e2d5020fc47c731de0d2053ed1adc",
+            "8dcfb132aa6cc5fa52cf1949d85da123cbec062cce1902f95774396d378575ba",
         ),
     ],
 )

--- a/tests/unittests/test_visualizers/test_ocr_visualizer.py
+++ b/tests/unittests/test_visualizers/test_ocr_visualizer.py
@@ -71,5 +71,5 @@ def test_ocr_visualizer():
 
     assert (
         computed_hash
-        == "fd2002331686f3579151061ec07367da5e3050bb60a085c1764f76486f5b2a91"
+        == "fd255eba6a051a851dd81f9d05dea6d4881dc2ad0efc5aeb7e6d08e8698d6e47"
     )


### PR DESCRIPTION
Adapts LuxonisTrain to the LuxonisML changes that landed after `v0.9.1-beta`, and ports the Codecov fixes from the same window. Three separate commits, reviewable independently.

## 1. LuxonisML API changes

Both breakages hit `type-check` on **every** open PR, since CI installs `luxonis-ml @ git+...@main` on non-release branches — they are not specific to any one branch. Both come from LuxonisML [#457](https://github.com/luxonis/luxonis-ml/pull/457).

**`--list-augmentations`** — `luxonis_ml.data.utils.augmentations_collector` was deleted; the tracking now lives in the loader, which reports the applied augmentations as record metadata. Rather than reconstructing them from `cfg_preprocessing.get_active_augmentations()`, `_yield_visualizations` reads them per sample with `get_tracked_augmentations(sample.metadata)`. The `# type: ignore[attr-defined]` on `raw_loader.augmentations` goes away, and the reported augmentations become genuinely per-sample instead of depending on collector state.

**`ParamValue`** — narrowed from `Mapping[PrimitiveType, ...]` to `Mapping[str, ...]`. `GradientAccumulationScheduler` is keyed by epoch and genuinely requires `int` keys, so that assignment is now an explicit `cast`.

Added `test_list_augmentations`, which asserts the augmentation name actually reaches the footer (`captured == [["HorizontalFlip"]]`) instead of merely checking that a footer was drawn, injecting `HorizontalFlip` with `p: 1.0` so it is deterministic. The path had no coverage at all before, which is why the break surfaced only as a type error.

## 2. Visualizer reference hashes

`test_classification_visualizer` and `test_ocr_visualizer` compare renders against golden hashes, and both had drifted on `main` independently of this work — the same new hashes appear with published `luxonis-ml==0.9.1`, so the cause is the rendering stack under unpinned dependencies, not LuxonisML. Only the `font_scale=None` parametrization changed; the explicit `font_scale=1.0` case still matches, which points at text metrics rather than the visualizers.

The classification value is the one CI itself computed. The OCR value never ran on CI, because the job uses `pytest -x` and stopped at the first failure, so it comes from a local run cross-checked against #421.

> [!NOTE]
> #421 updates these same two lines to exactly these values, so whichever merges first leaves the other with a trivial conflict.

## 3. Codecov fixes (LuxonisML #463 and #479)

- Coverage is uploaded **once**, from a new `coverage` job gated on `tests`, instead of each suite uploading its own partial report for Codecov to treat as the total.
- `codecov/test-results-action` is deprecated, replaced by `codecov-action` with `report_type: test_results`.
- The base-report workflow now resolves the CI run of the **merged pull request** instead of downloading the newest artifacts of any branch, and skips the upload when the merge changed the tree the coverage was measured on.

While porting, one more problem surfaced: `pytest --cov` was never asked for an XML report and there is no `[tool.coverage.xml]` section, so `coverage.xml` never existed — both the artifact upload and the Codecov upload had nothing to work with. Reports are now written per suite (`coverage-<suite>.xml`), which also stops them overwriting each other when artifacts are merged, and the upload steps run on `always()` since a failing suite is exactly when its results are worth keeping.


## Verification

- `type-check`, `pre-commit`, `docs`, `config-test` and **`tests (unit)`** all pass on CI
- Locally against a venv built from LuxonisML `main`: unit suite **251 passed**, `test_list_augmentations` passes, pyright clean apart from `aimet_torch` imports the venv lacks
- Both workflows parse, the folded `pytest` command expands correctly, and the per-suite `coverage-<suite>.xml` / `junit-<suite>.xml` files were confirmed to be produced
- pre-commit hooks clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visualization outputs now display the augmentations applied to each sample when augmentation tracking is enabled.
  * Augmentation listings are now covered by integration testing.

* **Bug Fixes**
  * Updated visualizer output validation to reflect corrected classification and OCR rendering results.

* **Chores**
  * Improved automated coverage collection, aggregation, and reporting across test suites.
  * Added safeguards to ensure coverage reports correspond to the correct merged changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->