### PR TITLE
Tell the user that Roboflow needs an API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Get started with `LuxonisTrain` in just a few steps:
 
    We will use a sample COCO dataset from `RoboFlow` in this example.
 
+   > [!IMPORTANT]
+   > A `roboflow://` source needs the `ROBOFLOW_API_KEY` environment variable.
+   > Get your key from the
+   > [Roboflow settings](https://app.roboflow.com/settings/api). The
+   > [Roboflow documentation](https://docs.roboflow.com/reference/authentication/authentication/find-your-roboflow-api-key)
+   > gives the steps.
+
 1. **Start training**
 
    ```bash


### PR DESCRIPTION
## Purpose

The Quick Start trains on a Roboflow dataset, but it never tells the user that
Roboflow needs an API key. LuxonisML raises a `RuntimeError` when
`ROBOFLOW_API_KEY` is not set, and it raises before it downloads anything. The
Quick Start command thus fails for every new user who does not already hold a
key.

The Credentials section names the variable, but it sits far below the Quick
Start and gives no link to the key.

## Specification

The Quick Start step that introduces the Roboflow dataset gets an
`[!IMPORTANT]` note. The note names the `ROBOFLOW_API_KEY` variable and links
two pages:

- the Roboflow settings, where the user copies the key;
- the Roboflow documentation, which gives the steps.

The change touches `README.md` only. It adds no code and changes no behavior.

luxonis-ml PR #488 adds the same note to its own Quick Start, which uses the
same `roboflow://` example.

## Dependencies & Potential Impact

None / not applicable. The change is documentation only, so no service, API, or
dependency is affected.

## Deployment Plan

None / not applicable. The README publishes with the repository, so the change
needs no rollout.

## Testing & Validation

- `pre-commit run --files README.md` passes, `mdformat` included.
- Both links were opened and return live pages. The Roboflow documentation page
  is titled "Find Your Roboflow API Key" and sends the user to
  `app.roboflow.com/settings/api`.

## AI Usage

Assisted-by: Claude Code:claude-opus-5[1m]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Quick Start warning explaining that `roboflow://` datasets require a `ROBOFLOW_API_KEY`.
  * Included links to API-key setup instructions and additional documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->