### PR TITLE
Use the shared release workflows

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -23,6 +23,10 @@ enhancement:
       - "feat/*"
       - "enhancement/*"
 
+release:
+  - head-branch:
+      - "release/*"
+
 fix:
   - head-branch:
       - "fix/*"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,25 @@
+# Groups the notes that `gh release create --generate-notes` writes.
+changelog:
+  exclude:
+    labels:
+      - release
+  categories:
+    - title: New features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - fix
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - DevOps
+        - tests
+        - dependencies
+        - automated
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   deploy:
+    # The `pypi` environment holds a required reviewer. This job waits for an
+    # approval before it uploads, whatever started it.
+    environment: pypi
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   deploy:
-    # The `pypi` environment holds a required reviewer. This job waits for an
-    # approval before it uploads, whatever started it.
     environment: pypi
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -15,4 +15,5 @@ jobs:
       version: ${{ inputs.version }}
       version-file: luxonis_train/__init__.py
       project-name: LuxonisTrain
-    secrets: inherit
+    secrets:
+      WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -1,0 +1,18 @@
+name: Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "major, minor, patch, or an explicit version such as 1.2.3"
+        type: string
+        default: patch
+
+jobs:
+  release-pr:
+    uses: luxonis/luxonis-ml/.github/workflows/reusable-release-pr.yaml@main
+    with:
+      version: ${{ inputs.version }}
+      version-file: luxonis_train/__init__.py
+      project-name: LuxonisTrain
+    secrets: inherit

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,16 @@
+name: Release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: >-
+      github.event.pull_request.merged &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    uses: luxonis/luxonis-ml/.github/workflows/reusable-release-tag.yaml@main
+    with:
+      version-file: luxonis_train/__init__.py
+    secrets: inherit

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -13,4 +13,5 @@ jobs:
     uses: luxonis/luxonis-ml/.github/workflows/reusable-release-tag.yaml@main
     with:
       version-file: luxonis_train/__init__.py
-    secrets: inherit
+    secrets:
+      WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,8 @@ A release needs two manual steps: start the workflow, then merge the pull reques
 
 Both workflows are thin callers. The shared logic lives in `luxonis-ml`, in `.github/workflows/reusable-release-pr.yaml` and `.github/workflows/reusable-release-tag.yaml`, so every Luxonis repository releases the same way.
 
+`.github/release.yaml` groups the generated notes into categories from the pull request labels.
+
 > [!IMPORTANT]
 > The release runs on the `WORKFLOW_SECRET` secret. The default token does not start CI on a bot pull request, and it cannot start the publish workflow from a release event.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,21 @@ Our GitHub Actions workflow is run when a new PR is opened.
 > [!IMPORTANT]
 > Successful completion of all the workflow checks is required for merging a PR.
 
+## Releases
+
+A release needs two manual steps: start the workflow, then merge the pull request it opens.
+
+1. Run the `Release PR` workflow from the Actions tab. Give it `major`, `minor`, `patch`, or an explicit version such as `1.2.3`.
+1. The workflow changes `__version__` in `luxonis_train/__init__.py` and opens a `release/vX.Y.Z` pull request that lists the changes after the last tag.
+1. Review the pull request, wait for CI, and merge it.
+1. The `Release Tag` workflow then tags `vX.Y.Z-beta` on the merge commit and creates the GitHub release with generated notes.
+1. The release publication starts the PyPI upload.
+
+Both workflows are thin callers. The shared logic lives in `luxonis-ml`, in `.github/workflows/reusable-release-pr.yaml` and `.github/workflows/reusable-release-tag.yaml`, so every Luxonis repository releases the same way.
+
+> [!IMPORTANT]
+> The release runs on the `WORKFLOW_SECRET` secret. The default token does not start CI on a bot pull request, and it cannot start the publish workflow from a release event.
+
 ## Making and Submitting Changes
 
 1. Make changes in a new branch with a descriptive prefix such as `feat/` or `fix/`.


### PR DESCRIPTION
## Purpose

A release here needs a hand-made pull request and then a hand-made GitHub
release. This change adopts the shared release workflows, so LuxonisTrain
releases the same way as the other Luxonis repositories. Only two manual
actions stay: you start the workflow, and you merge the pull request it opens.

## Specification

Two thin caller workflows:

- `.github/workflows/release-pr.yaml` runs on manual dispatch. Give it `major`,
  `minor`, `patch`, or an explicit version. It calls
  `luxonis/luxonis-ml/.github/workflows/reusable-release-pr.yaml@main`, which
  changes `__version__` and opens the `release/vX.Y.Z` pull request.
- `.github/workflows/release-tag.yaml` runs when a `release/*` pull request
  merges. It calls the matching reusable workflow, which tags `vX.Y.Z-beta` on
  the merge commit and creates the release with generated notes.

Both callers pass `luxonis_train/__init__.py` as the version file, and
`LuxonisTrain` as the project name. This repository copies no script: the
reusable workflows check out the version tool from `luxonis-ml`.

The second commit adds `.github/release.yaml`, which groups the generated notes
by label, and a `release/*` rule in the labeler that drives its exclusion. Drop
that commit if you want the plain flat notes.

## Dependencies & Potential Impact

**This pull request needs luxonis/luxonis-ml#485 on `main` first.** The
reusable workflows do not exist until it merges, and a caller that references a
missing workflow fails when it runs.

No package code changes. `python-publish.yaml` keeps its trigger, and it still
runs from the release event.

The release runs on the `WORKFLOW_SECRET` secret, which this repository already
uses for `actions_autoupdate.yaml` and `dependencies_autoupdate.yaml`. That
secret must have the scope to create a release.

## Deployment Plan

1. Merge luxonis/luxonis-ml#485.
2. Merge this pull request.
3. Run `Release PR` from the Actions tab for the next release.
4. Review and merge the pull request it opens. `Release Tag` then creates the
   tag and the release, and the release event starts the PyPI upload.

To go back to the manual process, delete the two caller workflows.

## Testing & Validation

Verified on a local machine:

- The version tool against this repository's `luxonis_train/__init__.py`. It
  reads `0.4.6`, and `--set minor` writes `0.5.0` while changing one line only.
- `actionlint` on both caller workflows.
- The full `prek` hook set on all five changed files.
- The single-file sparse checkout that the reusable workflows use to fetch the
  version tool. A real clone produces exactly that one file.

Only a live run can prove the rest, and it needs luxonis-ml#485 on `main`
first.

## AI Usage

Assisted-by: Claude Code:claude-opus-5[1m]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
