### PR TITLE
Fix the PPLCNetV3 detection backbone channel count

### DIFF
--- a/luxonis_train/nodes/backbones/pplcnet_v3/pplcnet_v3.py
+++ b/luxonis_train/nodes/backbones/pplcnet_v3/pplcnet_v3.py
@@ -82,10 +82,7 @@ class PPLCNetV3(BaseNode):
         self.blocks = nn.ModuleList(blocks)
 
         if self.use_detection_backbone:
-            blocks_out_channels = [
-                scale_up(blocks[i].out_channels, self.scale)
-                for i in range(1, 5)
-            ]
+            blocks_out_channels = [blocks[i].out_channels for i in range(1, 5)]
 
             detecion_out_channels = [
                 int(c * self.scale) for c in [16, 24, 56, 480]

--- a/tests/unittests/test_callbacks/test_ema.py
+++ b/tests/unittests/test_callbacks/test_ema.py
@@ -57,6 +57,11 @@ def test_ema_initialization(model: LightningModule, ema_callback: EMACallback):
     assert ema_callback.ema.use_dynamic_decay == ema_callback.use_dynamic_decay
 
 
+def test_ema_before_fit_start(ema_callback: EMACallback):
+    with pytest.raises(ValueError, match="not yet init"):
+        _ = ema_callback.ema
+
+
 def test_ema_update_on_batch_end(
     model: LightningModule, ema_callback: EMACallback
 ):

--- a/tests/unittests/test_pplcnet_v3.py
+++ b/tests/unittests/test_pplcnet_v3.py
@@ -1,0 +1,31 @@
+import torch
+from torch import Size
+
+from luxonis_train.nodes.backbones import PPLCNetV3
+
+
+def test_recognition_backbone():
+    backbone = _build_backbone(use_detection_backbone=False)
+    out = backbone(torch.rand(2, 3, 48, 320))
+    assert len(out) == 5
+    assert out[-1].shape[-2:] == (1, 40)
+
+
+def test_detection_backbone():
+    backbone = _build_backbone(use_detection_backbone=True)
+    out = backbone(torch.rand(2, 3, 48, 320))
+    assert [f.shape[1] for f in out] == [15, 22, 53, 456]
+
+
+def _build_backbone(use_detection_backbone: bool) -> PPLCNetV3:
+    # `variant=` hides the injected parameters from pyright.
+    _, variants = PPLCNetV3.get_variants()
+    variant = variants["rec-light"]
+    return PPLCNetV3(
+        input_shapes=[{"features": [Size((3, 48, 320))]}],
+        scale=variant["scale"],
+        n_branches=variant["n_branches"],
+        layer_params=variant["layer_params"],
+        use_detection_backbone=use_detection_backbone,
+        max_text_len=40,
+    )


### PR DESCRIPTION
## Purpose

`PPLCNetV3` crashes when a configuration sets `use_detection_backbone`
to `true`. The detection branch has never worked. This PR corrects the
channel count and adds the tests that the branch never had.

The PR also unblocks the codecov check on #443. That PR renames
`detecion_blocks` to `detection_blocks` and corrects an "initalized"
typo in `EMACallback`. Both renamed lines sit in untested code, so
codecov counts them as missed and fails `codecov/patch`. The new tests
cover them.

## Specification

- Use the block widths directly in the PPLCNetV3 detection backbone.
  `LCNetV3Layer` scales its `out_channels` in the constructor. The
  backbone scaled the same value a second time:

  ```python
  blocks_out_channels = [
      scale_up(blocks[i].out_channels, self.scale) for i in range(1, 5)
  ]
  ```

  The `rec-light` variant uses the scale 0.95. The second scale turns
  the true block widths `[64, 128, 240, 480]` into
  `[64, 128, 224, 464]`. The detection convolutions then expect 224
  channels, but the blocks give 240:

  ```
  RuntimeError: Given groups=1, weight of size [53, 224, 1, 1],
  expected input[2, 240, 6, 40] to have 224 channels,
  but got 240 channels instead
  ```

- Add `tests/unittests/test_pplcnet_v3.py`. It covers the two backbone
  modes:
  - The recognition mode gives 5 outputs. The last output is pooled to
    `(1, max_text_len)`.
  - The detection mode gives 4 outputs with the widths
    `[15, 22, 53, 456]`.
- Add `test_ema_before_fit_start`. It covers the `EMACallback.ema`
  guard. The guard raises before `on_fit_start` builds the model.

No variant sets `use_detection_backbone` to `true`. No test covered
the branch. The defect stayed hidden for these two reasons.

## Dependencies & Potential Impact

- Not breaking. The detection branch raised a `RuntimeError` before
  this change. No configuration can depend on the old widths.
- The change does not touch the recognition path. The
  `ocr_recognition` predefined model uses that path.
- The tests read only the forward outputs. They do not name the
  `detecion_blocks` attribute. #443 can thus rename the attribute
  without a test change.
- No dependency changes.

## Deployment Plan

None / not applicable — the changes ship with the next release.

## Testing & Validation

- `test_detection_backbone` fails on `main` with the `RuntimeError`
  above. It passes with this change.
- `pytest tests/unittests`: 508 passed. The run excludes
  `tests/unittests/test_losses`, which holds the known expired
  gcloud-ADC failures.
- The pre-commit hooks ran on both commits. All hooks pass.
- `pyright --warnings`: at parity with `main`. The one error is the
  pre-existing `aimet_torch` import from the optional extra.

## AI Usage

Assisted-by: Claude:claude-opus-5

Submitted code was reviewed by a human: NO

The author is taking the responsibility for the contribution: YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QA7RcK3rsE5mHX7J6X1Vxh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected channel sizing in the PPLCNetV3 detection backbone to ensure detection features have the expected dimensions.
  * Improved EMA callback behavior when accessed before training initialization by providing a clear error.

* **Tests**
  * Added coverage for PPLCNetV3 recognition and detection outputs, including feature dimensions.
  * Added validation for EMA access before training begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->